### PR TITLE
Bugfix: env variables

### DIFF
--- a/builder/package-lock.json
+++ b/builder/package-lock.json
@@ -18,7 +18,7 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
-        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.4",
+        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -4353,9 +4353,9 @@
       }
     },
     "node_modules/@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.4.tgz",
-      "integrity": "sha512-sRw6fqJNiPs6GLXo75FOHy6GcZgSnTfdbzuNe7M+i+YdKTPJ+nifE02/UnVa8azH02PcsM8sIkQTo/jQhTwzwg==",
+      "version": "0.0.1-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.6.tgz",
+      "integrity": "sha512-fxwXA+jHtLJwfyXgov8Kv4GtzOwBHYMOYP3kB8RKWUO7iCC9+VxUsPx/AYPJGQNiexgjPIUOUaDInVkVouyyjw==",
       "dependencies": {
         "@mui/material": "^5.12.1"
       },
@@ -18766,9 +18766,9 @@
       }
     },
     "@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.4.tgz",
-      "integrity": "sha512-sRw6fqJNiPs6GLXo75FOHy6GcZgSnTfdbzuNe7M+i+YdKTPJ+nifE02/UnVa8azH02PcsM8sIkQTo/jQhTwzwg==",
+      "version": "0.0.1-beta.6",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.6.tgz",
+      "integrity": "sha512-fxwXA+jHtLJwfyXgov8Kv4GtzOwBHYMOYP3kB8RKWUO7iCC9+VxUsPx/AYPJGQNiexgjPIUOUaDInVkVouyyjw==",
       "requires": {
         "@mui/material": "^5.12.1"
       }

--- a/builder/package.json
+++ b/builder/package.json
@@ -13,7 +13,7 @@
     "@types/node": "^16.18.25",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.1",
-    "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.4",
+    "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/wormhole-connect/.env.mainnet
+++ b/wormhole-connect/.env.mainnet
@@ -1,4 +1,0 @@
-REACT_APP_ENV=MAINNET
-REACT_APP_WORMHOLE_EXPLORER=https://wormhole.com/explorer/
-REACT_APP_WORMHOLE_API=http://api.staging.wormscan.io/
-REACT_APP_ATTEST_URL=https://www.portalbridge.com/#/register

--- a/wormhole-connect/.env.testnet
+++ b/wormhole-connect/.env.testnet
@@ -1,4 +1,0 @@
-REACT_APP_ENV=TESTNET
-REACT_APP_WORMHOLE_EXPLORER=https://wormhole.com/explorer/
-REACT_APP_WORMHOLE_API=https://api.testnet.wormscan.io/
-REACT_APP_ATTEST_URL=https://wormhole-foundation.github.io/example-token-bridge-ui/#/register

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -57,10 +57,8 @@
   "scripts": {
     "lint": "npm run prettier && eslint --fix ./src",
     "prettier": "prettier --write ./src",
-    "start": "env-cmd -f .env.testnet react-app-rewired start",
-    "start:prod": "env-cmd -f .env.mainnet react-app-rewired start",
-    "build": "NODE_ENV=production env-cmd -f .env.testnet react-app-rewired build --max_old_space_size=4096 build",
-    "build:prod": "env-cmd -f .env.mainnet react-app-rewired build --max_old_space_size=4096 build",
+    "start": "react-app-rewired start",
+    "build": "NODE_ENV=production react-app-rewired build --max_old_space_size=4096 build",
     "test": "jest ./tests/*.test.ts --detectOpenHandles",
     "eject": "react-app-rewired eject"
   },

--- a/wormhole-connect/public/index.html
+++ b/wormhole-connect/public/index.html
@@ -16,6 +16,6 @@
   <body style="margin: 0">
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <!-- <div id="wormhole-connect" config='{"networks": ["goerli", "mumbai"], "tokens": ["ETH", "WETH", "MATIC", "WMATIC"], "theme": "light"}'></div> -->
-    <div id="wormhole-connect"></div>
+    <div id="wormhole-connect" config='{"env": "mainnet"}'></div>
   </body>
 </html>

--- a/wormhole-connect/src/components/AlertBanner.tsx
+++ b/wormhole-connect/src/components/AlertBanner.tsx
@@ -35,10 +35,6 @@ function AlertBanner(props: Props) {
   const { classes } = useStyles();
   const [alertContent, setAlertContent] = useState(props.content);
 
-  const clear = () => {
-    setAlertContent(undefined);
-  };
-
   useEffect(() => {
     if (props.content) {
       setAlertContent(props.content);
@@ -46,7 +42,7 @@ function AlertBanner(props: Props) {
   }, [props.content]);
 
   return (
-    <Collapse in={props.show && !!props.content} onExited={clear}>
+    <Collapse in={props.show && !!props.content} unmountOnExit>
       <div
         className={joinClass([
           classes.base,

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -26,15 +26,15 @@ if (!el)
 const configJson = el.getAttribute('config');
 export const config: WormholeConnectConfig | null = JSON.parse(configJson!);
 
-export const isProduction = config && config.env === 'mainnet';
-export const CONFIG = isProduction ? CONF.MAINNET : CONF.TESTNET;
-export const ENV = isProduction ? 'MAINNET' : 'TESTNET';
+export const isMainnet = config && config.env === 'mainnet';
+export const CONFIG = isMainnet ? CONF.MAINNET : CONF.TESTNET;
+export const ENV = isMainnet ? 'MAINNET' : 'TESTNET';
 
 export const WORMHOLE_EXPLORER = 'https://wormhole.com/explorer/';
-export const WORMHOLE_API = isProduction
+export const WORMHOLE_API = isMainnet
   ? 'http://api.wormscan.io/'
   : 'https://api.testnet.wormscan.io/';
-export const ATTEST_URL = isProduction
+export const ATTEST_URL = isMainnet
   ? 'https://www.portalbridge.com/#/register'
   : 'https://wormhole-foundation.github.io/example-token-bridge-ui/#/register';
 
@@ -61,24 +61,24 @@ const testnetRpcs = {
 };
 conf.rpcs = Object.assign(
   {},
-  isProduction ? mainnetRpcs : testnetRpcs,
+  isMainnet ? mainnetRpcs : testnetRpcs,
   config?.rpcs || {},
 );
 export const WH_CONFIG = conf;
 
-export const CHAINS = isProduction ? MAINNET_NETWORKS : TESTNET_NETWORKS;
+export const CHAINS = isMainnet ? MAINNET_NETWORKS : TESTNET_NETWORKS;
 export const CHAINS_ARR =
   config && config.networks
     ? Object.values(CHAINS).filter((c) => config.networks!.includes(c.key))
     : (Object.values(CHAINS) as NetworkConfig[]);
 
-export const TOKENS = isProduction ? MAINNET_TOKENS : TESTNET_TOKENS;
+export const TOKENS = isMainnet ? MAINNET_TOKENS : TESTNET_TOKENS;
 export const TOKENS_ARR =
   config && config.tokens
     ? Object.values(TOKENS).filter((c) => config.tokens!.includes(c.key))
     : (Object.values(TOKENS) as TokenConfig[]);
 
-export const GAS_ESTIMATES = isProduction
+export const GAS_ESTIMATES = isMainnet
   ? MAINNET_GAS_ESTIMATES
   : TESTNET_GAS_ESTIMATES;
 

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -26,10 +26,17 @@ if (!el)
 const configJson = el.getAttribute('config');
 export const config: WormholeConnectConfig | null = JSON.parse(configJson!);
 
-const { REACT_APP_ENV } = process.env;
-export const isProduction =
-  (config && config.env === 'mainnet') || REACT_APP_ENV === 'MAINNET';
+export const isProduction = config && config.env === 'mainnet';
 export const CONFIG = isProduction ? CONF.MAINNET : CONF.TESTNET;
+export const ENV = isProduction ? 'MAINNET' : 'TESTNET';
+
+export const WORMHOLE_EXPLORER = 'https://wormhole.com/explorer/';
+export const WORMHOLE_API = isProduction
+  ? 'http://api.wormscan.io/'
+  : 'https://api.testnet.wormscan.io/';
+export const ATTEST_URL = isProduction
+  ? 'https://www.portalbridge.com/#/register'
+  : 'https://wormhole-foundation.github.io/example-token-bridge-ui/#/register';
 
 const conf = WormholeContext.getConfig(CONFIG.env);
 const mainnetRpcs = {

--- a/wormhole-connect/src/sdk/index.ts
+++ b/wormhole-connect/src/sdk/index.ts
@@ -11,7 +11,7 @@ import {
 import { Transaction } from '@solana/web3.js';
 
 import { getTokenById, getTokenDecimals, getWrappedTokenId } from '../utils';
-import { TOKENS, WH_CONFIG } from '../config';
+import { isProduction, TOKENS, WH_CONFIG } from '../config';
 import { postVaa, signSolanaTransaction, TransferWallet } from 'utils/wallet';
 import { estimateClaimFees, estimateSendFees } from './gasEstimates';
 
@@ -20,9 +20,8 @@ export enum PaymentOption {
   AUTOMATIC = 3,
 }
 
-const { REACT_APP_ENV } = process.env;
-
-export const wh = new WormholeContext(REACT_APP_ENV! as Environment, WH_CONFIG);
+const ENV = isProduction ? 'MAINNET' : 'TESTNET';
+export const wh = new WormholeContext(ENV as Environment, WH_CONFIG);
 
 export interface ParsedMessage {
   sendTx: string;

--- a/wormhole-connect/src/sdk/index.ts
+++ b/wormhole-connect/src/sdk/index.ts
@@ -11,7 +11,7 @@ import {
 import { Transaction } from '@solana/web3.js';
 
 import { getTokenById, getTokenDecimals, getWrappedTokenId } from '../utils';
-import { isProduction, TOKENS, WH_CONFIG } from '../config';
+import { isMainnet, TOKENS, WH_CONFIG } from '../config';
 import { postVaa, signSolanaTransaction, TransferWallet } from 'utils/wallet';
 import { estimateClaimFees, estimateSendFees } from './gasEstimates';
 
@@ -20,7 +20,7 @@ export enum PaymentOption {
   AUTOMATIC = 3,
 }
 
-const ENV = isProduction ? 'MAINNET' : 'TESTNET';
+const ENV = isMainnet ? 'MAINNET' : 'TESTNET';
 export const wh = new WormholeContext(ENV as Environment, WH_CONFIG);
 
 export interface ParsedMessage {

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -3,7 +3,7 @@ import { ChainId } from '@wormhole-foundation/wormhole-connect-sdk';
 import axios from 'axios';
 
 import { utils } from 'ethers';
-import { CHAINS } from '../config';
+import { CHAINS, WORMHOLE_API } from '../config';
 import { ParsedMessage } from '../sdk';
 
 export type ParsedVaa = {
@@ -24,8 +24,6 @@ export type ParsedVaa = {
   txHash: string;
 };
 
-const { REACT_APP_WORMHOLE_API } = process.env;
-
 export async function fetchVaa(
   txData: ParsedMessage,
 ): Promise<ParsedVaa | undefined> {
@@ -36,7 +34,7 @@ export async function fetchVaa(
   const emitterAddress = txData.emitterAddress.startsWith('0x')
     ? txData.emitterAddress.slice(2)
     : txData.emitterAddress;
-  const url = `${REACT_APP_WORMHOLE_API}api/v1/vaas/${emitterChain.id}/${emitterAddress}/${txData.sequence}`;
+  const url = `${WORMHOLE_API}api/v1/vaas/${emitterChain.id}/${emitterAddress}/${txData.sequence}`;
 
   return axios
     .get(url)

--- a/wormhole-connect/src/views/Bridge/Inputs.tsx/To.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs.tsx/To.tsx
@@ -3,9 +3,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { BigNumber } from 'ethers';
 import { makeStyles } from 'tss-react/mui';
 import { RootState } from '../../../store';
+import { CircularProgress, Link, Typography } from '@mui/material';
 import { setToNetworksModal } from '../../../store/router';
 import { TransferWallet, signSolanaTransaction } from '../../../utils/wallet';
-import { TOKENS } from '../../../config';
+import { getWrappedToken, getWrappedTokenId } from '../../../utils';
+import { joinClass } from '../../../utils/style';
+import { ATTEST_URL, TOKENS } from '../../../config';
 import { getBalance, getForeignAsset, solanaContext } from '../../../sdk';
 import {
   formatBalance,
@@ -17,11 +20,6 @@ import Inputs from './Inputs';
 import Input from './Input';
 import Select from './Select';
 import InputTransparent from '../../../components/InputTransparent';
-import { getWrappedToken, getWrappedTokenId } from '../../../utils';
-import { CircularProgress, Link, Typography } from '@mui/material';
-import { joinClass } from '../../../utils/style';
-
-const { REACT_APP_ATTEST_URL } = process.env;
 
 const useStyles = makeStyles()((theme) => ({
   associatedTokenWarning: {
@@ -216,7 +214,7 @@ function ToInputs() {
     () => (
       <Typography>
         This token is not registered, you must{' '}
-        <Link target={'_blank'} variant="inherit" href={REACT_APP_ATTEST_URL}>
+        <Link target={'_blank'} variant="inherit" href={ATTEST_URL}>
           register
         </Link>{' '}
         it before you continue. Newly registered tokens will not have liquid

--- a/wormhole-connect/src/views/Redeem/AddToWallet.tsx
+++ b/wormhole-connect/src/views/Redeem/AddToWallet.tsx
@@ -10,7 +10,7 @@ import {
   CHAINS,
   TESTNET_TO_MAINNET_CHAIN_NAMES,
   TOKENS,
-  isProduction,
+  isMainnet,
 } from '../../config';
 import { MAINNET_NETWORKS } from '../../config/mainnet';
 import TokenIcon from '../../icons/TokenIcons';
@@ -129,7 +129,7 @@ function AddToWallet() {
     );
   }, [txData]);
 
-  const chainName = isProduction
+  const chainName = isMainnet
     ? (txData.toChain as ChainName)
     : TESTNET_TO_MAINNET_CHAIN_NAMES[txData.toChain];
   const chainId = coalesceChainId(chainName);

--- a/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
+++ b/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import { makeStyles } from 'tss-react/mui';
 import { LINK } from '../../utils/style';
-import { CHAINS } from '../../config';
+import { CHAINS, isProduction } from '../../config';
 import LaunchIcon from '@mui/icons-material/Launch';
 
 const useStyles = makeStyles()((theme) => ({
@@ -27,10 +27,7 @@ function ExplorerLink(props: ExplorerLinkProps) {
       ? `${networkConfig.explorerUrl}tx/${props.txHash}`
       : `${networkConfig.explorerUrl}address/${props.address}`;
 
-  if (
-    networkConfig.key === 'solana' &&
-    process.env.REACT_APP_ENV === 'TESTNET'
-  ) {
+  if (networkConfig.key === 'solana' && !isProduction) {
     explorerLink += '?cluster=devnet';
   }
 

--- a/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
+++ b/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import { makeStyles } from 'tss-react/mui';
 import { LINK } from '../../utils/style';
-import { CHAINS, isProduction } from '../../config';
+import { CHAINS, isMainnet } from '../../config';
 import LaunchIcon from '@mui/icons-material/Launch';
 
 const useStyles = makeStyles()((theme) => ({
@@ -27,7 +27,7 @@ function ExplorerLink(props: ExplorerLinkProps) {
       ? `${networkConfig.explorerUrl}tx/${props.txHash}`
       : `${networkConfig.explorerUrl}address/${props.address}`;
 
-  if (networkConfig.key === 'solana' && !isProduction) {
+  if (networkConfig.key === 'solana' && !isMainnet) {
     explorerLink += '?cluster=devnet';
   }
 

--- a/wormhole-connect/src/views/Redeem/Tag.tsx
+++ b/wormhole-connect/src/views/Redeem/Tag.tsx
@@ -3,12 +3,11 @@ import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { RootState } from '../../store';
 import { LINK } from '../../utils/style';
-import { CHAINS } from '../../config';
+import { CHAINS, WORMHOLE_EXPLORER } from '../../config';
 import InputContainer from '../../components/InputContainer';
 import ArrowRight from '../../icons/ArrowRight';
 import LaunchIcon from '@mui/icons-material/Launch';
 import TokenIcon from '../../icons/TokenIcons';
-const { REACT_APP_WORMHOLE_EXPLORER } = process.env;
 
 const useStyles = makeStyles()((theme) => ({
   row: {
@@ -42,7 +41,7 @@ function NetworksTag() {
     : txData.emitterAddress;
   const link =
     txData &&
-    `${REACT_APP_WORMHOLE_EXPLORER}?emitterChain=${fromNetworkConfig.id}&emitterAddress=${emitterAddress}&sequence=${txData.sequence}`;
+    `${WORMHOLE_EXPLORER}?emitterChain=${fromNetworkConfig.id}&emitterAddress=${emitterAddress}&sequence=${txData.sequence}`;
 
   return (
     <div>


### PR DESCRIPTION
Closes #508 

In the integration it was loading the wrong .env file, it was loading testnet values for mainnet.  Didn't catch this because when deploying to netlify, it loads the correct file.  Changed it so it determines the value based on the `isMainnet` constant.