### PR TITLE
Increased BSC claim gas estimate to 300000

### DIFF
--- a/wormhole-connect/src/config/mainnet.ts
+++ b/wormhole-connect/src/config/mainnet.ts
@@ -596,7 +596,7 @@ export const MAINNET_GAS_ESTIMATES: GasEstimates = {
     sendToken: 200000,
     sendNativeWithRelay: 200000,
     sendTokenWithRelay: 300000,
-    claim: 250000,
+    claim: 300000,
   },
   avalanche: {
     sendNative: 100000,


### PR DESCRIPTION
Previously claim transactions would revert during simulation because the gas limit was not high enough. Now it passes when redeeming Base tokens on BSC https://bscscan.com/tx/0x960c56705cbd520b2078534516d1b85712ed11d83991c677e3c3e5e3a626046a. We should consider not passing `gasLimit` when claiming to not run into this issue on other/future chains.