### PR TITLE
Removed Claim gas estimate that sometimes causes TX to revert

### DIFF
--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -166,12 +166,7 @@ export class BridgeRoute extends BaseRoute {
       );
     }
 
-    const tx = await wh.redeem(
-      destChain,
-      messageInfo.rawVaa,
-      { gasLimit: 250000 },
-      payer,
-    );
+    const tx = await wh.redeem(destChain, messageInfo.rawVaa, undefined, payer);
     const txId = await signAndSendTransaction(
       destChainName,
       tx,


### PR DESCRIPTION
Claiming is the only call that we pass hard-coded gas estimates for and it will cause the TX to revert if it's too low. Rather than bumping it, we should let the wallet simulate the gas cost by passing `undefined` to overrides. 

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/807