### PR TITLE
[#266] Fix wallet options offered when resuming a transfer

### DIFF
--- a/wormhole-connect/src/views/WalletModal.tsx
+++ b/wormhole-connect/src/views/WalletModal.tsx
@@ -110,9 +110,10 @@ function WalletsModal(props: Props) {
 
   function getAvailableWallets() {
     const chain =
-      props.chain || props.type === TransferWallet.SENDING
+      props.chain ||
+      (props.type === TransferWallet.SENDING
         ? fromNetwork
-        : toNetwork;
+        : toNetwork);
 
     const config = CHAINS[chain!];
     if (!config) return Object.values(WALLETS);


### PR DESCRIPTION
Add parenthesis to fix a ternary condition which would yield the wrong chain to use.

Closes #266 