### PR TITLE
fix: clear wallet if not supported on network

### DIFF
--- a/wormhole-connect/src/components/ConnectWallet.tsx
+++ b/wormhole-connect/src/components/ConnectWallet.tsx
@@ -11,7 +11,7 @@ import WalletIcons from '../icons/WalletIcons';
 import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
 import Popover from '@mui/material/Popover';
 import { setWalletModal } from '../store/router';
-import { clearWallet } from '../store/wallet';
+import { disconnectWallet as disconnectFromStore } from '../store/wallet';
 import { ScopedCssBaseline } from '@mui/material';
 
 const useStyles = makeStyles()((theme) => ({
@@ -72,7 +72,7 @@ function ConnectWallet(props: Props) {
   };
 
   const disconnectWallet = async () => {
-    dispatch(clearWallet(type));
+    dispatch(disconnectFromStore(type));
   };
 
   return wallet && wallet.address ? (

--- a/wormhole-connect/src/store/wallet.ts
+++ b/wormhole-connect/src/store/wallet.ts
@@ -32,6 +32,7 @@ const initialState: WalletState = {
 
 export type ConnectPayload = {
   address: string;
+  type: Context;
   icon?: string;
   name: string;
 };
@@ -46,6 +47,7 @@ export const walletSlice = createSlice({
     ) => {
       state.sending.address = payload.address;
       state.sending.currentAddress = payload.address;
+      state.sending.type = payload.type;
       state.sending.name = payload.name;
       state.sending.error = '';
       state.sending.icon = payload.icon;
@@ -56,11 +58,18 @@ export const walletSlice = createSlice({
     ) => {
       state.receiving.address = payload.address;
       state.receiving.currentAddress = payload.address;
+      state.receiving.type = payload.type;
       state.receiving.name = payload.name;
       state.receiving.error = '';
       state.receiving.icon = payload.icon;
     },
     clearWallet: (
+      state: WalletState,
+      { payload }: PayloadAction<TransferWallet>,
+    ) => {
+      state[payload] = NO_WALLET;
+    },
+    disconnectWallet: (
       state: WalletState,
       { payload }: PayloadAction<TransferWallet>,
     ) => {
@@ -82,6 +91,12 @@ export const walletSlice = createSlice({
       state[type].currentAddress = address;
     },
     clearWallets: (state: WalletState) => {
+      Object.keys(state).forEach((key) => {
+        // @ts-ignore
+        state[key] = initialState[key];
+      });
+    },
+    disconnectWallets: (state: WalletState) => {
       disconnect(TransferWallet.SENDING);
       disconnect(TransferWallet.RECEIVING);
       Object.keys(state).forEach((key) => {
@@ -99,6 +114,8 @@ export const {
   setCurrentAddress,
   setWalletError,
   clearWallets,
+  disconnectWallet,
+  disconnectWallets,
 } = walletSlice.actions;
 
 export default walletSlice.reducer;

--- a/wormhole-connect/src/views/WalletModal.tsx
+++ b/wormhole-connect/src/views/WalletModal.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '@mui/material/styles';
 import { useDispatch, useSelector } from 'react-redux';
 import { Wallet, WalletState } from '@xlabs-libs/wallet-aggregator-core';
 import { getWallets as getSuiWallets } from '@xlabs-libs/wallet-aggregator-sui';
-import { CHAINS, CHAINS_ARR } from '../config';
+import { CHAINS } from '../config';
 import { RootState } from '../store';
 import { setWalletModal } from '../store/router';
 import {
@@ -33,8 +33,8 @@ const useStyles = makeStyles()((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     width: '100%',
-    gap: '16px',
     padding: '16px 8px',
     transition: `background-color 0.4s`,
     cursor: 'pointer',
@@ -45,6 +45,15 @@ const useStyles = makeStyles()((theme) => ({
     '&:not(:last-child)': {
       borderBottom: `0.5px solid ${theme.palette.divider}`,
     },
+  },
+  walletRowLeft: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: '16px',
+  },
+  context: {
+    opacity: '0.6',
   },
   notInstalled: {
     opacity: '60%',
@@ -110,12 +119,8 @@ const getWalletOptions = async (
       [Context.SUI]: suiOptions,
     };
 
-    return Object.entries(allWallets)
-      .filter(
-        ([type]) =>
-          !!CHAINS_ARR.find((chain: ChainConfig) => chain.context === type),
-      )
-      .map(([type, wallets]) => mapWallets(wallets, type))
+    return Object.keys(allWallets)
+      .map((key) => mapWallets(allWallets[key], key as Context))
       .reduce((acc, arr) => acc.concat(arr), []);
   }
   if (config.context === Context.ETH) {
@@ -127,6 +132,12 @@ const getWalletOptions = async (
     return Object.values(mapWallets(suiOptions, Context.SUI));
   }
   return [];
+};
+
+const getWalletChainText = (context: Context) => {
+  if (context === Context.SOLANA) return 'Solana';
+  if (context === Context.SUI) return 'Sui';
+  return 'EVM';
 };
 
 type Props = {
@@ -207,6 +218,7 @@ function WalletsModal(props: Props) {
     if (address) {
       const payload = {
         address,
+        type: walletInfo.type,
         icon: wallet.getIcon(),
         name: wallet.getName(),
       };
@@ -232,9 +244,14 @@ function WalletsModal(props: Props) {
         : () => window.open(wallet.wallet.getUrl());
       return (
         <div className={classes.walletRow} key={i} onClick={select}>
-          <WalletIcon name={wallet.name} icon={wallet.icon} height={32} />
-          <div className={`${!ready && classes.notInstalled}`}>
-            {!ready && 'Install'} {wallet.name}
+          <div className={classes.walletRowLeft}>
+            <WalletIcon name={wallet.name} icon={wallet.icon} height={32} />
+            <div className={`${!ready && classes.notInstalled}`}>
+              {!ready && 'Install'} {wallet.name}
+            </div>
+          </div>
+          <div className={classes.context}>
+            {getWalletChainText(wallet.type)}
           </div>
         </div>
       );


### PR DESCRIPTION
There is some weirdness around Nightly specifically.  The wallet classes are different between Solana and Sui and have different addresses. Also, we don't change the wallet address if the account is changed because of how it works with Metamask.  For now, I think it works best to have the 2 separate versions of Nightly listed and have them select the one that matches the chain they are using.  To help clarify things, I added the chain/context to the right