### PR TITLE
fix: align text on mobile

### DIFF
--- a/wormhole-connect/src/views/Bridge/GasOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/GasOptions.tsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles()((theme) => ({
     [theme.breakpoints.down('sm')]: {
       flexDirection: 'column',
       gap: '16px',
+      alignItems: 'flex-start',
     },
   },
   title: {

--- a/wormhole-connect/src/views/Bridge/Preview.tsx
+++ b/wormhole-connect/src/views/Bridge/Preview.tsx
@@ -45,7 +45,7 @@ const getAutomaticRows = (
       )} ${receivingToken}`,
     },
     {
-      title: 'Native token on destination',
+      title: 'Native gas on destination',
       value: `${receiveNativeAmt} ${destinationGasToken}`,
     },
     {


### PR DESCRIPTION
Quick style fix for mobile.  Also, uses the same terminology for the gas dropoff ("Native gas")