### PR TITLE
Fix mainnet wormscan URL http -> https

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
-        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.4",
+        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -9196,9 +9196,9 @@
       }
     },
     "node_modules/@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.4.tgz",
-      "integrity": "sha512-sRw6fqJNiPs6GLXo75FOHy6GcZgSnTfdbzuNe7M+i+YdKTPJ+nifE02/UnVa8azH02PcsM8sIkQTo/jQhTwzwg==",
+      "version": "0.0.1-beta.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.7.tgz",
+      "integrity": "sha512-8jqjQB0XTsvmhrGI0Il56uKvEHAqWVQgrcyjCBW0cAhvQV5iECj6cTodhxikiRGMwnqE9bwbKmxeWd6Pnv07jQ==",
       "dependencies": {
         "@mui/material": "^5.12.1"
       },
@@ -34815,9 +34815,9 @@
       }
     },
     "@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.4",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.4.tgz",
-      "integrity": "sha512-sRw6fqJNiPs6GLXo75FOHy6GcZgSnTfdbzuNe7M+i+YdKTPJ+nifE02/UnVa8azH02PcsM8sIkQTo/jQhTwzwg==",
+      "version": "0.0.1-beta.7",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.7.tgz",
+      "integrity": "sha512-8jqjQB0XTsvmhrGI0Il56uKvEHAqWVQgrcyjCBW0cAhvQV5iECj6cTodhxikiRGMwnqE9bwbKmxeWd6Pnv07jQ==",
       "requires": {
         "@mui/material": "^5.12.1"
       }
@@ -47247,7 +47247,7 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
-        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.4",
+        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -32,7 +32,7 @@ export const ENV = isMainnet ? 'MAINNET' : 'TESTNET';
 
 export const WORMHOLE_EXPLORER = 'https://wormhole.com/explorer/';
 export const WORMHOLE_API = isMainnet
-  ? 'http://api.wormscan.io/'
+  ? 'https://api.wormscan.io/'
   : 'https://api.testnet.wormscan.io/';
 export const ATTEST_URL = isMainnet
   ? 'https://www.portalbridge.com/#/register'


### PR DESCRIPTION
`http` causes a mixed content error on Chrome: https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content#loading_mixed-content_resources

Partially fixes #528 (along with #526)