### PR TITLE
[#253] Disconnect wallet when the user changes to another account

### DIFF
--- a/wormhole-connect/src/views/WalletModal.tsx
+++ b/wormhole-connect/src/views/WalletModal.tsx
@@ -138,6 +138,12 @@ function WalletsModal(props: Props) {
       dispatch(clearWallet(props.type));
     });
 
+    // when the user has multiple wallets connected and either changes
+    // or disconnects the current wallet, clear the wallet
+    wallet.on('accountsChanged', () => {
+      wallet.disconnect();
+    });
+
     const address = wallet.getAddress();
     if (address) {
       const payload = { address, type: walletInfo.type };


### PR DESCRIPTION
The `accountsChanged` triggers in these cases:
 * The user disconnect the current account, so metamask picks the next one connected as current
 * The user manually switches to another account

Closes #96