### PR TITLE
fix: set claim gas

### DIFF
--- a/wormhole-connect/src/sdk/index.ts
+++ b/wormhole-connect/src/sdk/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@wormhole-foundation/wormhole-connect-sdk';
 
 import { getTokenById, getTokenDecimals, getWrappedTokenId } from '../utils';
-import { isMainnet, TOKENS, WH_CONFIG } from '../config';
+import { GAS_ESTIMATES, isMainnet, TOKENS, WH_CONFIG } from '../config';
 import { postVaa, signAndSendTransaction, TransferWallet } from 'utils/wallet';
 import { estimateClaimFees, estimateSendFees } from './gasEstimates';
 
@@ -251,7 +251,8 @@ export const claimTransfer = async (
     await postVaa(connection, contracts.core, Buffer.from(vaa));
   }
 
-  const tx = await wh.redeem(destChain, vaa, { gasLimit: 250000 }, payerAddr);
+  const gasLimit = GAS_ESTIMATES[destChainName]?.claim || 250000;
+  const tx = await wh.redeem(destChain, vaa, { gasLimit }, payerAddr);
   const txId = await signAndSendTransaction(
     destChainName,
     tx,


### PR DESCRIPTION
#228 

It sounds like this error can occur if the gas is set too high or too low.  It also seems to appear more frequently during claiming.  I noticed that the gas limit was set to 250000 rather that taking in the more accurate figures from the config.