### PR TITLE
[577] Break down automatic payment total fees when the token is not the native token

### DIFF
--- a/wormhole-connect/src/views/Bridge/GasOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/GasOptions.tsx
@@ -90,19 +90,27 @@ const getOptions = (
         : '—',
   };
   if (!relayAvail) return [manual];
-  const automaticFees = toFixedDecimals(
-    `${Number.parseFloat(gasEst.automatic) + relayerFee!}`,
-    6,
-  );
+
+  let estimateText = '-';
+
+  if (gasEst.automatic && relayerFee !== undefined) {
+    const isNative = token === source.gasToken;
+
+    const fee = toFixedDecimals(
+      `${relayerFee + (isNative ? Number.parseFloat(gasEst.automatic) : 0)}`,
+      6,
+    );
+    estimateText = isNative
+      ? `${fee} ${token}`
+      : `${gasEst.automatic} ${source.gasToken} & ${fee} ${token}`;
+  }
+
   const automatic = {
     key: PaymentOption.AUTOMATIC,
     title: payWith(source.gasToken, token),
     subtitle: '(one transaction)',
     description: `Gas fees on ${dest.displayName} will be paid automatically`,
-    estimate:
-      gasEst.automatic && relayerFee !== undefined
-        ? `${automaticFees} ${token}`
-        : '—',
+    estimate: estimateText,
   };
   return [automatic, manual];
 };

--- a/wormhole-connect/src/views/Bridge/Preview.tsx
+++ b/wormhole-connect/src/views/Bridge/Preview.tsx
@@ -24,10 +24,18 @@ const getAutomaticRows = (
   sendingGasEst: string,
 ): RowsData => {
   const receivingToken = token.wrappedAsset || token.symbol;
-  const totalFees = toFixedDecimals(
-    `${Number.parseFloat(sendingGasEst) + relayerFee}`,
-    6,
-  );
+  const isNative = token.symbol === sourceGasToken;
+  let totalFeesText = '';
+  if (sendingGasEst && relayerFee) {
+    const fee = toFixedDecimals(
+      `${relayerFee + (isNative ? Number.parseFloat(sendingGasEst) : 0)}`,
+      6,
+    );
+    totalFeesText = isNative
+      ? `${fee} ${token.symbol}`
+      : `${sendingGasEst} ${sourceGasToken} & ${fee} ${token.symbol}`;
+  }
+
   return [
     {
       title: 'Amount',
@@ -42,16 +50,15 @@ const getAutomaticRows = (
     },
     {
       title: 'Total fee estimates',
-      value:
-        totalFees && totalFees !== 'NaN' ? `${totalFees} ${token.symbol}` : '',
+      value: totalFeesText,
       rows: [
-        {
-          title: 'Relayer fee',
-          value: relayerFee ? `${relayerFee} ${token.symbol}` : '—',
-        },
         {
           title: 'Source chain gas estimate',
           value: sendingGasEst ? `~ ${sendingGasEst} ${sourceGasToken}` : '—',
+        },
+        {
+          title: 'Relayer fee',
+          value: relayerFee ? `${relayerFee} ${token.symbol}` : '—',
         },
       ],
     },


### PR DESCRIPTION
Non native transfer wSUI from Fuji to Mumbai:

![image](https://user-images.githubusercontent.com/11276821/236568123-2404ff5c-c32a-42aa-b975-e29ef222cb92.png)

![image](https://user-images.githubusercontent.com/11276821/236569340-b0afa34c-ea4c-4dc2-9f29-f271cae2c7dd.png)

Native transfer AVAX from Fuji to Mumbai:

![image](https://user-images.githubusercontent.com/11276821/236567973-f01ba306-d295-4527-af8b-2bb59a3b6137.png)

![image](https://user-images.githubusercontent.com/11276821/236568003-01d45976-702f-4170-a6d7-4e36e34e326f.png)

Closes #577 