### PR TITLE
Fix bridge route isTransferCompleted signedVaa serialization

### DIFF
--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -19,6 +19,7 @@ import { adaptParsedMessage } from './common';
 import { toDecimals } from '../balance';
 import { calculateGas } from '../gas';
 import { TransferInfoBaseParams } from './routeAbstract';
+import { hexlify } from 'ethers/lib/utils.js';
 
 export interface BridgePreviewParams {
   destToken: TokenConfig;
@@ -317,9 +318,6 @@ export class BridgeRoute extends BaseRoute {
     destChain: ChainName | ChainId,
     messageInfo: VaaInfo,
   ): Promise<boolean> {
-    return wh.isTransferCompleted(
-      destChain,
-      Buffer.from(messageInfo.rawVaa).toString(),
-    );
+    return wh.isTransferCompleted(destChain, hexlify(messageInfo.rawVaa));
   }
 }


### PR DESCRIPTION
The VAA was being serialized to utf8 instead of hex. This would cause downstream components that call arrayify on the value to throw. We now hexlify the VAA bytes instead.