### PR TITLE
Add gas estimates for mainnet

### DIFF
--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -2,8 +2,16 @@ import {
   WormholeContext,
   CONFIG as CONF,
 } from '@wormhole-foundation/wormhole-connect-sdk';
-import { MAINNET_NETWORKS, MAINNET_TOKENS } from './mainnet';
-import { TESTNET_NETWORKS, TESTNET_TOKENS } from './testnet';
+import {
+  MAINNET_NETWORKS,
+  MAINNET_TOKENS,
+  MAINNET_GAS_ESTIMATES,
+} from './mainnet';
+import {
+  TESTNET_NETWORKS,
+  TESTNET_TOKENS,
+  TESTNET_GAS_ESTIMATES,
+} from './testnet';
 import { TokenConfig, NetworkConfig, WormholeConnectConfig } from './types';
 import { dark, light } from '../theme';
 import {
@@ -61,6 +69,10 @@ export const TOKENS_ARR =
   config && config.tokens
     ? Object.values(TOKENS).filter((c) => config.tokens!.includes(c.symbol))
     : (Object.values(TOKENS) as TokenConfig[]);
+
+export const GAS_ESTIMATES = isProduction
+  ? MAINNET_GAS_ESTIMATES
+  : TESTNET_GAS_ESTIMATES;
 
 export const THEME_MODE = config && config.mode ? config.mode : 'dark';
 export const CUSTOM_THEME = config && config.customTheme;

--- a/wormhole-connect/src/config/mainnet.ts
+++ b/wormhole-connect/src/config/mainnet.ts
@@ -280,7 +280,7 @@ export const MAINNET_GAS_ESTIMATES: GasEstimates = {
     claim: 300000,
   },
   polygon: {
-    sendNative: 200000,
+    sendNative: 100000,
     sendToken: 150000,
     sendNativeWithRelay: 200000,
     sendTokenWithRelay: 250000,
@@ -291,7 +291,7 @@ export const MAINNET_GAS_ESTIMATES: GasEstimates = {
     sendToken: 200000,
     sendNativeWithRelay: 200000,
     sendTokenWithRelay: 300000,
-    claim: 175000,
+    claim: 250000,
   },
   avalanche: {
     sendNative: 100000,
@@ -301,18 +301,18 @@ export const MAINNET_GAS_ESTIMATES: GasEstimates = {
     claim: 300000,
   },
   fantom: {
-    sendNative: 150000,
+    sendNative: 100000,
     sendToken: 150000,
-    sendNativeWithRelay: 200000,
+    sendNativeWithRelay: 250000,
     sendTokenWithRelay: 300000,
-    claim: 250000,
+    claim: 300000,
   },
   celo: {
-    sendNative: 100000,
-    sendToken: 100000,
+    sendNative: 150000,
+    sendToken: 150000,
     sendNativeWithRelay: 300000,
     sendTokenWithRelay: 300000,
-    claim: 175000,
+    claim: 300000,
   },
   moonbeam: {
     sendNative: 100000,

--- a/wormhole-connect/src/config/mainnet.ts
+++ b/wormhole-connect/src/config/mainnet.ts
@@ -1,5 +1,5 @@
 import { CONFIG } from '@wormhole-foundation/wormhole-connect-sdk';
-import { NetworksConfig, TokenConfig, Icon } from './types';
+import { NetworksConfig, TokenConfig, Icon, GasEstimates } from './types';
 
 const { chains } = CONFIG.MAINNET;
 
@@ -268,5 +268,62 @@ export const MAINNET_TOKENS: { [key: string]: TokenConfig } = {
     color: '#8457EF',
     decimals: 9,
     solDecimals: 9,
+  },
+};
+
+export const MAINNET_GAS_ESTIMATES: GasEstimates = {
+  ethereum: {
+    sendNative: 100000,
+    sendToken: 150000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 300000,
+    claim: 300000,
+  },
+  polygon: {
+    sendNative: 200000,
+    sendToken: 150000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 250000,
+    claim: 300000,
+  },
+  bsc: {
+    sendNative: 100000,
+    sendToken: 200000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 300000,
+    claim: 175000,
+  },
+  avalanche: {
+    sendNative: 100000,
+    sendToken: 150000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 300000,
+    claim: 300000,
+  },
+  fantom: {
+    sendNative: 150000,
+    sendToken: 150000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 300000,
+    claim: 250000,
+  },
+  celo: {
+    sendNative: 100000,
+    sendToken: 100000,
+    sendNativeWithRelay: 300000,
+    sendTokenWithRelay: 300000,
+    claim: 175000,
+  },
+  moonbeam: {
+    sendNative: 100000,
+    sendToken: 150000,
+    sendNativeWithRelay: 200000,
+    sendTokenWithRelay: 300000,
+    claim: 300000,
+  },
+  solana: {
+    sendNative: 15000,
+    sendToken: 15000,
+    claim: 25000,
   },
 };

--- a/wormhole-connect/src/config/testnet.ts
+++ b/wormhole-connect/src/config/testnet.ts
@@ -284,7 +284,7 @@ export const TESTNET_TOKENS: { [key: string]: TokenConfig } = {
   },
 };
 
-export const GAS_ESTIMATES: GasEstimates = {
+export const TESTNET_GAS_ESTIMATES: GasEstimates = {
   goerli: {
     sendNative: 100000,
     sendToken: 150000,

--- a/wormhole-connect/src/sdk/gasEstimates.ts
+++ b/wormhole-connect/src/sdk/gasEstimates.ts
@@ -7,7 +7,7 @@ import {
   MAINNET_CHAINS,
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { toFixedDecimals } from '../utils/balance';
-import { GAS_ESTIMATES } from '../config/testnet';
+import { GAS_ESTIMATES } from '../config';
 import { PaymentOption } from '.';
 import { getTokenDecimals } from '../utils';
 
@@ -81,7 +81,10 @@ const getGasFeeFallback = async (
   const fromChainId = context.toChainId(fromNetwork);
   const fromChainName = context.toChainName(fromNetwork);
   const sendNative = token === 'native';
-  const gasEstimates = GAS_ESTIMATES[fromChainName]!;
+  const gasEstimates = GAS_ESTIMATES[fromChainName];
+  if (!gasEstimates)
+    throw new Error(`no gas estimates configured, cannot estimate fees`);
+
   // Solana gas estimates
   if (fromChainId === MAINNET_CHAINS.solana) {
     return toFixedDecimals(utils.formatUnits(gasEstimates.sendToken, 9), 6);

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../sdk';
 import { CHAINS, TOKENS } from '../../config';
 import WalletsModal from '../WalletModal';
-import { GAS_ESTIMATES } from '../../config/testnet';
+import { GAS_ESTIMATES } from '../../config';
 import { fetchRedeemedEvent, fetchSwapEvent } from '../../utils/events';
 
 import Header from './Header';


### PR DESCRIPTION
I used the testnet estimates as a base, and updated according to the txs I saw on the mainnet explorers for each chain.