### PR TITLE
Routes more abstractions

### DIFF
--- a/wormhole-connect/src/store/redeem.ts
+++ b/wormhole-connect/src/store/redeem.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { ParsedVaa } from 'utils/vaa';
 import { ParsedMessage, ParsedRelayerMessage } from '../utils/sdk';
 import { Route } from './transferInput';
 
@@ -9,7 +8,7 @@ export enum MessageType {
 }
 
 export interface RedeemState {
-  vaa: ParsedVaa | undefined;
+  readyForRedeem: boolean;
   txData: ParsedMessage | ParsedRelayerMessage | undefined;
   sendTx: string;
   redeemTx: string;
@@ -19,7 +18,7 @@ export interface RedeemState {
 }
 
 const initialState: RedeemState = {
-  vaa: undefined,
+  readyForRedeem: false,
   txData: undefined,
   sendTx: '',
   redeemTx: '',
@@ -32,8 +31,11 @@ export const redeemSlice = createSlice({
   name: 'redeem',
   initialState,
   reducers: {
-    setVaa: (state: RedeemState, { payload }: PayloadAction<ParsedVaa>) => {
-      state.vaa = payload;
+    setReadyForRedeem: (
+      state: RedeemState,
+      { payload }: PayloadAction<boolean>,
+    ) => {
+      state.readyForRedeem = payload;
     },
     setTxDetails: (state: RedeemState, { payload }: PayloadAction<any>) => {
       state.txData = payload;
@@ -69,7 +71,7 @@ export const redeemSlice = createSlice({
 });
 
 export const {
-  setVaa,
+  setReadyForRedeem,
   setTxDetails,
   setSendTx,
   setRedeemTx,

--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -261,6 +261,13 @@ export class BridgeRoute extends RouteAbstract {
     return adaptParsedMessage(message);
   }
 
+  public async isTransferCompleted(
+    destChain: ChainName | ChainId,
+    signedVaa: string,
+  ): Promise<boolean> {
+    return await wh.isTransferCompleted(destChain, signedVaa);
+  }
+
   public async getPreview({
     destToken,
     sourceGasToken,

--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -27,7 +27,6 @@ import { PreviewData } from './types';
 // wh connect uses
 export const adaptParsedMessage = async (
   parsed: SdkParsedMessage | SdkParsedRelayerMessage,
-  route: Route,
 ): Promise<ParsedMessage | ParsedRelayerMessage> => {
   const tokenId = {
     address: parsed.tokenAddress,
@@ -38,7 +37,6 @@ export const adaptParsedMessage = async (
 
   const base: ParsedMessage = {
     ...parsed,
-    route,
     amount: parsed.amount.toString(),
     tokenKey: token?.key || '',
     tokenDecimals: decimals,
@@ -275,7 +273,7 @@ export class BridgeRoute extends RouteAbstract {
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const info = await wh.getVaa(tx, chain);
     const message = await wh.parseMessage(info);
-    return adaptParsedMessage(message, Route.BRIDGE);
+    return adaptParsedMessage(message);
   }
 
   public async isTransferCompleted(

--- a/wormhole-connect/src/utils/routes/hashflow.ts
+++ b/wormhole-connect/src/utils/routes/hashflow.ts
@@ -91,6 +91,14 @@ export class HashflowRoute extends RouteAbstract {
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
     throw new Error('Method not implemented.');
   }
+
+  public async isTransferCompleted(
+    destChain: ChainName | ChainId,
+    signedVaa: string,
+  ): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
   public getPreview<P>(params: P): Promise<PreviewData> {
     throw new Error('Method not implemented.');
   }

--- a/wormhole-connect/src/utils/routes/hashflow.ts
+++ b/wormhole-connect/src/utils/routes/hashflow.ts
@@ -2,7 +2,6 @@ import {
   ChainName,
   ChainId,
   TokenId,
-  VaaInfo,
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { TokenConfig } from '../../config/types';
 import RouteAbstract from './routeAbstract';
@@ -79,22 +78,25 @@ export class HashflowRoute extends RouteAbstract {
   ): Promise<any> {
     throw new Error('Method not implemented.');
   }
-  public redeem(
-    destChain: ChainName | ChainId,
-    vaa: Uint8Array,
-    recipient: string,
-  ): Promise<string> {
+
+  public readyForRedeem(
+    txData: ParsedMessage | ParsedRelayerMessage,
+  ): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
+
+  public redeem(txData: ParsedMessage | ParsedRelayerMessage): Promise<string> {
     throw new Error('Method not implemented.');
   }
   public parseMessage(
-    info: VaaInfo<any>,
+    tx: string,
+    chain: ChainName | ChainId,
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
     throw new Error('Method not implemented.');
   }
 
   public async isTransferCompleted(
-    destChain: ChainName | ChainId,
-    signedVaa: string,
+    txData: ParsedMessage | ParsedRelayerMessage,
   ): Promise<boolean> {
     throw new Error('Method not implemented.');
   }

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -208,7 +208,7 @@ export class RelayRoute extends BridgeRoute {
   public async readyForRedeem(
     txData: ParsedMessage | ParsedRelayerMessage,
   ): Promise<boolean> {
-    throw new Error('not implemented');
+    return true;
   }
 
   async redeem(txData: ParsedMessage | ParsedRelayerMessage): Promise<string> {

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -229,6 +229,13 @@ export class RelayRoute extends BridgeRoute {
     };
   }
 
+  public async isTransferCompleted(
+    destChain: ChainName | ChainId,
+    signedVaa: string,
+  ): Promise<boolean> {
+    return await wh.isTransferCompleted(destChain, signedVaa);
+  }
+
   public async getPreview({
     token,
     destToken,

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -222,7 +222,7 @@ export class RelayRoute extends BridgeRoute {
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const info = await wh.getVaa(tx, chain);
     const message = await wh.parseMessage(info);
-    const parsed: any = await adaptParsedMessage(message, Route.RELAY);
+    const parsed: any = await adaptParsedMessage(message);
     if (parsed.payloadID !== PayloadType.AUTOMATIC) {
       throw new Error('wrong payload, not a token bridge relay transfer');
     }

--- a/wormhole-connect/src/utils/routes/routeAbstract.ts
+++ b/wormhole-connect/src/utils/routes/routeAbstract.ts
@@ -2,7 +2,6 @@ import {
   TokenId,
   ChainName,
   ChainId,
-  VaaInfo,
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { TokenConfig } from 'config/types';
 import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
@@ -91,18 +90,20 @@ export default abstract class RouteAbstract {
   ): Promise<any>;
 
   public abstract parseMessage(
-    info: VaaInfo<any>,
+    tx: string,
+    chain: ChainName | ChainId,
   ): Promise<ParsedMessage | ParsedRelayerMessage>;
 
   public abstract redeem(
-    destChain: ChainName | ChainId,
-    vaa: Uint8Array,
-    recipient: string,
+    txData: ParsedMessage | ParsedRelayerMessage,
   ): Promise<string>;
 
+  public abstract readyForRedeem(
+    txData: ParsedMessage | ParsedRelayerMessage,
+  ): Promise<boolean>;
+
   public abstract isTransferCompleted(
-    destChain: ChainName | ChainId,
-    signedVaa: string,
+    txData: ParsedMessage | ParsedRelayerMessage,
   ): Promise<boolean>;
 
   public abstract getPreview(params: any): Promise<PreviewData>;

--- a/wormhole-connect/src/utils/routes/routeAbstract.ts
+++ b/wormhole-connect/src/utils/routes/routeAbstract.ts
@@ -100,6 +100,11 @@ export default abstract class RouteAbstract {
     recipient: string,
   ): Promise<string>;
 
+  public abstract isTransferCompleted(
+    destChain: ChainName | ChainId,
+    signedVaa: string,
+  ): Promise<boolean>;
+
   public abstract getPreview(params: any): Promise<PreviewData>;
   // send, validate, estimate gas, isRouteAvailable, parse data from VAA/fetch data, claim
 }

--- a/wormhole-connect/src/utils/sdk.ts
+++ b/wormhole-connect/src/utils/sdk.ts
@@ -12,8 +12,6 @@ import {
 import { getWrappedTokenId } from '.';
 import { TOKENS, WH_CONFIG, isMainnet } from '../config';
 
-import { Route } from 'store/transferInput';
-
 export enum PayloadType {
   MANUAL = 1,
   AUTOMATIC = 3,
@@ -41,7 +39,6 @@ export interface ParsedMessage {
   emitterAddress: string;
   sequence: string;
   block: number;
-  route: Route;
   gasFee?: string;
   payload?: string;
 }

--- a/wormhole-connect/src/utils/sdk.ts
+++ b/wormhole-connect/src/utils/sdk.ts
@@ -12,6 +12,8 @@ import {
 import { getWrappedTokenId } from '.';
 import { TOKENS, WH_CONFIG, isMainnet } from '../config';
 
+import { Route } from 'store/transferInput';
+
 export enum PayloadType {
   MANUAL = 1,
   AUTOMATIC = 3,
@@ -39,6 +41,7 @@ export interface ParsedMessage {
   emitterAddress: string;
   sequence: string;
   block: number;
+  route: Route;
   gasFee?: string;
   payload?: string;
 }

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -14,6 +14,7 @@ import {
   setToken,
   setSupportedSourceTokens,
   setSupportedDestTokens,
+  setTransferRoute,
 } from '../../store/transferInput';
 import { wh, isAcceptedToken, toChainId } from '../../utils/sdk';
 import { CHAINS, TOKENS, TOKENS_ARR } from '../../config';
@@ -57,9 +58,12 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-function isSupportedToken(token: string, supportedTokens: TokenConfig[]): boolean {
+function isSupportedToken(
+  token: string,
+  supportedTokens: TokenConfig[],
+): boolean {
   if (!token) return true;
-  return supportedTokens.some(t => t.key === token);
+  return supportedTokens.some((t) => t.key === token);
 }
 
 function Bridge() {

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Context, VaaInfo } from '@wormhole-foundation/wormhole-connect-sdk';
+import { Context } from '@wormhole-foundation/wormhole-connect-sdk';
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 
@@ -29,7 +29,7 @@ import AlertBanner from '../../components/AlertBanner';
 import PoweredByIcon from '../../icons/PoweredBy';
 import { LINK } from '../../utils/style';
 import { estimateClaimGasFees } from '../../utils/gasEstimates';
-import { getVaa } from '../../utils/sdk';
+import { ParsedMessage, ParsedRelayerMessage } from '../../utils/sdk';
 import Operator from '../../utils/routes';
 
 const useStyles = makeStyles()((theme) => ({
@@ -113,10 +113,9 @@ function Send(props: { valid: boolean }) {
         { toNativeToken },
       );
 
-      let vaa: VaaInfo<any> | undefined;
+      let message: ParsedMessage | ParsedRelayerMessage;
       const toRedeem = setInterval(async () => {
-        if (vaa) {
-          const message = await operator.parseMessage(route, vaa);
+        if (message) {
           clearInterval(toRedeem);
           dispatch(setIsTransactionInProgress(false));
           dispatch(setSendTx(txId));
@@ -124,7 +123,7 @@ function Send(props: { valid: boolean }) {
           dispatch(setRoute('redeem'));
           setSendError('');
         } else {
-          vaa = await getVaa(txId, fromNetwork!);
+          message = await operator.parseMessage(route, txId, fromNetwork!);
         }
       }, 1000);
     } catch (e) {

--- a/wormhole-connect/src/views/Redeem/Redeem.tsx
+++ b/wormhole-connect/src/views/Redeem/Redeem.tsx
@@ -13,6 +13,7 @@ import Spacer from '../../components/Spacer';
 import NetworksTag from './Tag';
 import Stepper from './Stepper';
 import GovernorEnqueuedWarning from './GovernorEnqueuedWarning';
+import { Route } from '../../store/transferInput';
 import Operator from '../../utils/routes';
 
 class Redeem extends React.Component<
@@ -23,6 +24,7 @@ class Redeem extends React.Component<
     txData: ParsedMessage | ParsedRelayerMessage;
     transferComplete: boolean;
     isVaaEnqueued: boolean;
+    route: Route;
   },
   {
     readyForRedeem: boolean;
@@ -47,7 +49,7 @@ class Redeem extends React.Component<
   async checkReadyForRedeem() {
     if (!this.props.txData.sendTx || this.state.readyForRedeem) return;
     const isReadyForRedeem = await new Operator().readyForRedeem(
-      this.props.txData.route,
+      this.props.route,
       this.props.txData,
     );
     if (isReadyForRedeem) {
@@ -72,7 +74,7 @@ class Redeem extends React.Component<
   async getTransferComplete() {
     if (!this.state.readyForRedeem || !this.props.txData) return;
     const isComplete = await new Operator().isTransferCompleted(
-      this.props.txData.route,
+      this.props.route,
       this.props.txData,
     );
     if (isComplete) this.props.setTransferComplete();
@@ -128,9 +130,9 @@ class Redeem extends React.Component<
 }
 
 function mapStateToProps(state: RootState) {
-  const { txData, transferComplete, isVaaEnqueued } = state.redeem;
+  const { txData, transferComplete, isVaaEnqueued, route } = state.redeem;
 
-  return { txData, transferComplete, isVaaEnqueued };
+  return { txData, transferComplete, isVaaEnqueued, route };
 }
 
 const mapDispatchToProps = (dispatch) => {

--- a/wormhole-connect/src/views/Redeem/SendFrom.tsx
+++ b/wormhole-connect/src/views/Redeem/SendFrom.tsx
@@ -8,7 +8,6 @@ import {
   MAX_DECIMALS,
   getTokenDecimals,
 } from '../../utils';
-import { ParsedVaa } from '../../utils/vaa';
 import { toChainId } from '../../utils/sdk';
 import { toDecimals } from '../../utils/balance';
 
@@ -81,7 +80,9 @@ const getRows = (txData: any): RowsData => {
 };
 
 function SendFrom() {
-  const vaa: ParsedVaa = useSelector((state: RootState) => state.redeem.vaa);
+  const readyForRedeem: boolean = useSelector(
+    (state: RootState) => state.redeem.readyForRedeem,
+  );
   const txData = useSelector((state: RootState) => state.redeem.txData)!;
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
@@ -105,7 +106,7 @@ function SendFrom() {
         />
         <RenderRows rows={rows} />
       </InputContainer>
-      {!transferComplete && !vaa && (
+      {!transferComplete && !readyForRedeem && (
         <Confirmations chain={txData.fromChain} blockHeight={txData.block} />
       )}
     </div>

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -204,7 +204,6 @@ const getRows = async (
 function SendTo() {
   const dispatch = useDispatch();
   const {
-    vaa,
     redeemTx,
     transferComplete,
     route: routeType,
@@ -233,14 +232,14 @@ function SendTo() {
   // get the redeem tx, for automatic transfers only
   const getRedeemTx = useCallback(async () => {
     if (redeemTx) return redeemTx;
-    if (vaa) {
+    if (txData) {
       const redeemed = await fetchRedeemTx(txData);
       if (redeemed) {
         dispatch(setRedeemTx(redeemed.transactionHash));
         return redeemed.transactionHash;
       }
     }
-  }, [redeemTx, vaa, txData, dispatch]);
+  }, [redeemTx, txData, dispatch]);
 
   useEffect(() => {
     if (!txData) return;
@@ -278,12 +277,7 @@ function SendTo() {
         registerWalletSigner(txData.toChain, TransferWallet.RECEIVING);
         await switchNetwork(networkConfig.chainId, TransferWallet.RECEIVING);
       }
-      const txId = await new Operator().redeem(
-        routeType,
-        txData.toChain,
-        utils.arrayify(vaa.bytes),
-        wallet.address,
-      );
+      const txId = await new Operator().redeem(routeType, txData);
       dispatch(setRedeemTx(txId));
       dispatch(setTransferComplete(true));
       setInProgress(false);

--- a/wormhole-connect/src/views/Redeem/Stepper.tsx
+++ b/wormhole-connect/src/views/Redeem/Stepper.tsx
@@ -3,16 +3,17 @@ import Stepper from '../../components/Stepper/Stepper';
 import SendFrom from './SendFrom';
 import SendTo from './SendTo';
 import BridgeComplete from './BridgeComplete';
-import { ParsedVaa } from '../../utils/vaa';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../store';
 
 export default function MilestoneStepper() {
-  const vaa: ParsedVaa = useSelector((state: RootState) => state.redeem.vaa);
+  const readyForRedeem: boolean = useSelector(
+    (state: RootState) => state.redeem.readyForRedeem,
+  );
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
-  const activeStep = transferComplete ? 4 : vaa ? 2 : 1;
+  const activeStep = transferComplete ? 4 : readyForRedeem ? 2 : 1;
 
   const steps = [
     {

--- a/wormhole-connect/src/views/TxSearch.tsx
+++ b/wormhole-connect/src/views/TxSearch.tsx
@@ -4,7 +4,6 @@ import { useDispatch } from 'react-redux';
 import { Select, MenuItem } from '@mui/material';
 import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import { CHAINS_ARR } from '../config';
-import { getVaa } from '../utils/sdk';
 import Operator from '../utils/routes';
 import { setTxDetails, setRoute as setTransferRoute } from '../store/redeem';
 import { setRoute } from '../store/router';
@@ -63,10 +62,16 @@ function TxSearch() {
       return setError('Invalid transaction ID');
     }
     try {
-      const vaaInfo = await getVaa(state.tx, state.chain as ChainName);
       const operator = new Operator();
-      const route = operator.getRouteForVaa(vaaInfo.vaa);
-      const message = await operator.parseMessage(route, vaaInfo);
+      const route = await operator.getRouteForTx(
+        state.tx,
+        state.chain as ChainName,
+      );
+      const message = await operator.parseMessage(
+        route,
+        state.tx,
+        state.chain as ChainName,
+      );
       setError('');
       dispatch(setTxDetails(message));
       dispatch(setTransferRoute(route));


### PR DESCRIPTION
The goal with this PR is to remove things from the React code that assume the token bridge route or token bridge with relay route.

For example, 'isTransferCompleted' was added to the route interface, and the concept of storing a VAA in the react state was replaced by storing a boolean 'isRedeemReady'

I tested this with the ‘Bridge’ route and the 'Relay' route (as well as testing pasting a transaction while its in progress and seeing it live update to complete)