### PR TITLE
Use ScopedCssBaseline to apply reset only to wh connect components

### DIFF
--- a/wormhole-connect/public/index.html
+++ b/wormhole-connect/public/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>React App</title>
   </head>
-  <body>
+  <body style="margin: 0">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <!-- <div id="wormhole-connect" config='{"networks": ["goerli", "mumbai"], "tokens": ["ETH", "WETH", "MATIC", "WMATIC"], "theme": "light"}'></div> -->
     <div id="wormhole-connect"></div>

--- a/wormhole-connect/src/App.tsx
+++ b/wormhole-connect/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
-import CssBaseline from '@mui/material/CssBaseline';
+import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 // import Box from '@mui/material/Box';
 import { PaletteMode } from '@mui/material';
@@ -36,38 +36,11 @@ function App() {
     <Provider store={store}>
       <ColorModeContext.Provider value={colorMode}>
         <ThemeProvider theme={theme}>
-          <CssBaseline enableColorScheme />
-          {/* light/dark theme switch */}
-          {/* <Box
-            sx={{
-              display: 'flex',
-              width: '100%',
-              alignItems: 'center',
-              justifyContent: 'end',
-              bgcolor: 'background.default',
-              color: 'text.primary',
-              borderRadius: 1,
-              p: 3,
-            }}
-          >
-            {theme.palette.mode} mode
-            <IconButton
-              sx={{ ml: 1 }}
-              onClick={colorMode.toggleColorMode}
-              color="inherit"
-            >
-              {theme.palette.mode === 'dark' ? (
-                <Brightness7Icon />
-              ) : (
-                <Brightness4Icon />
-              )}
-            </IconButton>
-          </Box> */}
-
-          {/* App content */}
-          <BackgroundImage>
-            <AppRouter />
-          </BackgroundImage>
+          <ScopedCssBaseline enableColorScheme>
+            <BackgroundImage>
+              <AppRouter />
+            </BackgroundImage>
+          </ScopedCssBaseline>
         </ThemeProvider>
       </ColorModeContext.Provider>
     </Provider>

--- a/wormhole-connect/src/components/Modal.tsx
+++ b/wormhole-connect/src/components/Modal.tsx
@@ -1,6 +1,6 @@
 import { makeStyles } from 'tss-react/mui';
 import React from 'react';
-import { Dialog } from '@mui/material';
+import { Dialog, ScopedCssBaseline } from '@mui/material';
 // import { useTheme } from '@mui/material/styles';
 // import useMediaQuery from '@mui/material/useMediaQuery';
 import CloseIcon from '../icons/Close';
@@ -68,16 +68,18 @@ function Modal({ open, width, closable, children, onClose }: Props) {
       // maxWidth={width}
       // fullScreen={fullScreen}
     >
-      <div className={classes.container}>
-        {closable && (
-          <CloseIcon
-            sx={{ fontSize: 32 }}
-            className={classes.close}
-            onClick={onClose}
-          />
-        )}
-        <div className={classes.modal}>{children}</div>
-      </div>
+      <ScopedCssBaseline enableColorScheme>
+        <div className={classes.container}>
+          {closable && (
+            <CloseIcon
+              sx={{ fontSize: 32 }}
+              className={classes.close}
+              onClick={onClose}
+            />
+          )}
+          <div className={classes.modal}>{children}</div>
+        </div>
+      </ScopedCssBaseline>
     </Dialog>
   );
 }


### PR DESCRIPTION
Screenshot using `ScopedCssBaseline`:

![image](https://user-images.githubusercontent.com/11276821/235503239-474dfd3d-4a2f-4f96-b0b4-c277edec9e7d.png)

Notice the container is now inside a `div` with class `MuiScopedCssBaseline-root css-1ltrd4y-MuiScopedCssBaseline-root`. I had to manually remove the margin from the body since it's no longer reset.