### PR TITLE
fix: remove working directory entirely

### DIFF
--- a/.github/workflows/wormhole-connect.yml
+++ b/.github/workflows/wormhole-connect.yml
@@ -8,7 +8,6 @@ jobs:
 
     steps:
       - name: Lint
-        working-directory: ./wormhole-connect
         run: npm run lint
 
   test:
@@ -16,5 +15,4 @@ jobs:
 
     steps:
       - name: Test
-        working-directory: ./wormhole-connect
         run: npm run test


### PR DESCRIPTION
It must start in this directory, maybe because the name of the file matches the name of the directory?