### PR TITLE
Generic types for sdk contexts

### DIFF
--- a/sdk/src/contexts/abstracts/relayer.ts
+++ b/sdk/src/contexts/abstracts/relayer.ts
@@ -2,7 +2,10 @@ import { BigNumber, BigNumberish } from 'ethers';
 import { TokenId, ChainName, ChainId } from '../../types';
 import { TokenBridgeAbstract } from './tokenBridge';
 
-export abstract class RelayerAbstract extends TokenBridgeAbstract {
+export abstract class RelayerAbstract<
+  SendResult,
+  RedeemResult,
+> extends TokenBridgeAbstract<SendResult, RedeemResult> {
   protected abstract sendWithRelay(
     token: TokenId | 'native',
     amount: string,
@@ -12,7 +15,7 @@ export abstract class RelayerAbstract extends TokenBridgeAbstract {
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     overrides?: any,
-  ): Promise<any>;
+  ): Promise<SendResult>;
   protected abstract calculateNativeTokenAmt(
     destChain: ChainName | ChainId,
     tokenId: TokenId,

--- a/sdk/src/contexts/abstracts/relayer.ts
+++ b/sdk/src/contexts/abstracts/relayer.ts
@@ -3,9 +3,8 @@ import { TokenId, ChainName, ChainId } from '../../types';
 import { TokenBridgeAbstract } from './tokenBridge';
 
 export abstract class RelayerAbstract<
-  SendResult,
-  RedeemResult,
-> extends TokenBridgeAbstract<SendResult, RedeemResult> {
+  TransactionResult,
+> extends TokenBridgeAbstract<TransactionResult> {
   protected abstract sendWithRelay(
     token: TokenId | 'native',
     amount: string,
@@ -15,7 +14,7 @@ export abstract class RelayerAbstract<
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     overrides?: any,
-  ): Promise<SendResult>;
+  ): Promise<TransactionResult>;
   protected abstract calculateNativeTokenAmt(
     destChain: ChainName | ChainId,
     tokenId: TokenId,

--- a/sdk/src/contexts/abstracts/tokenBridge.ts
+++ b/sdk/src/contexts/abstracts/tokenBridge.ts
@@ -9,7 +9,7 @@ import {
 } from '../../types';
 
 // template for different environment contexts
-export abstract class TokenBridgeAbstract {
+export abstract class TokenBridgeAbstract<SendResult, RedeemResult> {
   protected abstract contracts: AnyContracts;
 
   /**
@@ -23,7 +23,7 @@ export abstract class TokenBridgeAbstract {
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     relayerFee: any,
-  ): Promise<any>;
+  ): Promise<SendResult>;
 
   protected abstract sendWithPayload(
     token: TokenId | 'native',
@@ -33,7 +33,7 @@ export abstract class TokenBridgeAbstract {
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     payload: any,
-  ): Promise<any>;
+  ): Promise<SendResult>;
 
   protected abstract formatAddress(address: string): any;
   protected abstract parseAddress(address: any): string;
@@ -69,7 +69,7 @@ export abstract class TokenBridgeAbstract {
     signedVAA: Uint8Array,
     overrides: any,
     payerAddr?: any,
-  ): Promise<any>;
+  ): Promise<RedeemResult>;
   protected abstract isTransferCompleted(
     destChain: ChainName | ChainId,
     signedVaa: string,

--- a/sdk/src/contexts/abstracts/tokenBridge.ts
+++ b/sdk/src/contexts/abstracts/tokenBridge.ts
@@ -9,7 +9,7 @@ import {
 } from '../../types';
 
 // template for different environment contexts
-export abstract class TokenBridgeAbstract<SendResult, RedeemResult> {
+export abstract class TokenBridgeAbstract<TransactionResult> {
   protected abstract contracts: AnyContracts;
 
   /**
@@ -23,7 +23,7 @@ export abstract class TokenBridgeAbstract<SendResult, RedeemResult> {
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     relayerFee: any,
-  ): Promise<SendResult>;
+  ): Promise<TransactionResult>;
 
   protected abstract sendWithPayload(
     token: TokenId | 'native',
@@ -33,7 +33,7 @@ export abstract class TokenBridgeAbstract<SendResult, RedeemResult> {
     recipientChain: ChainName | ChainId,
     recipientAddress: string,
     payload: any,
-  ): Promise<SendResult>;
+  ): Promise<TransactionResult>;
 
   protected abstract formatAddress(address: string): any;
   protected abstract parseAddress(address: any): string;
@@ -69,7 +69,7 @@ export abstract class TokenBridgeAbstract<SendResult, RedeemResult> {
     signedVAA: Uint8Array,
     overrides: any,
     payerAddr?: any,
-  ): Promise<RedeemResult>;
+  ): Promise<TransactionResult>;
   protected abstract isTransferCompleted(
     destChain: ChainName | ChainId,
     signedVaa: string,

--- a/sdk/src/contexts/eth/index.ts
+++ b/sdk/src/contexts/eth/index.ts
@@ -30,10 +30,9 @@ import { parseVaa } from '../../vaa';
 import { RelayerAbstract } from '../abstracts/relayer';
 import { SolanaContext } from '../solana';
 
-export class EthContext<T extends WormholeContext> extends RelayerAbstract<
-  ethers.ContractReceipt,
-  ethers.ContractReceipt
-> {
+export class EthContext<
+  T extends WormholeContext,
+> extends RelayerAbstract<ethers.ContractReceipt> {
   readonly type = Context.ETH;
   readonly contracts: EthContracts<T>;
   readonly context: T;

--- a/sdk/src/contexts/eth/index.ts
+++ b/sdk/src/contexts/eth/index.ts
@@ -22,6 +22,7 @@ import {
   NATIVE,
   ParsedRelayerMessage,
   ParsedMessage,
+  Context,
 } from '../../types';
 import { WormholeContext } from '../../wormhole';
 import { EthContracts } from './contracts';
@@ -29,7 +30,11 @@ import { parseVaa } from '../../vaa';
 import { RelayerAbstract } from '../abstracts/relayer';
 import { SolanaContext } from '../solana';
 
-export class EthContext<T extends WormholeContext> extends RelayerAbstract {
+export class EthContext<T extends WormholeContext> extends RelayerAbstract<
+  ethers.ContractReceipt,
+  ethers.ContractReceipt
+> {
+  readonly type = Context.ETH;
   readonly contracts: EthContracts<T>;
   readonly context: T;
 

--- a/sdk/src/contexts/solana/index.ts
+++ b/sdk/src/contexts/solana/index.ts
@@ -68,7 +68,7 @@ const SOLANA_TESTNET_EMITTER_ID =
 
 export class SolanaContext<
   T extends WormholeContext,
-> extends TokenBridgeAbstract<Transaction, Transaction> {
+> extends TokenBridgeAbstract<Transaction> {
   readonly type = Context.SOLANA;
   protected contracts: SolContracts<T>;
   readonly context: T;

--- a/sdk/src/contexts/solana/index.ts
+++ b/sdk/src/contexts/solana/index.ts
@@ -42,6 +42,7 @@ import {
   ChainId,
   NATIVE,
   ParsedMessage,
+  Context,
 } from '../../types';
 import { SolContracts } from './contracts';
 import { WormholeContext } from '../../wormhole';
@@ -67,7 +68,8 @@ const SOLANA_TESTNET_EMITTER_ID =
 
 export class SolanaContext<
   T extends WormholeContext,
-> extends TokenBridgeAbstract {
+> extends TokenBridgeAbstract<Transaction, Transaction> {
+  readonly type = Context.SOLANA;
   protected contracts: SolContracts<T>;
   readonly context: T;
   connection: Connection | undefined;
@@ -607,7 +609,7 @@ export class SolanaContext<
     signedVAA: Uint8Array,
     overrides: any,
     payerAddr?: PublicKeyInitData,
-  ): Promise<any> {
+  ): Promise<Transaction> {
     if (!payerAddr)
       throw new Error(
         'receiving wallet address required for redeeming on Solana',

--- a/sdk/src/contexts/sui/index.ts
+++ b/sdk/src/contexts/sui/index.ts
@@ -44,10 +44,9 @@ interface TransferWithRelay {
   recipient: string;
 }
 
-export class SuiContext<T extends WormholeContext> extends RelayerAbstract<
-  TransactionBlock,
-  TransactionBlock
-> {
+export class SuiContext<
+  T extends WormholeContext,
+> extends RelayerAbstract<TransactionBlock> {
   readonly type = Context.SUI;
   protected contracts: SuiContracts<T>;
   readonly context: T;

--- a/sdk/src/contexts/sui/index.ts
+++ b/sdk/src/contexts/sui/index.ts
@@ -19,6 +19,7 @@ import {
   ChainId,
   NATIVE,
   ParsedMessage,
+  Context,
 } from '../../types';
 import { WormholeContext } from '../../wormhole';
 import { RelayerAbstract } from '../abstracts/relayer';
@@ -43,7 +44,11 @@ interface TransferWithRelay {
   recipient: string;
 }
 
-export class SuiContext<T extends WormholeContext> extends RelayerAbstract {
+export class SuiContext<T extends WormholeContext> extends RelayerAbstract<
+  TransactionBlock,
+  TransactionBlock
+> {
+  readonly type = Context.SUI;
   protected contracts: SuiContracts<T>;
   readonly context: T;
   readonly provider: JsonRpcProvider;

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,14 +1,14 @@
 import { Network as Environment } from '@certusone/wormhole-sdk';
 import { BigNumber } from 'ethers';
-import { WormholeContext } from './wormhole';
+import { MainnetChainId, MainnetChainName } from './config/MAINNET';
+import { TestnetChainId, TestnetChainName } from './config/TESTNET';
 import { EthContext } from './contexts/eth';
-import { SolanaContext } from './contexts/solana';
 import { EthContracts } from './contexts/eth/contracts';
+import { SolanaContext } from './contexts/solana';
 import { SolContracts } from './contexts/solana/contracts';
-import { MainnetChainName, MainnetChainId } from './config/MAINNET';
-import { TestnetChainName, TestnetChainId } from './config/TESTNET';
 import { SuiContext } from './contexts/sui';
 import { SuiContracts } from './contexts/sui/contracts';
+import { WormholeContext } from './wormhole';
 
 export const NATIVE = 'native';
 // TODO: conditionally set these types
@@ -104,3 +104,6 @@ export type TokenDetails = {
   symbol: string;
   decimals: number;
 };
+
+export type SendResult = ReturnType<AnyContext['send']>;
+export type RedeemResult = ReturnType<AnyContext['redeem']>;


### PR DESCRIPTION
Add generic types to contexts. Infer result types for the send, sendWithRelay, and redeem operations instead of manually defining it in the base wormhole context.