### PR TITLE
Add bottom margin to terms callout

### DIFF
--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -49,7 +49,7 @@ const useStyles = makeStyles()((theme) => ({
   tosDisclaimer: {
     display: 'flex',
     flexDirection: 'row',
-    marginBottom: 5,
+    marginBottom: 10,
     marginLeft: 16,
     fontSize: '12px',
   },


### PR DESCRIPTION
`By proceeding, you agree to the Terms of Use` line felt too close to the Approve button. Open to feedback about values between 5-10px as well.

Before:
![before](https://i.imgur.com/m8Bzrbr.png)

After:
![after](https://i.imgur.com/P7XmNl5.png)