### PR TITLE
[#353] Fix bug where the sender wallet balance would be overriden by the destination wallet

### DIFF
--- a/wormhole-connect/src/store/transfer.ts
+++ b/wormhole-connect/src/store/transfer.ts
@@ -43,6 +43,7 @@ export interface TransferState {
     claim: string;
   };
   isTransactionInProgress: boolean;
+  receiverNativeBalance: string | undefined;
 }
 
 const initialState: TransferState = {
@@ -78,6 +79,7 @@ const initialState: TransferState = {
     claim: '',
   },
   isTransactionInProgress: false,
+  receiverNativeBalance: '',
 };
 
 export const transferSlice = createSlice({
@@ -164,6 +166,12 @@ export const transferSlice = createSlice({
     ) => {
       state.balances = { ...state.balances, ...payload };
     },
+    setReceiverNativeBalance: (
+      state: TransferState,
+      { payload }: PayloadAction<string>,
+    ) => {
+      state.receiverNativeBalance = payload;
+    },
     clearBalances: (state: TransferState) => {
       state.balances = {};
     },
@@ -243,6 +251,7 @@ export const {
   setClaimGasEst,
   clearTransfer,
   setIsTransactionInProgress,
+  setReceiverNativeBalance,
 } = transferSlice.actions;
 
 export default transferSlice.reducer;

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -5,8 +5,7 @@ import { BigNumber } from 'ethers';
 import { useDispatch } from 'react-redux';
 import { RootState } from '../../store';
 import {
-  setBalance,
-  formatBalance,
+  setReceiverNativeBalance,
   setAutomaticRelayAvail,
   setDestGasPayment,
   touchValidations,
@@ -26,6 +25,7 @@ import ToNetworksModal from './Modals/ToNetworksModal';
 import TokensModal from './Modals/TokensModal';
 import FromInputs from './Inputs.tsx/From';
 import ToInputs from './Inputs.tsx/To';
+import { toDecimals } from '../../utils/balance';
 
 const useStyles = makeStyles()((theme) => ({
   bridgeContent: {
@@ -66,6 +66,20 @@ function Bridge() {
   const { sending, receiving } = useSelector(
     (state: RootState) => state.wallet,
   );
+
+  // check destination native balance
+  useEffect(() => {
+    if (!fromNetwork || !toNetwork || !receiving.address) return;
+    const networkConfig = CHAINS[toNetwork]!;
+    getNativeBalance(receiving.address, toNetwork).then((res: BigNumber) => {
+      const tokenConfig = TOKENS[networkConfig.gasToken];
+      if (!tokenConfig)
+        throw new Error('Could not get native gas token config');
+      dispatch(
+        setReceiverNativeBalance(toDecimals(res, tokenConfig.decimals, 6)),
+      );
+    });
+  }, [fromNetwork, toNetwork, receiving.address]);
 
   // check if automatic relay option is available
   useEffect(() => {


### PR DESCRIPTION
The Bridge had a hook which would retrieve the destination network native gas balance for the destination wallet. It'd dispatch the `setBalance` action for that token, which would be set as a balance for the sender address, which is incorrect. While for most chains this would not be an issue since the native gas token is not available as an option in the tokens list, for Celo, which is treated as a normal ERC20 token, the sender's balance would be replaced by the receiver's.

@anondev2323 Please let me know if this removal is safe, since you might have a better insight where the stored balances are used. I do not think it's needed, since the balances are specifically for the sender wallet, but just to be sure.

Closes #353 