### PR TITLE
Fix wallet detection for uninstalled wallets

### DIFF
--- a/wormhole-connect/src/views/WalletModal.tsx
+++ b/wormhole-connect/src/views/WalletModal.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles()((theme) => ({
 
 const getReady = (wallet: Wallet) => {
   const ready = wallet.getWalletState();
-  return ready !== WalletState.Unsupported;
+  return ready !== WalletState.Unsupported && ready !== WalletState.NotDetected;
 };
 
 type WalletData = {


### PR DESCRIPTION
The check missed the `NotDetected` (i.e. not installed) state