### PR TITLE
Fix issues with wrapped token verification

### DIFF
--- a/wormhole-connect/src/views/Bridge/Inputs.tsx/To.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs.tsx/To.tsx
@@ -193,7 +193,7 @@ function ToInputs() {
     } else {
       setWarnings([]);
     }
-  }, [toNetwork, foreignAsset, wallet, associatedTokenAddress]);
+  }, [toNetwork, token, foreignAsset, wallet, associatedTokenAddress]);
 
   return (
     <Inputs


### PR DESCRIPTION
 * It would set the foreign address only if it existed, thus leaving an inconsistent state
 * It would not trigger the validation when switching the target chain

Closes #410 