### PR TITLE
Add foreign asset address cache

### DIFF
--- a/sdk/src/contexts/aptos/context.ts
+++ b/sdk/src/contexts/aptos/context.ts
@@ -37,7 +37,7 @@ import {
 import { sha3_256 } from 'js-sha3';
 import { MAINNET_CHAINS } from '../../config/MAINNET';
 import { SolanaContext } from '../solana';
-import { stripHexPrefix } from '../../utils';
+import { ForeignAssetCache, stripHexPrefix } from '../../utils';
 
 export const APTOS_COIN = '0x1::aptos_coin::AptosCoin';
 
@@ -49,8 +49,9 @@ export class AptosContext<
   readonly context: T;
   readonly aptosClient: AptosClient;
   readonly coinClient: CoinClient;
+  private foreignAssetCache: ForeignAssetCache;
 
-  constructor(context: T) {
+  constructor(context: T, foreignAssetCache: ForeignAssetCache) {
     super();
     this.context = context;
     const rpc = context.conf.rpcs.aptos;
@@ -58,6 +59,7 @@ export class AptosContext<
     this.aptosClient = new AptosClient(rpc);
     this.coinClient = new CoinClient(this.aptosClient);
     this.contracts = new AptosContracts(context, this.aptosClient);
+    this.foreignAssetCache = foreignAssetCache;
   }
 
   async send(
@@ -184,6 +186,15 @@ export class AptosContext<
     tokenId: TokenId,
     chain: ChainName | ChainId,
   ): Promise<string | null> {
+    const chainName = this.context.toChainName(chain);
+    if (this.foreignAssetCache.get(tokenId.chain, tokenId.address, chainName)) {
+      return this.foreignAssetCache.get(
+        tokenId.chain,
+        tokenId.address,
+        chainName,
+      )!;
+    }
+
     const chainId = this.context.toChainId(tokenId.chain);
     const toChainId = this.context.toChainId(chain);
     if (toChainId === chainId) return tokenId.address;
@@ -195,12 +206,21 @@ export class AptosContext<
     const formattedAddr = await tokenContext.formatAssetAddress(
       tokenId.address,
     );
-    return await getForeignAssetAptos(
+    const asset = await getForeignAssetAptos(
       this.aptosClient,
       token_bridge,
       chainId,
       hexlify(formattedAddr),
     );
+
+    if (!asset) return null;
+    this.foreignAssetCache.set(
+      tokenId.chain,
+      tokenId.address,
+      chainName,
+      asset,
+    );
+    return asset;
   }
 
   async mustGetForeignAsset(

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -1,4 +1,4 @@
-import { Context, WormholeConfig } from './types';
+import { ChainName, Context, WormholeConfig } from './types';
 
 export function filterByContext(config: WormholeConfig, context: Context) {
   return Object.values(config.chains).filter((c) => c.context === context);
@@ -6,4 +6,35 @@ export function filterByContext(config: WormholeConfig, context: Context) {
 
 export function stripHexPrefix(val: string) {
   return val.startsWith('0x') ? val.slice(2) : val;
+}
+
+// (asset chain, asset address, foreign chain) => address
+type ForeignAssetCacheMap = Partial<
+  Record<ChainName, Partial<Record<string, Partial<Record<ChainName, string>>>>>
+>;
+export class ForeignAssetCache {
+  private cache: ForeignAssetCacheMap;
+
+  constructor() {
+    this.cache = {};
+  }
+
+  get(assetChain: ChainName, assetAddress: string, foreignChain: ChainName) {
+    return this.cache[assetChain]?.[assetAddress]?.[foreignChain];
+  }
+
+  set(
+    assetChain: ChainName,
+    assetAddress: string,
+    foreignChain: ChainName,
+    address: string,
+  ) {
+    if (!this.cache[assetChain]) {
+      this.cache[assetChain] = {};
+    }
+    if (!this.cache[assetChain]![assetAddress]) {
+      this.cache[assetChain]![assetAddress] = {};
+    }
+    this.cache[assetChain]![assetAddress]![foreignChain] = address;
+  }
 }

--- a/sdk/src/wormhole.ts
+++ b/sdk/src/wormhole.ts
@@ -25,6 +25,7 @@ import {
 import { SeiContext } from './contexts/sei';
 import DEVNET_CONFIG, { DEVNET_CHAINS } from './config/DEVNET';
 import { CosmosContext } from './contexts/cosmos';
+import { ForeignAssetCache } from './utils';
 
 /**
  * The WormholeContext manages connections to Wormhole Core, Bridge and NFT Bridge contracts.
@@ -55,6 +56,7 @@ import { CosmosContext } from './contexts/cosmos';
  * )
  */
 export class WormholeContext extends MultiProvider<Domain> {
+  private foreignAssetCache: ForeignAssetCache = new ForeignAssetCache();
   readonly conf: WormholeConfig;
 
   constructor(env: Environment, conf?: WormholeConfig) {
@@ -151,22 +153,22 @@ export class WormholeContext extends MultiProvider<Domain> {
     const { context } = this.conf.chains[chainName]!;
     switch (context) {
       case Context.ETH: {
-        return new EthContext(this);
+        return new EthContext(this, this.foreignAssetCache);
       }
       case Context.SOLANA: {
-        return new SolanaContext(this);
+        return new SolanaContext(this, this.foreignAssetCache);
       }
       case Context.SUI: {
-        return new SuiContext(this);
+        return new SuiContext(this, this.foreignAssetCache);
       }
       case Context.APTOS: {
-        return new AptosContext(this);
+        return new AptosContext(this, this.foreignAssetCache);
       }
       case Context.SEI: {
-        return new SeiContext(this);
+        return new SeiContext(this, this.foreignAssetCache);
       }
       case Context.COSMOS: {
-        return new CosmosContext(this, chainName);
+        return new CosmosContext(this, chainName, this.foreignAssetCache);
       }
       default: {
         throw new Error('Not able to retrieve context');

--- a/wormhole-connect/src/views/Redeem/AddToWallet.tsx
+++ b/wormhole-connect/src/views/Redeem/AddToWallet.tsx
@@ -28,6 +28,7 @@ import { TransferWallet, switchNetwork, watchAsset } from '../../utils/wallet';
 
 import TokenIcon from '../../icons/TokenIcons';
 import ExplorerLink from './ExplorerLink';
+import { isCosmWasmChain } from '../../utils/cosmos';
 
 const useStyles = makeStyles()((theme) => ({
   addToken: {


### PR DESCRIPTION
Create a cache object which `WormholeContext` passes down to the specific contexts. The aim of this cache is to prevent repeating `getForeignAsset` queries when the information will be the same.