### PR TITLE
Docs: Adding SDK readme, tweak root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,57 @@ Wormhole Connect is a project to facilitate integration with the Wormhole protoc
 
 ### wormhole-connect
 
-An app that brings all the functionality and utility of the Wormhole token bridge right into your application and removes all of the complexity. It is is built to be embedded within any application, simply copy a script tag or (future) install the npm package. Optionally, configure a number of parameters such as supported chains/tokens and theme.
+An app that brings all the functionality and utility of the Wormhole token bridge right into your application and removes all of the complexity. It is built to be embedded within any application, simply copy a script tag or install the [npm package](https://www.npmjs.com/package/@wormhole-foundation/wormhole-connect). 
 
-### sdk
+Optionally, configure a number of parameters such as supported chains/tokens and theme.
+
+Read more [here](./wormhole-connect/README.md)
+
+### SDK
 
 The beginning of a refactor of the existing sdk. It is written in Typescript and is built with ease-of-use in mind. It is organized into different `context` classes (i.e. evm, solana, terra, etc) which each implement the same methods with standardized parameters.
 
-### builder
+Read more [here](./sdk/README.md)
 
-Initially this serves as a way to test integrating wormhole-connect. In the future, this will become a playground where developers can come to customize their integration by selecting the chain and tokens they would like to support as well as edit theme variables to make it blend seamlessly within their application.
+### Builder
 
-## Setup
+Initially this serves as a way to test integrating wormhole-connect. 
+
+In the future, this will become a playground where developers can come to customize their integration by selecting the chain and tokens they would like to support as well as edit theme variables to make it blend seamlessly within their application.
+
+Read more [here](./builder/README.md)
+
+
+## Integration 
+
+Include the wormhole connect 
+
+```html
+<!-- include in <head> -->
+<script src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.1-beta.2/dist/main.js" defer></script>
+<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.1-beta.2/dist/main.css" />
+
+<!-- include in <body> -->
+<div id="wormhole-connect"></div>
+```
+
+OR
+
+```javascript
+import WormholeBridge from '@wormhole-foundation/wormhole-connect';
+function App() {
+  return (
+    <WormholeBridge />
+  );
+}
+```
+
+
+## Contributing
+
+Contributions are welcome! To work on wormhole-connect locally you'll want to use `npm link` to make the changes to the SDK immediately available.
+
+### Setup
 
 1) Link the sdk
 
@@ -45,27 +85,6 @@ Start builder UI and view in browser at localhost:3000
 npm run start
 ```
 
-Render Connect with the following code 
-
-```html
-<!-- include in <head> -->
-<script src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.1-beta.2/dist/main.js" defer></script>
-<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.1-beta.2/dist/main.css" />
-
-<!-- include in <body> -->
-<div id="wormhole-connect"></div>
-```
-
-OR
-
-```javascript
-import WormholeBridge from '@wormhole-foundation/wormhole-connect';
-function App() {
-  return (
-    <WormholeBridge />
-  );
-}
-```
 
 ## Disclaimer
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
-        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
+        "@wormhole-foundation/wormhole-connect": "^0.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
@@ -9347,9 +9347,9 @@
       }
     },
     "node_modules/@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.7.tgz",
-      "integrity": "sha512-8jqjQB0XTsvmhrGI0Il56uKvEHAqWVQgrcyjCBW0cAhvQV5iECj6cTodhxikiRGMwnqE9bwbKmxeWd6Pnv07jQ==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.4.tgz",
+      "integrity": "sha512-txm+8XDO1veJK/zydgm141QfjY9zCw7eWJ7tMpXWgheaqtPrMMOY6q+x3+iCVnuL4gbdUsf2Je8GheGq8sLohg==",
       "dependencies": {
         "@mui/material": "^5.12.1"
       },
@@ -35159,9 +35159,9 @@
       }
     },
     "@wormhole-foundation/wormhole-connect": {
-      "version": "0.0.1-beta.7",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.1-beta.7.tgz",
-      "integrity": "sha512-8jqjQB0XTsvmhrGI0Il56uKvEHAqWVQgrcyjCBW0cAhvQV5iECj6cTodhxikiRGMwnqE9bwbKmxeWd6Pnv07jQ==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/wormhole-connect/-/wormhole-connect-0.0.4.tgz",
+      "integrity": "sha512-txm+8XDO1veJK/zydgm141QfjY9zCw7eWJ7tMpXWgheaqtPrMMOY6q+x3+iCVnuL4gbdUsf2Je8GheGq8sLohg==",
       "requires": {
         "@mui/material": "^5.12.1"
       }
@@ -35227,7 +35227,7 @@
     "@wormhole-foundation/wormhole-connect-sdk": {
       "version": "file:sdk",
       "requires": {
-        "@certusone/wormhole-sdk": "0.9.17",
+        "@certusone/wormhole-sdk": "^0.9.17",
         "@injectivelabs/sdk-ts": "1.0.211",
         "@mysten/sui.js": "^0.32.2",
         "@nomad-xyz/multi-provider": "^1.1.0",
@@ -47651,7 +47651,7 @@
         "@types/node": "^16.18.25",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.1",
-        "@wormhole-foundation/wormhole-connect": "^0.0.1-beta.6",
+        "@wormhole-foundation/wormhole-connect": "^0.0.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,27 @@
+Wormhole Connect SDK
+--------------------
+
+
+An SDK that wraps the core Wormhole SDK and provides a convenient API to interact with the Wormhole Token Bridge protocol.
+
+
+Here is an example showing how to send a token across chains using this SDK: 
+```ts
+ const context = new WormholeContext('MAINNET');
+ 
+ // interact easily with any chain!
+ // supports EVM, Solana, Terra, etc
+ const tokenId = {
+   chain: 'ethereum',
+   address: '0x123...',
+ }
+
+ const receipt = context.send(
+   tokenId,
+   '10', // amount
+   'ethereum', // sending chain
+   '0x789...', // sender address
+   'moonbeam', // destination chain
+   '0x789...', // recipient address on destination chain
+ )
+```


### PR DESCRIPTION
The setup instructions are not what we want devs to use to get things running (right?)

Also wasn't sure what to fill the SDK readme with but I wanted to link to it from the root README. I added the example from `wormhole.ts` for now but it could use a lot more