### PR TITLE
fix: dont disconnect wallets when routing back to bridge page

### DIFF
--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -55,10 +55,6 @@ function AppRouter() {
     if (prevRoute === bridgeRoute && route !== bridgeRoute) {
       dispatch(clearTransfer());
     }
-    // reset wallets when starting a new bridge transfer
-    if (prevRoute !== bridgeRoute && route === bridgeRoute) {
-      dispatch(clearWallets());
-    }
   }, [route, prevRoute, dispatch]);
 
   return (


### PR DESCRIPTION
Not sure if this was done for a specific reason? I can't see a good reason to reset them though... and it's annoying for the user if the user clicked on the FAQ page for example and then wants to go back, they have to restart their transaction.

Also more importantly, because this component uses the same instance of the wallet from the window object as the app which installed it (e.g. Drift ui) this disconnects the wallet in the app too, not just in the bridge component. So it feels very buggy as a user.