### PR TITLE
Refactor: move source/dest info shown in the redeem view to the routes

### DIFF
--- a/wormhole-connect/src/components/RenderRows.tsx
+++ b/wormhole-connect/src/components/RenderRows.tsx
@@ -32,7 +32,12 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-export function RenderRows(props: { rows: NestedRow[]; small?: boolean }) {
+interface RenderRowsProps {
+  rows: NestedRow[];
+  small?: boolean;
+}
+
+export function RenderRows(props: RenderRowsProps) {
   const { classes } = useStyles();
   const [collapsed, setCollapsed] = React.useState(true);
   const toggleCollapsed = () => setCollapsed((prev) => !prev);

--- a/wormhole-connect/src/utils/balance.ts
+++ b/wormhole-connect/src/utils/balance.ts
@@ -1,11 +1,11 @@
-import { BigNumber, utils } from 'ethers';
+import { BigNumberish, utils } from 'ethers';
 import { TOKENS } from '../config';
 
 /**
  * Makes a BigNumber have # of decimals
  */
 export function toDecimals(
-  amnt: BigNumber,
+  amnt: BigNumberish,
   tokenDecimals: number,
   numDecimals?: number,
 ): string {

--- a/wormhole-connect/src/utils/gas.ts
+++ b/wormhole-connect/src/utils/gas.ts
@@ -1,0 +1,68 @@
+import { getTotalGasUsed } from '@mysten/sui.js';
+import {
+  AptosContext,
+  ChainName,
+  SuiContext,
+  WormholeContext,
+} from '@wormhole-foundation/wormhole-connect-sdk';
+import { Types } from 'aptos';
+import { BigNumber } from 'ethers';
+import { CHAINS, GAS_ESTIMATES, TOKENS } from '../config';
+import { MAX_DECIMALS, getTokenDecimals } from './index';
+import { toDecimals } from './balance';
+import { estimateClaimGasFees } from './gasEstimates';
+import { toChainId, wh } from './sdk';
+
+/**
+ * Retrieve the gas used for the execution of a redeem transaction
+ * Falls back to gas estimations if the transaction id is not provided
+ *
+ * @param chain The transaction's chain
+ * @param receiveTx The transaction's id
+ * @returns
+ */
+export const calculateGas = async (chain: ChainName, receiveTx?: string) => {
+  const { gasToken } = CHAINS[chain]!;
+  const token = TOKENS[gasToken];
+  const decimals = getTokenDecimals(toChainId(chain), token.tokenId);
+
+  if (chain === 'solana') {
+    return toDecimals(
+      BigNumber.from(GAS_ESTIMATES.solana!.claim),
+      decimals,
+      MAX_DECIMALS,
+    );
+  }
+  if (receiveTx) {
+    if (chain === 'aptos') {
+      const aptosClient = (
+        wh.getContext('aptos') as AptosContext<WormholeContext>
+      ).aptosClient;
+      const txn = await aptosClient.getTransactionByHash(receiveTx);
+      if (txn.type === 'user_transaction') {
+        const userTxn = txn as Types.UserTransaction;
+        const gasFee = BigNumber.from(userTxn.gas_used).mul(
+          userTxn.gas_unit_price,
+        );
+        return toDecimals(gasFee || 0, decimals, MAX_DECIMALS);
+      }
+    } else if (chain === 'sui') {
+      const provider = (wh.getContext('sui') as SuiContext<WormholeContext>)
+        .provider;
+      const txBlock = await provider.getTransactionBlock({
+        digest: receiveTx,
+        options: { showEvents: true, showEffects: true, showInput: true },
+      });
+      const gasFee = BigNumber.from(getTotalGasUsed(txBlock) || 0);
+      return toDecimals(gasFee, decimals, MAX_DECIMALS);
+    } else {
+      const provider = wh.mustGetProvider(chain);
+      const receipt = await provider.getTransactionReceipt(receiveTx);
+      const { gasUsed, effectiveGasPrice } = receipt;
+      if (!gasUsed || !effectiveGasPrice) return;
+      const gasFee = gasUsed.mul(effectiveGasPrice);
+      return toDecimals(gasFee, decimals, MAX_DECIMALS);
+    }
+  }
+  return await estimateClaimGasFees(chain);
+};

--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { BigNumber, utils } from 'ethers';
+import { BigNumber, BigNumberish, utils } from 'ethers';
 import {
   TokenId,
   ChainName,
@@ -189,7 +189,7 @@ export function fromNormalizedDecimals(
 }
 
 export function toNormalizedDecimals(
-  amount: BigNumber,
+  amount: BigNumberish,
   decimals: number,
   numDecimals?: number,
 ): string {

--- a/wormhole-connect/src/utils/routes/hashflow.ts
+++ b/wormhole-connect/src/utils/routes/hashflow.ts
@@ -5,9 +5,9 @@ import {
   VaaInfo,
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { TokenConfig } from '../../config/types';
-import RouteAbstract from './routeAbstract';
+import RouteAbstract, { TransferInfoBaseParams } from './routeAbstract';
 import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
-import { PreviewData } from './types';
+import { TransferDisplayData } from './types';
 import { BigNumber } from 'ethers';
 
 export class HashflowRoute extends RouteAbstract {
@@ -92,7 +92,7 @@ export class HashflowRoute extends RouteAbstract {
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
     throw new Error('Method not implemented.');
   }
-  public getPreview<P>(params: P): Promise<PreviewData> {
+  public getPreview<P>(params: P): Promise<TransferDisplayData> {
     throw new Error('Method not implemented.');
   }
   public getNativeBalance(
@@ -128,6 +128,16 @@ export class HashflowRoute extends RouteAbstract {
     throw new Error('Method not implemented.');
   }
   getVaa(tx: string, chain: ChainName | ChainId): Promise<VaaInfo<any>> {
+    throw new Error('Method not implemented.');
+  }
+  getTransferSourceInfo<T extends TransferInfoBaseParams>(
+    params: T,
+  ): Promise<TransferDisplayData> {
+    throw new Error('Method not implemented.');
+  }
+  getTransferDestInfo<T extends TransferInfoBaseParams>(
+    params: T,
+  ): Promise<TransferDisplayData> {
     throw new Error('Method not implemented.');
   }
 }

--- a/wormhole-connect/src/utils/routes/operator.ts
+++ b/wormhole-connect/src/utils/routes/operator.ts
@@ -10,13 +10,13 @@ import { RelayRoute } from './relay';
 import { HashflowRoute } from './hashflow';
 import { TokenConfig } from 'config/types';
 import { ParsedMessage, ParsedRelayerMessage, PayloadType } from '../sdk';
-import RouteAbstract from './routeAbstract';
+import RouteAbstract, { TransferInfoBaseParams } from './routeAbstract';
 import {
   CHAIN_ID_SEI,
   ParsedVaa,
   parseTokenTransferPayload,
 } from '@certusone/wormhole-sdk';
-import { PreviewData } from './types';
+import { TransferDisplayData } from './types';
 import { BigNumber } from 'ethers';
 
 export default class Operator {
@@ -215,7 +215,7 @@ export default class Operator {
     return await r.parseMessage(info);
   }
 
-  async getPreview(route: Route, params: any): Promise<PreviewData> {
+  async getPreview(route: Route, params: any): Promise<TransferDisplayData> {
     const r = this.getRoute(route);
     return await r.getPreview(params);
   }
@@ -274,5 +274,21 @@ export default class Operator {
   ): Promise<VaaInfo<any>> {
     const r = this.getRoute(route);
     return r.getVaa(tx, network);
+  }
+
+  public getTransferSourceInfo<T extends TransferInfoBaseParams>(
+    route: Route,
+    params: T,
+  ): Promise<TransferDisplayData> {
+    const r = this.getRoute(route);
+    return r.getTransferSourceInfo(params);
+  }
+
+  public getTransferDestInfo<T extends TransferInfoBaseParams>(
+    route: Route,
+    params: T,
+  ): Promise<TransferDisplayData> {
+    const r = this.getRoute(route);
+    return r.getTransferDestInfo(params);
   }
 }

--- a/wormhole-connect/src/utils/routes/routeAbstract.ts
+++ b/wormhole-connect/src/utils/routes/routeAbstract.ts
@@ -6,8 +6,12 @@ import {
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { TokenConfig } from 'config/types';
 import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
-import { PreviewData } from './types';
+import { TransferDisplayData } from './types';
 import { BigNumber } from 'ethers';
+
+export interface TransferInfoBaseParams {
+  txData: ParsedMessage | ParsedRelayerMessage;
+}
 
 export default abstract class RouteAbstract {
   // protected abstract sendGasFallback: { [key: ChainName]: TokenConfig };
@@ -101,7 +105,14 @@ export default abstract class RouteAbstract {
     recipient: string,
   ): Promise<string>;
 
-  public abstract getPreview(params: any): Promise<PreviewData>;
+  public abstract getPreview(params: any): Promise<TransferDisplayData>;
+  public abstract getTransferSourceInfo<T extends TransferInfoBaseParams>(
+    params: T,
+  ): Promise<TransferDisplayData>;
+  public abstract getTransferDestInfo<T extends TransferInfoBaseParams>(
+    params: T,
+  ): Promise<TransferDisplayData>;
+
   // send, validate, estimate gas, isRouteAvailable, parse data from VAA/fetch data, claim
 
   abstract getNativeBalance(

--- a/wormhole-connect/src/utils/routes/types.ts
+++ b/wormhole-connect/src/utils/routes/types.ts
@@ -13,4 +13,4 @@ export interface NestedRow extends Row {
   rows?: Row[];
 }
 
-export type PreviewData = NestedRow[];
+export type TransferDisplayData = NestedRow[];

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -57,9 +57,12 @@ const useStyles = makeStyles()((theme) => ({
   },
 }));
 
-function isSupportedToken(token: string, supportedTokens: TokenConfig[]): boolean {
+function isSupportedToken(
+  token: string,
+  supportedTokens: TokenConfig[],
+): boolean {
   if (!token) return true;
-  return supportedTokens.some(t => t.key === token);
+  return supportedTokens.some((t) => t.key === token);
 }
 
 function Bridge() {

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -7,7 +7,11 @@ import { makeStyles } from 'tss-react/mui';
 import { CHAINS, TOKENS } from '../../config';
 import { RootState } from '../../store';
 import { setRoute } from '../../store/router';
-import { setTxDetails, setSendTx } from '../../store/redeem';
+import {
+  setTxDetails,
+  setSendTx,
+  setRoute as setRedeemTransferRoute,
+} from '../../store/redeem';
 import { displayWalletAddress } from '../../utils';
 import {
   registerWalletSigner,
@@ -29,7 +33,6 @@ import AlertBanner from '../../components/AlertBanner';
 import PoweredByIcon from '../../icons/PoweredBy';
 import { LINK } from '../../utils/style';
 import { estimateClaimGasFees } from '../../utils/gasEstimates';
-import { getVaa } from '../../utils/sdk';
 import Operator from '../../utils/routes';
 
 const useStyles = makeStyles()((theme) => ({
@@ -122,6 +125,7 @@ function Send(props: { valid: boolean }) {
           dispatch(setSendTx(txId));
           dispatch(setTxDetails(message));
           dispatch(setRoute('redeem'));
+          dispatch(setRedeemTransferRoute(route));
           setSendError('');
         } else {
           vaa = await operator.getVaa(route, txId, fromNetwork!);

--- a/wormhole-connect/src/views/Redeem/SendFrom.tsx
+++ b/wormhole-connect/src/views/Redeem/SendFrom.tsx
@@ -1,99 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { RootState } from '../../store';
-import { Route } from '../../store/transferInput';
-import { CHAINS, TOKENS } from '../../config';
-import {
-  toNormalizedDecimals,
-  MAX_DECIMALS,
-  getTokenDecimals,
-} from '../../utils';
-import { ParsedVaa } from '../../utils/vaa';
-import { toChainId } from '../../utils/sdk';
-import { toDecimals } from '../../utils/balance';
-
 import InputContainer from '../../components/InputContainer';
-import Header from './Header';
-import { RenderRows, RowsData } from '../../components/RenderRows';
+import { RenderRows } from '../../components/RenderRows';
+import { RootState } from '../../store';
+import Operator, { TransferDisplayData } from '../../utils/routes';
 import Confirmations from './Confirmations';
-
-const getRows = (txData: any): RowsData => {
-  const formattedAmt = toNormalizedDecimals(
-    txData.amount,
-    txData.tokenDecimals,
-    MAX_DECIMALS,
-  );
-  const { gasToken: sourceGasTokenSymbol } = CHAINS[txData.fromChain]!;
-  const sourceGasToken = TOKENS[sourceGasTokenSymbol];
-  const decimals = getTokenDecimals(
-    toChainId(sourceGasToken.nativeNetwork),
-    sourceGasToken.tokenId,
-  );
-  const formattedGas =
-    txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
-  const type = txData.payloadID;
-  const token = TOKENS[txData.tokenKey];
-
-  // manual transfers
-  if (type === Route.BRIDGE) {
-    return [
-      {
-        title: 'Amount',
-        value: `${formattedAmt} ${token.symbol}`,
-      },
-      {
-        title: 'Gas fee',
-        value: formattedGas ? `${formattedGas} ${sourceGasTokenSymbol}` : '—',
-      },
-    ];
-  }
-
-  // automatic transfers
-  const formattedFee = toNormalizedDecimals(
-    txData.relayerFee,
-    txData.tokenDecimals,
-    MAX_DECIMALS,
-  );
-  const formattedToNative = toNormalizedDecimals(
-    txData.toNativeTokenAmount,
-    txData.tokenDecimals,
-    MAX_DECIMALS,
-  );
-  const { gasToken } = CHAINS[txData.toChain]!;
-  return [
-    {
-      title: 'Amount',
-      value: `${formattedAmt} ${token.symbol}`,
-    },
-    {
-      title: 'Gas fee',
-      value: formattedGas ? `${formattedGas} ${sourceGasTokenSymbol}` : '—',
-    },
-    {
-      title: 'Relayer fee',
-      value: `${formattedFee} ${token.symbol}`,
-    },
-    {
-      title: 'Convert to native gas token',
-      value: `≈ ${formattedToNative} ${token.symbol} \u2192 ${gasToken}`,
-    },
-  ];
-};
+import Header from './Header';
 
 function SendFrom() {
-  const vaa: ParsedVaa = useSelector((state: RootState) => state.redeem.vaa);
+  const { vaa, route } = useSelector((state: RootState) => state.redeem);
   const txData = useSelector((state: RootState) => state.redeem.txData)!;
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
 
-  const [rows, setRows] = useState([] as RowsData);
+  const [rows, setRows] = useState([] as TransferDisplayData);
 
   useEffect(() => {
     if (!txData) return;
-    const rows = getRows(txData);
-    setRows(rows);
-  }, [txData]);
+    new Operator()
+      .getTransferSourceInfo(route, { txData })
+      .then((rows) => setRows(rows));
+  }, [txData, route]);
 
   return (
     <div>


### PR DESCRIPTION
Build the transfer source and destination info displayed at the redeem view on the routes instead of the SendFrom/SendTo components