### PR TITLE
[#329] Integer amount validation

### DIFF
--- a/wormhole-connect/src/views/Bridge/Inputs.tsx/From.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs.tsx/From.tsx
@@ -35,7 +35,8 @@ function FromInputs() {
   const openFromNetworksModal = () => dispatch(setFromNetworksModal(true));
   const openTokensModal = () => dispatch(setTokensModal(true));
   function handleAmountChange(event) {
-    dispatch(setAmount(event.target.value));
+    const newAmount = Number.parseFloat(event.target.value);
+    dispatch(setAmount(newAmount));
   }
   const validateAmount = () => validate(dispatch);
 


### PR DESCRIPTION
Issue: #329

Validations fail when inputting an integer value (e.g. `1`). This is due to the value being stored as a string instead of number, which results in incorrect numbers when computing validations. Trying to add a string and a number concatenates them as strings and then converts the result to a number. See the screenshots below.

Update: this should also solve the missing amount + fees exceeding balance error (originally from #246)

Before:

![image](https://user-images.githubusercontent.com/11276821/232524937-cb19087b-e502-4b08-ae6a-31cef8d4f689.png)

After:

![image](https://user-images.githubusercontent.com/11276821/232524993-a855bcce-0e9c-47aa-aab5-6c72389de119.png)
