### PR TITLE
[#430] Fix decimals for mainnet ETH token

### DIFF
--- a/wormhole-connect/src/config/mainnet.ts
+++ b/wormhole-connect/src/config/mainnet.ts
@@ -101,7 +101,7 @@ export const MAINNET_TOKENS: { [key: string]: TokenConfig } = {
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
     color: '#62688F',
-    decimals: 9,
+    decimals: 18,
     solDecimals: 8,
     wrappedAsset: 'WETH',
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11276821/234680964-5ef041f0-9ae3-4ad8-9356-e41bf9b8682b.png)

Closes #430 #431 
Should also address #432, although we're missing the gas estimations from the mainnet config.