### PR TITLE
[#225] Bugfix disable controls on tx approval

### DIFF
--- a/wormhole-connect/src/store/transfer.ts
+++ b/wormhole-connect/src/store/transfer.ts
@@ -194,7 +194,7 @@ export const transferSlice = createSlice({
       { payload }: PayloadAction<boolean>,
     ) => {
       state.isTransactionInProgress = payload;
-    }
+    },
   },
 });
 

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -58,7 +58,7 @@ function Bridge() {
     automaticRelayAvail,
     toNativeToken,
     relayerFee,
-    isTransactionInProgress
+    isTransactionInProgress,
   } = useSelector((state: RootState) => state.transfer);
   const { sending, receiving } = useSelector(
     (state: RootState) => state.wallet,

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -49,7 +49,7 @@ function Send(props: { valid: boolean }) {
     toNativeToken,
     relayerFee,
     automaticRelayAvail,
-    isTransactionInProgress
+    isTransactionInProgress,
   } = transfer;
   const [isConnected, setIsConnected] = useState(
     sending.currentAddress.toLowerCase() === sending.address.toLowerCase(),


### PR DESCRIPTION
Adds an `isTransactionInProgress` state variable to the transfer slice, replacing the `inProgress` local state in the Send button. The new state variable is used to disable the gas controls.

I also noticed that "From" inputs can also be modified by the user after approving. I'll open a different PR for those changes, since it modifies files outside the scope of this issue.

Closes #225 