### PR TITLE
fix: bug with alert component

### DIFF
--- a/wormhole-connect/src/components/AlertBanner.tsx
+++ b/wormhole-connect/src/components/AlertBanner.tsx
@@ -33,13 +33,6 @@ type Props = {
 
 function AlertBanner(props: Props) {
   const { classes } = useStyles();
-  const [alertContent, setAlertContent] = useState(props.content);
-
-  useEffect(() => {
-    if (props.content) {
-      setAlertContent(props.content);
-    }
-  }, [props.content]);
 
   return (
     <Collapse in={props.show && !!props.content} unmountOnExit>
@@ -52,7 +45,7 @@ function AlertBanner(props: Props) {
         style={{ margin: props.margin || 0 }}
       >
         <AlertIcon />
-        {alertContent}
+        {props.content}
       </div>
     </Collapse>
   );


### PR DESCRIPTION
Alert was being cleared and not reset.  I found there is an `unmountOnExit` option which seems to do the trick