### PR TITLE
[#903] Don't wait to reaching finality before moving on to the Redeem page

### DIFF
--- a/sdk/src/contexts/aptos/context.ts
+++ b/sdk/src/contexts/aptos/context.ts
@@ -8,36 +8,26 @@ import {
   ParsedMessage,
   Context,
   ParsedRelayerPayload,
-  VaaInfo,
 } from '../../types';
 import { WormholeContext } from '../../wormhole';
 import { TokenBridgeAbstract } from '../abstracts/tokenBridge';
 import { AptosContracts } from './contracts';
 import { AptosClient, CoinClient, Types } from 'aptos';
 import {
-  CHAIN_ID_APTOS,
   getForeignAssetAptos,
   getIsTransferCompletedAptos,
-  getSignedVAAWithRetry,
   getTypeFromExternalAddress,
   hexToUint8Array,
   isValidAptosType,
   parseTokenTransferPayload,
-  parseVaa,
   redeemOnAptos,
   transferFromAptos,
 } from '@certusone/wormhole-sdk';
-import {
-  arrayify,
-  hexZeroPad,
-  hexlify,
-  stripZeros,
-  zeroPad,
-} from 'ethers/lib/utils';
+import { arrayify, hexlify, stripZeros, zeroPad } from 'ethers/lib/utils';
 import { sha3_256 } from 'js-sha3';
 import { MAINNET_CHAINS } from '../../config/MAINNET';
 import { SolanaContext } from '../solana';
-import { ForeignAssetCache, stripHexPrefix } from '../../utils';
+import { ForeignAssetCache } from '../../utils';
 
 export const APTOS_COIN = '0x1::aptos_coin::AptosCoin';
 
@@ -248,10 +238,10 @@ export class AptosContext<
     return decimals;
   }
 
-  async getVaa(
+  async getMessage(
     tx: string,
     chain: ChainName | ChainId,
-  ): Promise<VaaInfo<Types.UserTransaction>> {
+  ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const transaction = await this.aptosClient.getTransactionByHash(tx);
     if (transaction.type !== 'user_transaction') {
       throw new Error(`${tx} is not a user_transaction`);
@@ -264,46 +254,11 @@ export class AptosContext<
       throw new Error(`WormholeMessage not found for ${tx}`);
     }
 
-    const { sender, sequence } = message.data;
+    const { payload, sender, sequence } = message.data;
 
-    const emitter = stripHexPrefix(
-      hexZeroPad(
-        hexlify(sender, {
-          allowMissingPrefix: true,
-          hexPad: 'left',
-        }),
-        32,
-      ),
+    const parsed = parseTokenTransferPayload(
+      Buffer.from(payload.slice(2), 'hex'),
     );
-
-    const { vaaBytes } = await getSignedVAAWithRetry(
-      this.context.conf.wormholeHosts,
-      CHAIN_ID_APTOS,
-      emitter,
-      sequence,
-      undefined,
-      undefined,
-      this.context.conf.wormholeHosts.length,
-    );
-
-    const parsedVaa = parseVaa(vaaBytes);
-    return {
-      transaction: userTransaction,
-      rawVaa: vaaBytes,
-      vaa: {
-        ...parsedVaa,
-        sequence: parsedVaa.sequence.toString(),
-      },
-    };
-  }
-
-  async parseMessage(
-    info: VaaInfo<Types.UserTransaction>,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const { transaction, vaa } = info;
-
-    const { emitterChain: chain, payload, emitterAddress, sequence } = vaa;
-    const parsed = parseTokenTransferPayload(payload);
     const tokenContext = this.context.getContext(parsed.tokenChain as ChainId);
     const destContext = this.context.getContext(parsed.toChain as ChainId);
     const tokenAddress = await tokenContext.parseAssetAddress(
@@ -312,13 +267,13 @@ export class AptosContext<
     const tokenChain = this.context.toChainName(parsed.tokenChain);
 
     // make sender address even-length
-    const emitter = hexlify(emitterAddress, {
+    const emitter = hexlify(sender, {
       allowMissingPrefix: true,
       hexPad: 'left',
     });
     const parsedMessage: ParsedMessage = {
-      sendTx: transaction.hash,
-      sender: transaction.sender,
+      sendTx: userTransaction.hash,
+      sender: userTransaction.sender,
       amount: BigNumber.from(parsed.amount),
       payloadID: Number(parsed.payloadType),
       recipient: destContext.parseAddress(hexlify(parsed.to)),
@@ -332,9 +287,9 @@ export class AptosContext<
       },
       sequence: BigNumber.from(sequence),
       emitterAddress: hexlify(this.formatAddress(emitter)),
-      block: Number(transaction.version),
-      gasFee: BigNumber.from(transaction.gas_used).mul(
-        transaction.gas_unit_price,
+      block: Number(userTransaction.version),
+      gasFee: BigNumber.from(userTransaction.gas_used).mul(
+        userTransaction.gas_unit_price,
       ),
     };
     return parsedMessage;

--- a/sdk/src/contexts/aptos/context.ts
+++ b/sdk/src/contexts/aptos/context.ts
@@ -291,6 +291,9 @@ export class AptosContext<
       gasFee: BigNumber.from(userTransaction.gas_used).mul(
         userTransaction.gas_unit_price,
       ),
+      payload: parsed.tokenTransferPayload.length
+        ? hexlify(parsed.tokenTransferPayload)
+        : undefined,
     };
     return parsedMessage;
   }

--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -387,6 +387,9 @@ export class CosmosContext<
       emitterAddress,
       block: tx.height,
       gasFee: BigNumber.from(tx.gasUsed),
+      payload: parsed.tokenTransferPayload.length
+        ? hexlify(parsed.tokenTransferPayload)
+        : undefined,
     };
   }
 

--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -1,6 +1,5 @@
 import {
   cosmos,
-  getSignedVAAWithRetry,
   parseTokenTransferPayload,
   parseVaa,
 } from '@certusone/wormhole-sdk';
@@ -30,7 +29,6 @@ import {
   ParsedRelayerMessage,
   ParsedRelayerPayload,
   TokenId,
-  VaaInfo,
 } from '../../types';
 import { WormholeContext } from '../../wormhole';
 import { TokenBridgeAbstract } from '../abstracts/tokenBridge';
@@ -331,53 +329,32 @@ export class CosmosContext<
     return decimals;
   }
 
-  async getVaa(
-    txId: string,
+  async getMessage(
+    id: string,
     chain: ChainName | ChainId,
-  ): Promise<VaaInfo<any>> {
+  ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const client = await this.getCosmWasmClient(chain);
-    const tx = await client.getTx(txId);
+    const tx = await client.getTx(id);
     if (!tx) throw new Error('tx not found');
 
     // parse logs emitted for the tx execution
     const logs = cosmosLogs.parseRawLog(tx.rawLog);
 
-    const emitterAddress = searchCosmosLogs('message.sender', logs);
+    // extract information wormhole contract logs
+    // - message.message: the vaa payload (i.e. the transfer information)
+    // - message.sequence: the vaa's sequence number
+    // - message.sender: the vaa's emitter address
+    const tokenTransferPayload = searchCosmosLogs('message.message', logs);
+    if (!tokenTransferPayload)
+      throw new Error('message/transfer payload not found');
     const sequence = searchCosmosLogs('message.sequence', logs);
+    if (!sequence) throw new Error('sequence not found');
+    const emitterAddress = searchCosmosLogs('message.sender', logs);
+    if (!emitterAddress) throw new Error('emitter not found');
 
-    if (!sequence) throw new Error('VAA sequence not found');
-    if (!emitterAddress) throw new Error('VAA emitter not found');
-
-    const chainId = this.context.toChainId(chain);
-    const { vaaBytes } = await getSignedVAAWithRetry(
-      this.context.conf.wormholeHosts,
-      chainId,
-      emitterAddress,
-      sequence,
-      undefined,
-      undefined,
-      this.context.conf.wormholeHosts.length,
+    const parsed = parseTokenTransferPayload(
+      Buffer.from(tokenTransferPayload, 'hex'),
     );
-
-    const parsedVaa = parseVaa(vaaBytes);
-    return {
-      transaction: tx,
-      rawVaa: vaaBytes,
-      vaa: {
-        ...parsedVaa,
-        sequence: parsedVaa.sequence.toString(),
-      },
-    };
-  }
-
-  async parseMessage(
-    info: VaaInfo<any>,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const { transaction: tx, vaa: message } = info;
-
-    if (!tx) throw new Error('tx not found');
-
-    const parsed = parseTokenTransferPayload(message.payload);
 
     const decoded = decodeTxRaw(tx.tx);
     const { sender } = MsgExecuteContract.decode(
@@ -399,15 +376,15 @@ export class CosmosContext<
       payloadID: parsed.payloadType,
       recipient: destContext.parseAddress(hexlify(parsed.to)),
       toChain: this.context.toChainName(parsed.toChain),
-      fromChain: this.context.toChainName(message.emitterChain),
+      fromChain: this.context.toChainName(chain),
       tokenAddress,
       tokenChain,
       tokenId: {
         address: tokenAddress,
         chain: tokenChain,
       },
-      sequence: BigNumber.from(message.sequence),
-      emitterAddress: message.emitterAddress.toString('hex'),
+      sequence: BigNumber.from(sequence),
+      emitterAddress,
       block: tx.height,
       gasFee: BigNumber.from(tx.gasUsed),
     };

--- a/sdk/src/contexts/eth/context.ts
+++ b/sdk/src/contexts/eth/context.ts
@@ -584,6 +584,7 @@ export class EthContext<
       relayerFee: relayerPayload.relayerFee,
       toNativeTokenAmount: relayerPayload.toNativeTokenAmount,
       to: destContext.parseAddress(utils.hexlify(transferWithPayload.to)),
+      payload: transferWithPayload.payload,
     };
     return relayerMessage;
   }

--- a/sdk/src/contexts/eth/context.ts
+++ b/sdk/src/contexts/eth/context.ts
@@ -2,12 +2,7 @@ import {
   Implementation__factory,
   TokenImplementation__factory,
 } from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
-import {
-  TokenBridgePayload,
-  createNonce,
-  getSignedVAAWithRetry,
-  parseTokenTransferPayload,
-} from '@certusone/wormhole-sdk';
+import { createNonce } from '@certusone/wormhole-sdk';
 import {
   BigNumber,
   BigNumberish,
@@ -29,14 +24,13 @@ import {
   ParsedMessage,
   Context,
   ParsedRelayerPayload,
-  VaaInfo,
 } from '../../types';
 import { WormholeContext } from '../../wormhole';
 import { EthContracts } from './contracts';
 import { parseVaa } from '../../vaa';
 import { RelayerAbstract } from '../abstracts/relayer';
 import { SolanaContext } from '../solana';
-import { arrayify, hexZeroPad } from 'ethers/lib/utils';
+import { arrayify } from 'ethers/lib/utils';
 import { ForeignAssetCache } from '../../utils';
 
 export const NO_VAA_FOUND = 'No message publish found in logs';
@@ -479,48 +473,6 @@ export class EthContext<
     return await relayer.calculateNativeSwapAmountOut(token, amount);
   }
 
-  async getVaa(
-    tx: string,
-    chain: ChainName | ChainId,
-  ): Promise<VaaInfo<ContractReceipt>> {
-    const provider = this.context.mustGetProvider(chain);
-    const receipt = await provider.getTransactionReceipt(tx);
-    if (!receipt) throw new Error(`No receipt for ${tx} on ${chain}`);
-
-    const core = this.contracts.mustGetCore(chain);
-    const bridgeLogs = receipt.logs.filter((l: any) => {
-      return l.address === core.address;
-    });
-
-    if (bridgeLogs.length === 0) {
-      throw new Error(NO_VAA_FOUND);
-    }
-
-    const parsed = Implementation__factory.createInterface().parseLog(
-      bridgeLogs[0],
-    );
-
-    const { vaaBytes } = await getSignedVAAWithRetry(
-      this.context.conf.wormholeHosts,
-      this.context.toChainId(chain),
-      hexZeroPad(parsed.args.sender, 32).substring(2),
-      parsed.args.sequence.toString(),
-      undefined,
-      undefined,
-      this.context.conf.wormholeHosts.length,
-    );
-
-    const parsedVaa = parseVaa(vaaBytes);
-    return {
-      transaction: receipt,
-      rawVaa: vaaBytes,
-      vaa: {
-        ...parsedVaa,
-        sequence: parsedVaa.sequence.toString(),
-      },
-    };
-  }
-
   async getReceipt(
     tx: string,
     chain: ChainName | ChainId,
@@ -531,36 +483,91 @@ export class EthContext<
     return receipt;
   }
 
-  async parseMessage(
-    info: VaaInfo<ContractReceipt>,
+  async getMessage(
+    tx: string,
+    chain: ChainName | ChainId,
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const { transaction: receipt, vaa: vaa } = info;
+    const provider = this.context.mustGetProvider(chain);
+    const receipt = await provider.getTransactionReceipt(tx);
+    if (!receipt) throw new Error(`No receipt for ${tx} on ${chain}`);
 
-    const transfer = parseTokenTransferPayload(vaa.payload);
+    const bridge = this.contracts.mustGetBridge(chain);
+    const core = this.contracts.mustGetCore(chain);
+    const bridgeLogs = receipt.logs.filter((l: any) => {
+      return l.address === core.address;
+    });
 
-    const fromChain = this.context.toChainName(vaa.emitterChain);
+    if (bridgeLogs.length === 0) {
+      throw new Error(NO_VAA_FOUND);
+    }
 
     let gasFee: BigNumber = BigNumber.from(0);
     if (receipt.gasUsed && receipt.effectiveGasPrice) {
       gasFee = receipt.gasUsed.mul(receipt.effectiveGasPrice);
     }
 
-    const toChain = this.context.toChainName(transfer.toChain);
-    const tokenChain = this.context.toChainName(transfer.tokenChain);
+    const fromChain = this.context.toChainName(chain);
 
+    const parsed = Implementation__factory.createInterface().parseLog(
+      bridgeLogs[0],
+    );
+
+    // TODO: refactor everything from here to the end
+    if (parsed.args.payload.startsWith('0x01')) {
+      const transfer = await bridge.parseTransfer(parsed.args.payload);
+      const tokenChain = this.context.toChainName(transfer.tokenChain);
+      const toChain = this.context.toChainName(transfer.toChain);
+      const destContext = this.context.getContext(toChain);
+      const tokenContext = this.context.getContext(tokenChain);
+      const tokenAddress = await tokenContext.parseAssetAddress(
+        utils.hexlify(transfer.tokenAddress),
+      );
+      return {
+        sendTx: tx,
+        sender: receipt.from,
+        amount: transfer.amount,
+        payloadID: transfer.payloadID,
+        recipient: destContext.parseAddress(transfer.to),
+        toChain: this.context.toChainName(transfer.toChain),
+        fromChain,
+        tokenAddress,
+        tokenChain,
+        tokenId: {
+          chain: tokenChain,
+          address: tokenAddress,
+        },
+        sequence: parsed.args.sequence,
+        emitterAddress: utils.hexlify(this.formatAddress(bridge.address)),
+        block: receipt.blockNumber,
+        gasFee,
+      };
+    }
+
+    const transferWithPayload = await bridge.parseTransferWithPayload(
+      parsed.args.payload,
+    );
+    const tokenChain = this.context.toChainName(transferWithPayload.tokenChain);
+    const toChain = this.context.toChainName(transferWithPayload.toChain);
     const destContext = this.context.getContext(toChain);
     const tokenContext = this.context.getContext(tokenChain);
     const tokenAddress = await tokenContext.parseAssetAddress(
-      utils.hexlify(transfer.tokenAddress),
+      utils.hexlify(transferWithPayload.tokenAddress),
     );
+    /**
+     * Not all relayers follow the same payload structure (i.e. sei)
+     * so we request the destination context to parse the payload
+     */
+    const relayerPayload: ParsedRelayerPayload =
+      destContext.parseRelayerPayload(
+        Buffer.from(arrayify(transferWithPayload.payload)),
+      );
 
-    const baseMessage: ParsedMessage = {
-      sendTx: receipt.transactionHash,
+    const relayerMessage: ParsedRelayerMessage = {
+      sendTx: tx,
       sender: receipt.from,
-      amount: BigNumber.from(transfer.amount),
-      payloadID: transfer.payloadType,
-      recipient: destContext.parseAddress(utils.hexlify(transfer.to)),
-      toChain: this.context.toChainName(transfer.toChain),
+      amount: transferWithPayload.amount,
+      payloadID: transferWithPayload.payloadID,
+      toChain: this.context.toChainName(transferWithPayload.toChain),
       fromChain,
       tokenAddress,
       tokenChain,
@@ -568,37 +575,15 @@ export class EthContext<
         chain: tokenChain,
         address: tokenAddress,
       },
-      sequence: BigNumber.from(vaa.sequence),
-      emitterAddress: utils.hexlify(
-        this.formatAddress(utils.hexlify(vaa.emitterAddress)),
-      ),
+      sequence: parsed.args.sequence,
+      emitterAddress: utils.hexlify(this.formatAddress(bridge.address)),
       block: receipt.blockNumber,
       gasFee,
-      payload: transfer.tokenTransferPayload
-        ? utils.hexlify(transfer.tokenTransferPayload)
-        : undefined,
-    };
-
-    if (transfer.payloadType === TokenBridgePayload.Transfer) {
-      return baseMessage;
-    }
-
-    /**
-     * Not all relayers follow the same payload structure (i.e. sei)
-     * so we request the destination context to parse the payload
-     */
-    const relayerPayload: ParsedRelayerPayload =
-      destContext.parseRelayerPayload(
-        Buffer.from(arrayify(transfer.tokenTransferPayload)),
-      );
-
-    const relayerMessage: ParsedRelayerMessage = {
-      ...baseMessage,
       relayerPayloadId: relayerPayload.relayerPayloadId,
       recipient: destContext.parseAddress(relayerPayload.to),
       relayerFee: relayerPayload.relayerFee,
       toNativeTokenAmount: relayerPayload.toNativeTokenAmount,
-      to: destContext.parseAddress(utils.hexlify(transfer.to)),
+      to: destContext.parseAddress(utils.hexlify(transferWithPayload.to)),
     };
     return relayerMessage;
   }

--- a/sdk/src/contexts/sei/context.ts
+++ b/sdk/src/contexts/sei/context.ts
@@ -698,6 +698,9 @@ export class SeiContext<
       emitterAddress,
       block: tx.height,
       gasFee: BigNumber.from(tx.gasUsed),
+      payload: parsed.tokenTransferPayload.length
+        ? hexlify(parsed.tokenTransferPayload)
+        : undefined,
     };
   }
 

--- a/sdk/src/contexts/sei/context.ts
+++ b/sdk/src/contexts/sei/context.ts
@@ -3,7 +3,6 @@ import {
   WormholeWrappedInfo,
   buildTokenId,
   cosmos,
-  getSignedVAAWithRetry,
   hexToUint8Array,
   isNativeCosmWasmDenom,
   parseTokenTransferPayload,
@@ -13,7 +12,6 @@ import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing';
 import {
   Coin,
-  IndexedTx,
   StdFee,
   calculateFee,
   logs as cosmosLogs,
@@ -38,7 +36,6 @@ import {
   ParsedRelayerMessage,
   ParsedRelayerPayload,
   TokenId,
-  VaaInfo,
 } from '../../types';
 import { ForeignAssetCache, stripHexPrefix } from '../../utils';
 import { WormholeContext } from '../../wormhole';
@@ -643,10 +640,10 @@ export class SeiContext<
     return null;
   }
 
-  async getVaa(
+  async getMessage(
     id: string,
     chain: ChainName | ChainId,
-  ): Promise<VaaInfo<IndexedTx>> {
+  ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const client = await this.getCosmWasmClient();
     const tx = await client.getTx(id);
     if (!tx) throw new Error('tx not found');
@@ -654,40 +651,21 @@ export class SeiContext<
     // parse logs emitted for the tx execution
     const logs = cosmosLogs.parseRawLog(tx.rawLog);
 
+    // extract information wormhole contract logs
+    // - message.message: the vaa payload (i.e. the transfer information)
+    // - message.sequence: the vaa's sequence number
+    // - message.sender: the vaa's emitter address
+    const tokenTransferPayload = this.searchLogs('message.message', logs);
+    if (!tokenTransferPayload)
+      throw new Error('message/transfer payload not found');
     const sequence = this.searchLogs('message.sequence', logs);
     if (!sequence) throw new Error('sequence not found');
     const emitterAddress = this.searchLogs('message.sender', logs);
     if (!emitterAddress) throw new Error('emitter not found');
 
-    const { vaaBytes } = await getSignedVAAWithRetry(
-      this.context.conf.wormholeHosts,
-      CHAIN_ID_SEI,
-      emitterAddress,
-      sequence,
-      undefined,
-      undefined,
-      this.context.conf.wormholeHosts.length,
+    const parsed = parseTokenTransferPayload(
+      Buffer.from(tokenTransferPayload, 'hex'),
     );
-
-    const parsedVaa = parseVaa(vaaBytes);
-    return {
-      transaction: tx,
-      rawVaa: vaaBytes,
-      vaa: {
-        ...parsedVaa,
-        sequence: parsedVaa.sequence.toString(),
-      },
-    };
-  }
-
-  async parseMessage(
-    info: VaaInfo<IndexedTx>,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const { transaction: tx, vaa: message } = info;
-
-    if (!tx) throw new Error('tx not found');
-
-    const parsed = parseTokenTransferPayload(message.payload);
 
     const decoded = decodeTxRaw(tx.tx);
     const { sender } = MsgExecuteContract.decode(
@@ -709,15 +687,15 @@ export class SeiContext<
       payloadID: parsed.payloadType,
       recipient: destContext.parseAddress(hexlify(parsed.to)),
       toChain: this.context.toChainName(parsed.toChain),
-      fromChain: this.context.toChainName(message.emitterChain),
+      fromChain: this.context.toChainName(chain),
       tokenAddress,
       tokenChain,
       tokenId: {
         address: tokenAddress,
         chain: tokenChain,
       },
-      sequence: BigNumber.from(message.sequence),
-      emitterAddress: message.emitterAddress.toString('hex'),
+      sequence: BigNumber.from(sequence),
+      emitterAddress,
       block: tx.height,
       gasFee: BigNumber.from(tx.gasUsed),
     };

--- a/sdk/src/contexts/solana/context.ts
+++ b/sdk/src/contexts/solana/context.ts
@@ -764,6 +764,9 @@ export class SolanaContext<
         to: toAddress,
         relayerFee: parsedPayload.relayerFee,
         toNativeTokenAmount: parsedPayload.toNativeTokenAmount,
+        payload: transfer.tokenTransferPayload.length
+          ? hexlify(transfer.tokenTransferPayload)
+          : undefined,
       };
       return parsedPayloadMessage;
     }

--- a/sdk/src/contexts/sui/context.ts
+++ b/sdk/src/contexts/sui/context.ts
@@ -361,6 +361,9 @@ export class SuiContext<
         relayerPayloadId: parsed.payloadType as number,
         to: relayerPayload.to,
         toNativeTokenAmount: relayerPayload.toNativeTokenAmount,
+        payload: parsed.tokenTransferPayload.length
+          ? hexlify(parsed.tokenTransferPayload)
+          : undefined,
       };
       return relayerMessage;
     }

--- a/sdk/src/contexts/sui/context.ts
+++ b/sdk/src/contexts/sui/context.ts
@@ -323,7 +323,7 @@ export class SuiContext<
     }
     const { payload, sender: emitterAddress, sequence } = message.parsedJson;
 
-    const parsed = parseTokenTransferPayload(payload);
+    const parsed = parseTokenTransferPayload(Buffer.from(payload));
 
     const tokenContext = this.context.getContext(parsed.tokenChain as ChainId);
     const destContext = this.context.getContext(parsed.toChain as ChainId);

--- a/sdk/src/contexts/sui/context.ts
+++ b/sdk/src/contexts/sui/context.ts
@@ -4,7 +4,6 @@ import {
   PaginatedCoins,
   SUI_CLOCK_OBJECT_ID,
   SUI_TYPE_ARG,
-  SuiTransactionBlockResponse,
   TransactionBlock,
   getTotalGasUsed,
   getTransactionSender,
@@ -13,12 +12,9 @@ import {
 import { BigNumber, BigNumberish } from 'ethers';
 
 import {
-  CHAIN_ID_SUI,
   getForeignAssetSui,
   getIsTransferCompletedSui,
   getOriginalAssetSui,
-  getSignedVAAWithRetry,
-  parseVaa,
   redeemOnSui,
   transferFromSui,
 } from '@certusone/wormhole-sdk';
@@ -32,7 +28,6 @@ import {
   ParsedMessage,
   ParsedRelayerMessage,
   TokenId,
-  VaaInfo,
 } from '../../types';
 import { parseTokenTransferPayload } from '../../vaa';
 import { WormholeContext } from '../../wormhole';
@@ -40,7 +35,7 @@ import { RelayerAbstract } from '../abstracts/relayer';
 import { SolanaContext } from '../solana';
 import { SuiContracts } from './contracts';
 import { SuiRelayer } from './relayer';
-import { ForeignAssetCache, stripHexPrefix } from '../../utils';
+import { ForeignAssetCache } from '../../utils';
 
 export class SuiContext<
   T extends WormholeContext,
@@ -312,10 +307,10 @@ export class SuiContext<
     return metadata.decimals;
   }
 
-  async getVaa(
+  async getMessage(
     tx: string,
     chain: ChainName | ChainId,
-  ): Promise<VaaInfo<SuiTransactionBlockResponse>> {
+  ): Promise<ParsedMessage | ParsedRelayerMessage> {
     const txBlock = await this.provider.getTransactionBlock({
       digest: tx,
       options: { showEvents: true, showEffects: true, showInput: true },
@@ -326,34 +321,9 @@ export class SuiContext<
     if (!message || !message.parsedJson) {
       throw new Error('WormholeMessage not found');
     }
-    const { sender: emitterAddress, sequence } = message.parsedJson;
+    const { payload, sender: emitterAddress, sequence } = message.parsedJson;
 
-    const { vaaBytes } = await getSignedVAAWithRetry(
-      this.context.conf.wormholeHosts,
-      CHAIN_ID_SUI,
-      stripHexPrefix(emitterAddress),
-      sequence,
-      undefined,
-      undefined,
-      this.context.conf.wormholeHosts.length,
-    );
-
-    const parsedVaa = parseVaa(vaaBytes);
-    return {
-      transaction: txBlock,
-      rawVaa: vaaBytes,
-      vaa: {
-        ...parsedVaa,
-        sequence: parsedVaa.sequence.toString(),
-      },
-    };
-  }
-
-  async parseMessage(
-    info: VaaInfo<SuiTransactionBlockResponse>,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const { transaction: txBlock, vaa: message } = info;
-    const parsed = parseTokenTransferPayload(message.payload);
+    const parsed = parseTokenTransferPayload(payload);
 
     const tokenContext = this.context.getContext(parsed.tokenChain as ChainId);
     const destContext = this.context.getContext(parsed.toChain as ChainId);
@@ -369,15 +339,15 @@ export class SuiContext<
       payloadID: parsed.payloadType,
       recipient: destContext.parseAddress(hexlify(parsed.to)),
       toChain: this.context.toChainName(parsed.toChain),
-      fromChain: this.context.toChainName(message.emitterChain),
+      fromChain: this.context.toChainName(chain),
       tokenAddress,
       tokenChain,
       tokenId: {
         chain: tokenChain,
         address: tokenAddress,
       },
-      sequence: BigNumber.from(message.sequence),
-      emitterAddress: hexlify(message.emitterAddress),
+      sequence: BigNumber.from(sequence),
+      emitterAddress: hexlify(emitterAddress),
       block: Number(txBlock.checkpoint || ''),
       gasFee: gasFee ? BigNumber.from(gasFee) : undefined,
     };

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,9 +1,5 @@
-import {
-  Network as Environment,
-  ParsedVaa,
-  SignedVaa,
-} from '@certusone/wormhole-sdk';
-import { BigNumber, ContractReceipt } from 'ethers';
+import { Network as Environment } from '@certusone/wormhole-sdk';
+import { BigNumber } from 'ethers';
 import { MainnetChainId, MainnetChainName } from './config/MAINNET';
 import { TestnetChainId, TestnetChainName } from './config/TESTNET';
 import { AptosContext, AptosContracts } from './contexts/aptos';
@@ -12,10 +8,6 @@ import { SolanaContext, SolContracts } from './contexts/solana';
 import { SuiContext, SuiContracts } from './contexts/sui';
 import { SeiContext, SeiContracts } from './contexts/sei';
 import { WormholeContext } from './wormhole';
-import { Types } from 'aptos';
-import { TransactionResponse } from '@solana/web3.js';
-import { SuiTransactionBlockResponse } from '@mysten/sui.js';
-import { IndexedTx } from '@cosmjs/stargate';
 import { DevnetChainId, DevnetChainName } from './config/DEVNET';
 import { CosmosContext } from './contexts/cosmos';
 import { CosmosContracts } from './contexts/cosmos/contracts';
@@ -139,39 +131,3 @@ export type TokenDetails = {
 
 export type SendResult = Awaited<ReturnType<AnyContext['send']>>;
 export type RedeemResult = Awaited<ReturnType<AnyContext['redeem']>>;
-
-export type VaaSourceTransaction =
-  | ContractReceipt
-  | Types.UserTransaction
-  | TransactionResponse
-  | SuiTransactionBlockResponse
-  | IndexedTx;
-export interface VaaInfo<T extends VaaSourceTransaction = any> {
-  transaction: T;
-  rawVaa: SignedVaa;
-  // BigInt is not serializable to JSON, so we use a string instead
-  vaa: Omit<ParsedVaa, 'sequence'> & { sequence: string };
-}
-
-export type CCTPInfo = {
-  fromChain: ChainName;
-  transactionHash: string;
-  blockNumber: number;
-  gasUsed: string;
-  effectiveGasPrice: string;
-  burnToken: string;
-  depositor: string;
-  amount: BigNumber;
-  recipient: string;
-  destinationDomain: number;
-  destinationTokenMessenger: string;
-  destinationCaller: string;
-  message: string;
-  messageHash: string;
-  signedAttestation?: string;
-  relayerPayloadId?: number;
-  relayerFee?: string;
-  toNativeTokenAmount?: string;
-  vaaEmitter?: string;
-  vaaSequence?: string;
-};

--- a/sdk/src/wormhole.ts
+++ b/sdk/src/wormhole.ts
@@ -19,7 +19,6 @@ import {
   RedeemResult,
   SendResult,
   TokenId,
-  VaaInfo,
   WormholeConfig,
 } from './types';
 import { SeiContext } from './contexts/sei';
@@ -426,16 +425,12 @@ export class WormholeContext extends MultiProvider<Domain> {
     return context.parseAddress(address);
   }
 
-  async getVaa(tx: string, chain: ChainName | ChainId): Promise<VaaInfo> {
-    const context = this.getContext(chain);
-    return await context.getVaa(tx, chain);
-  }
-
-  async parseMessage(
-    info: VaaInfo,
+  async getMessage(
+    tx: string,
+    chain: ChainName | ChainId,
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const context = this.getContext(info.vaa.emitterChain as ChainId);
-    return context.parseMessage(info);
+    const context = this.getContext(chain);
+    return await context.getMessage(tx, chain);
   }
 
   /**

--- a/wormhole-connect/src/store/redeem.ts
+++ b/wormhole-connect/src/store/redeem.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { ParsedMessage, ParsedRelayerMessage } from '../utils/sdk';
 import { Route } from './transferInput';
-import { MessageInfo } from 'utils/routes';
+import { SignedMessage } from '../utils/routes/types';
 
 export enum MessageType {
   BRIDGE = 1,
@@ -9,8 +9,8 @@ export enum MessageType {
 }
 
 export interface RedeemState {
-  messageInfo: MessageInfo | undefined;
   txData: ParsedMessage | ParsedRelayerMessage | undefined;
+  signedMessage: SignedMessage | undefined;
   sendTx: string;
   redeemTx: string;
   transferComplete: boolean;
@@ -19,8 +19,8 @@ export interface RedeemState {
 }
 
 const initialState: RedeemState = {
-  messageInfo: undefined,
   txData: undefined,
+  signedMessage: undefined,
   sendTx: '',
   redeemTx: '',
   transferComplete: false,
@@ -32,13 +32,10 @@ export const redeemSlice = createSlice({
   name: 'redeem',
   initialState,
   reducers: {
-    setMessageInfo: (
+    setTxDetails: (
       state: RedeemState,
-      { payload }: PayloadAction<MessageInfo>,
+      { payload }: PayloadAction<ParsedMessage | ParsedRelayerMessage>,
     ) => {
-      state.messageInfo = payload;
-    },
-    setTxDetails: (state: RedeemState, { payload }: PayloadAction<any>) => {
       state.txData = payload;
     },
     setSendTx: (state: RedeemState, { payload }: PayloadAction<string>) => {
@@ -68,11 +65,16 @@ export const redeemSlice = createSlice({
         state[key] = initialState[key];
       });
     },
+    setSignedMessage: (
+      state: RedeemState,
+      { payload }: PayloadAction<SignedMessage>,
+    ) => {
+      state.signedMessage = payload;
+    },
   },
 });
 
 export const {
-  setMessageInfo,
   setTxDetails,
   setSendTx,
   setRedeemTx,
@@ -80,6 +82,7 @@ export const {
   setIsVaaEnqueued,
   clearRedeem,
   setRoute,
+  setSignedMessage,
 } = redeemSlice.actions;
 
 export default redeemSlice.reducer;

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -583,7 +583,13 @@ export class CosmosGatewayRoute extends BaseRoute {
   async getSignedMessage(
     message: TokenTransferMessage | RelayTransferMessage,
   ): Promise<SignedTokenTransferMessage | SignedRelayTransferMessage> {
-    const vaa = await fetchVaa(message);
+    const vaa = await fetchVaa({
+      ...message,
+      // transfers from cosmos vaas are emitted by wormchain and not by the source chain
+      fromChain: isCosmWasmChain(message.fromChain)
+        ? 'wormchain'
+        : message.fromChain,
+    });
 
     if (!vaa) {
       throw new Error('VAA not found');

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -4,7 +4,6 @@ import {
   CHAIN_ID_SOLANA,
   CHAIN_ID_WORMCHAIN,
   cosmos,
-  parseTokenTransferPayload,
 } from '@certusone/wormhole-sdk';
 import {
   CosmWasmClient,
@@ -31,7 +30,7 @@ import {
 import { MsgTransfer } from 'cosmjs-types/ibc/applications/transfer/v1/tx';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
 import { BigNumber, utils } from 'ethers';
-import { base58, hexlify } from 'ethers/lib/utils.js';
+import { arrayify, base58, hexlify } from 'ethers/lib/utils.js';
 import { toChainId, wh } from 'utils/sdk';
 import { MAX_DECIMALS, getTokenDecimals, toNormalizedDecimals } from '..';
 import { CHAINS, CONFIG, TOKENS } from '../../config';
@@ -606,11 +605,10 @@ export class CosmosGatewayRoute extends BaseRoute {
     const message = await wh.getMessage(hash, chain);
     if (!message.payload)
       throw new Error(`Missing payload from message ${hash} on chain ${chain}`);
-    const transfer = parseTokenTransferPayload(
-      Buffer.from(message.payload, 'hex'),
-    );
     const decoded: GatewayTransferMsg = JSON.parse(
-      transfer.tokenTransferPayload.toString(),
+      Buffer.from(
+        arrayify(message.payload, { allowMissingPrefix: true }),
+      ).toString(),
     );
     const adapted: any = await adaptParsedMessage({
       ...message,

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -24,8 +24,6 @@ import {
   ChainName,
   CosmosTransaction,
   TokenId,
-  VaaInfo,
-  VaaSourceTransaction,
   searchCosmosLogs,
   SolanaContext,
   WormholeContext,
@@ -41,16 +39,23 @@ import { Route } from '../../store/transferInput';
 import { isCosmWasmChain } from '../../utils/cosmos';
 import { toDecimals, toFixedDecimals } from '../balance';
 import { estimateSendGasFees } from '../gasEstimates';
-import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
 import { TransferWallet, signAndSendTransaction } from '../wallet';
 import { BaseRoute } from './baseRoute';
 import { adaptParsedMessage } from './common';
-import { TransferDisplayData } from './types';
 import {
-  MessageInfo,
+  RelayTransferMessage,
+  SignedRelayTransferMessage,
+  SignedTokenTransferMessage,
+  TokenTransferMessage,
+  TransferDisplayData,
+  isSignedWormholeMessage,
+} from './types';
+import {
+  UnsignedMessage,
+  SignedMessage,
   TransferDestInfoBaseParams,
   TransferInfoBaseParams,
-} from './routeAbstract';
+} from './types';
 import { calculateGas } from '../gas';
 import {
   Tendermint34Client,
@@ -59,6 +64,7 @@ import {
 } from '@cosmjs/tendermint-rpc';
 import { BridgeRoute } from './bridge';
 import { TokenConfig } from '../../config/types';
+import { fetchVaa } from '../vaa';
 
 interface GatewayTransferMsg {
   gateway_transfer: {
@@ -71,19 +77,6 @@ interface GatewayTransferMsg {
 
 interface FromCosmosPayload {
   gateway_ibc_token_bridge_payload: GatewayTransferMsg;
-}
-
-// this contains additional info given that the transaction that emits
-// the vaa ocurs in wormchain, but the original action that started
-// the process takes place in another cosmos chain
-interface GatewayVaaInfo<T extends VaaSourceTransaction = any>
-  extends VaaInfo<T> {
-  sourceChain: ChainName | ChainId;
-  sourceChainTx: string;
-  sourceChainSender: string;
-}
-function isGatewayVaaInfo(info: MessageInfo): info is GatewayVaaInfo {
-  return (info as GatewayVaaInfo).sourceChain !== undefined;
 }
 
 const IBC_MSG_TYPE = '/ibc.applications.transfer.v1.MsgTransfer';
@@ -338,60 +331,14 @@ export class CosmosGatewayRoute extends BaseRoute {
     );
   }
 
-  public async parseMessage(
-    info: VaaInfo | GatewayVaaInfo,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const message = await wh.parseMessage(info);
-    if (isCosmWasmChain(info.vaa.emitterChain as ChainId)) {
-      // need to set the info from the original cosmos chain
-      // even if the message originated from wormchain
-      const parsed = await adaptParsedMessage(message);
-      return isGatewayVaaInfo(info)
-        ? {
-            ...parsed,
-            sendTx: info.sourceChainTx,
-            fromChain: wh.toChainName(info.sourceChain),
-            sender: info.sourceChainSender,
-          }
-        : parsed;
-    }
-
-    const transfer = parseTokenTransferPayload(info.vaa.payload);
-    const decoded: GatewayTransferMsg = JSON.parse(
-      transfer.tokenTransferPayload.toString(),
-    );
-    const adapted: any = await adaptParsedMessage({
-      ...message,
-      recipient: Buffer.from(
-        decoded.gateway_transfer.recipient,
-        'base64',
-      ).toString(),
-      toChain: wh.toChainName(decoded.gateway_transfer.chain),
-    });
-
-    const parsed = {
-      ...adapted,
-      // the context assumes that if the transfer is payload 3, it's a relayer transfer
-      // but in this case, it is not, so we clear these fields
-      relayerFee: '0',
-      toNativeTokenAmount: '0',
-    };
-
-    return isGatewayVaaInfo(info)
-      ? { ...parsed, sendTx: info.sourceChainTx, fromChain: info.sourceChain }
-      : parsed;
-  }
-
   private async manualRedeem(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    message: SignedMessage,
     recipient: string,
   ): Promise<string> {
-    if (!isGatewayVaaInfo(messageInfo)) {
-      throw new Error('Message information is not for a gateway transfer');
-    }
-
-    const vaa = Buffer.from(messageInfo.rawVaa).toString('base64');
+    if (!isSignedWormholeMessage(message))
+      throw new Error('Signed message is not for gateway');
+    const vaa = Buffer.from(message.vaa).toString('base64');
     const msg: MsgExecuteContractEncodeObject = {
       typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
       value: MsgExecuteContract.fromPartial({
@@ -417,13 +364,9 @@ export class CosmosGatewayRoute extends BaseRoute {
 
   public async redeem(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    messageInfo: SignedMessage,
     recipient: string,
   ): Promise<string> {
-    if (!isGatewayVaaInfo(messageInfo)) {
-      throw new Error('Message information is not for a gateway transfer');
-    }
-
     const chain = wh.toChainId(destChain);
 
     if (isCosmWasmChain(chain)) {
@@ -620,21 +563,77 @@ export class CosmosGatewayRoute extends BaseRoute {
 
   isTransferCompleted(
     destChain: ChainName | ChainId,
-    messageInfo: VaaInfo,
+    message: SignedMessage,
   ): Promise<boolean> {
+    if (!isSignedWormholeMessage(message))
+      throw new Error('Signed message is not for gateway');
     return isCosmWasmChain(destChain)
-      ? wh.isTransferCompleted(CHAIN_ID_WORMCHAIN, hexlify(messageInfo.rawVaa))
-      : new BridgeRoute().isTransferCompleted(destChain, messageInfo);
+      ? wh.isTransferCompleted(CHAIN_ID_WORMCHAIN, hexlify(message.vaa))
+      : new BridgeRoute().isTransferCompleted(destChain, message);
   }
 
-  async getMessageInfo(
+  async getMessage(
     hash: string,
     chain: ChainName | ChainId,
-  ): Promise<VaaInfo | GatewayVaaInfo> {
-    if (!isCosmWasmChain(wh.toChainId(chain))) {
-      return wh.getVaa(hash, chain);
+  ): Promise<UnsignedMessage> {
+    const name = wh.toChainName(chain);
+    return isCosmWasmChain(name)
+      ? this.getMessageFromCosmos(hash, name)
+      : this.getMessageFromNonCosmos(hash, name);
+  }
+
+  async getSignedMessage(
+    message: TokenTransferMessage | RelayTransferMessage,
+  ): Promise<SignedTokenTransferMessage | SignedRelayTransferMessage> {
+    const vaa = await fetchVaa(message);
+
+    if (!vaa) {
+      throw new Error('VAA not found');
     }
 
+    return {
+      ...message,
+      vaa: utils.hexlify(vaa.bytes),
+    };
+  }
+
+  async getMessageFromNonCosmos(
+    hash: string,
+    chain: ChainName,
+  ): Promise<UnsignedMessage> {
+    // const message = await wh.getMessage(hash, chain);
+    // return adaptParsedMessage(message);
+    const message = await wh.getMessage(hash, chain);
+    if (!message.payload)
+      throw new Error(`Missing payload from message ${hash} on chain ${chain}`);
+    const transfer = parseTokenTransferPayload(
+      Buffer.from(message.payload, 'hex'),
+    );
+    const decoded: GatewayTransferMsg = JSON.parse(
+      transfer.tokenTransferPayload.toString(),
+    );
+    const adapted: any = await adaptParsedMessage({
+      ...message,
+      recipient: Buffer.from(
+        decoded.gateway_transfer.recipient,
+        'base64',
+      ).toString(),
+      toChain: wh.toChainName(decoded.gateway_transfer.chain),
+    });
+
+    return {
+      ...adapted,
+      // the context assumes that if the transfer is payload 3, it's a relayer transfer
+      // but in this case, it is not, so we clear these fields
+      relayerFee: '0',
+      toNativeTokenAmount: '0',
+    };
+  }
+
+  async getMessageFromCosmos(
+    hash: string,
+    chain: ChainName,
+  ): Promise<UnsignedMessage> {
     // Get tx on the source chain (e.g. osmosis)
     const sourceClient = await this.getCosmWasmClient(chain);
     const tx = await sourceClient.getTx(hash);
@@ -682,15 +681,16 @@ export class CosmosGatewayRoute extends BaseRoute {
     const sender = searchCosmosLogs('sender', logs);
     if (!sender) throw new Error('Missing sender in transaction logs');
 
-    const base = await wh.getVaa(destTx[0].hash, CHAIN_ID_WORMCHAIN);
+    const message = await wh.getMessage(destTx[0].hash, CHAIN_ID_WORMCHAIN);
+    const parsed = await adaptParsedMessage(message);
 
-    // add the original source chain and tx hash to the info
-    // the vaa contains only the wormchain information
     return {
-      ...base,
-      sourceChain: chain,
-      sourceChainTx: hash,
-      sourceChainSender: sender,
+      ...parsed,
+      // add the original source chain and tx hash to the info
+      // the vaa contains only the wormchain information
+      fromChain: wh.toChainName(chain),
+      sendTx: hash,
+      sender,
     };
   }
 

--- a/wormhole-connect/src/utils/routes/hashflow.ts
+++ b/wormhole-connect/src/utils/routes/hashflow.ts
@@ -6,12 +6,13 @@ import {
 import { BigNumber } from 'ethers';
 
 import { TokenConfig } from 'config/types';
-import RouteAbstract, {
+import {
   TransferInfoBaseParams,
-  MessageInfo,
-} from './routeAbstract';
-import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
+  UnsignedMessage,
+  SignedMessage,
+} from './types';
 import { TransferDisplayData } from './types';
+import RouteAbstract from './routeAbstract';
 
 export class HashflowRoute extends RouteAbstract {
   readonly NATIVE_GAS_DROPOFF_SUPPORTED = false;
@@ -87,14 +88,9 @@ export class HashflowRoute extends RouteAbstract {
   }
   public redeem(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    messageInfo: SignedMessage,
     recipient: string,
   ): Promise<string> {
-    throw new Error('Method not implemented.');
-  }
-  public parseMessage(
-    messageInfo: MessageInfo,
-  ): Promise<ParsedMessage | ParsedRelayerMessage> {
     throw new Error('Method not implemented.');
   }
   public getPreview<P>(params: P): Promise<TransferDisplayData> {
@@ -128,11 +124,14 @@ export class HashflowRoute extends RouteAbstract {
   }
   isTransferCompleted(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    message: SignedMessage,
   ): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
-  getMessageInfo(tx: string, chain: ChainName | ChainId): Promise<MessageInfo> {
+  getMessage(tx: string, chain: ChainName | ChainId): Promise<UnsignedMessage> {
+    throw new Error('Method not implemented.');
+  }
+  getSignedMessage(message: UnsignedMessage): Promise<SignedMessage> {
     throw new Error('Method not implemented.');
   }
   getTransferSourceInfo<T extends TransferInfoBaseParams>(

--- a/wormhole-connect/src/utils/routes/routeAbstract.ts
+++ b/wormhole-connect/src/utils/routes/routeAbstract.ts
@@ -1,28 +1,17 @@
 import {
-  TokenId,
-  ChainName,
   ChainId,
-  VaaInfo,
-  CCTPInfo,
+  ChainName,
+  TokenId,
 } from '@wormhole-foundation/wormhole-connect-sdk';
-import { BigNumber } from 'ethers';
-
 import { TokenConfig } from 'config/types';
-import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
-import { TransferDisplayData } from './types';
-
-// As more routes are added, more types should be added here (e.g. MessageInfo = ParsedVaa | DifferentRouteInfoStruct | ..)
-// This struct contains information needed to redeem the transfer
-export type MessageInfo = VaaInfo | CCTPInfo;
-
-export interface TransferInfoBaseParams {
-  txData: ParsedMessage | ParsedRelayerMessage;
-}
-
-export interface TransferDestInfoBaseParams {
-  txData: ParsedMessage | ParsedRelayerMessage;
-  receiveTx?: string;
-}
+import { BigNumber } from 'ethers';
+import {
+  UnsignedMessage,
+  SignedMessage,
+  TransferDestInfoBaseParams,
+  TransferDisplayData,
+  TransferInfoBaseParams,
+} from './types';
 
 export default abstract class RouteAbstract {
   abstract readonly NATIVE_GAS_DROPOFF_SUPPORTED: boolean;
@@ -116,13 +105,9 @@ export default abstract class RouteAbstract {
     routeOptions: any,
   ): Promise<any>;
 
-  public abstract parseMessage(
-    messageInfo: MessageInfo,
-  ): Promise<ParsedMessage | ParsedRelayerMessage>;
-
   public abstract redeem(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    messageInfo: SignedMessage,
     recipient: string,
   ): Promise<string>;
 
@@ -166,15 +151,15 @@ export default abstract class RouteAbstract {
     chain: ChainName | ChainId,
   ): Promise<string | null>;
 
-  abstract getMessageInfo(
+  abstract getMessage(
     tx: string,
     chain: ChainName | ChainId,
-    unsigned?: boolean,
-  ): Promise<MessageInfo | undefined>;
+  ): Promise<UnsignedMessage>;
+  abstract getSignedMessage(message: UnsignedMessage): Promise<SignedMessage>;
 
   abstract isTransferCompleted(
     destChain: ChainName | ChainId,
-    messageInfo: MessageInfo,
+    messageInfo: SignedMessage,
   ): Promise<boolean>;
 
   // swap information (native gas slider)

--- a/wormhole-connect/src/utils/routes/types.ts
+++ b/wormhole-connect/src/utils/routes/types.ts
@@ -1,3 +1,52 @@
+import { ParsedMessage, ParsedRelayerMessage } from '../sdk';
+
+export type TokenTransferMessage = ParsedMessage;
+export type RelayTransferMessage = ParsedRelayerMessage;
+export interface CCTPMessage {
+  message: string;
+}
+export type ManualCCTPMessage = CCTPMessage & ParsedMessage;
+export type RelayCCTPMessage = CCTPMessage & ParsedRelayerMessage;
+export type UnsignedCCTPMessage = ManualCCTPMessage | RelayCCTPMessage;
+export type UnsignedMessage =
+  | TokenTransferMessage
+  | RelayTransferMessage
+  | UnsignedCCTPMessage;
+
+export type SignedTokenTransferMessage = TokenTransferMessage & { vaa: string }; // hex encoded vaa bytes
+export type SignedRelayTransferMessage = RelayTransferMessage & { vaa: string }; // hex encoded vaa bytes
+export type SignedWormholeMessage =
+  | SignedTokenTransferMessage
+  | SignedRelayTransferMessage;
+export type SignedManualCCTPMessage = ManualCCTPMessage & {
+  attestation: string;
+};
+export type SignedRelayCCTPMessage = RelayCCTPMessage & { attestation: string };
+export type SignedCCTPMessage =
+  | SignedManualCCTPMessage
+  | SignedRelayCCTPMessage;
+export type SignedMessage = SignedWormholeMessage | SignedCCTPMessage;
+
+export const isSignedWormholeMessage = (
+  message: SignedMessage,
+): message is SignedWormholeMessage =>
+  typeof message === 'object' && 'vaa' in message;
+export const isSignedCCTPMessage = (
+  message: SignedMessage,
+): message is SignedCCTPMessage =>
+  typeof message === 'object' &&
+  'message' in message &&
+  'attestation' in message;
+
+export interface TransferInfoBaseParams {
+  txData: ParsedMessage | ParsedRelayerMessage;
+}
+
+export interface TransferDestInfoBaseParams {
+  txData: ParsedMessage | ParsedRelayerMessage;
+  receiveTx?: string;
+}
+
 export type Row = {
   title: string;
   value: string;

--- a/wormhole-connect/src/utils/sdk.ts
+++ b/wormhole-connect/src/utils/sdk.ts
@@ -135,6 +135,7 @@ export const toChainId = (chain: ChainName | ChainId) => {
   return wh.toChainId(chain);
 };
 
-export const getVaa = (tx: string, chain: ChainName | ChainId) => {
-  return wh.getVaa(tx, chain);
+export const getMessage = (tx: string, chain: ChainName | ChainId) => {
+  const context: any = wh.getContext(chain);
+  return context.getMessage(tx, chain);
 };

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -123,9 +123,7 @@ function Send(props: { valid: boolean }) {
             fromNetwork!,
             true, // don't need to get the signed attestation
           );
-        } catch (e) {
-          console.warn(e);
-        }
+        } catch (e) {}
         if (message === undefined) {
           await sleep(3000);
         }

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -20,7 +20,7 @@ import {
   TransferWallet,
 } from '../../utils/wallet';
 import { estimateClaimGasFees } from '../../utils/gasEstimates';
-import Operator, { MessageInfo } from '../../utils/routes';
+import Operator, { UnsignedMessage } from '../../utils/routes';
 import { validate, isTransferValid } from '../../utils/transferValidation';
 import {
   setManualGasEst,
@@ -114,21 +114,22 @@ function Send(props: { valid: boolean }) {
         { toNativeToken },
       );
 
-      let messageInfo: MessageInfo | undefined;
-      while (messageInfo === undefined) {
+      let message: UnsignedMessage | undefined;
+      while (message === undefined) {
         try {
-          messageInfo = await operator.getMessageInfo(
+          message = await operator.getMessage(
             route,
             txId,
             fromNetwork!,
             true, // don't need to get the signed attestation
           );
-        } catch {}
-        if (messageInfo === undefined) {
+        } catch (e) {
+          console.warn(e);
+        }
+        if (message === undefined) {
           await sleep(3000);
         }
       }
-      const message = await operator.parseMessage(route, messageInfo);
       dispatch(setIsTransactionInProgress(false));
       dispatch(setSendTx(txId));
       dispatch(setTxDetails(message));

--- a/wormhole-connect/src/views/Redeem/SendFrom.tsx
+++ b/wormhole-connect/src/views/Redeem/SendFrom.tsx
@@ -10,10 +10,7 @@ import Confirmations from './Confirmations';
 import Header from './Header';
 
 function SendFrom() {
-  const { messageInfo, route } = useSelector(
-    (state: RootState) => state.redeem,
-  );
-  const txData = useSelector((state: RootState) => state.redeem.txData)!;
+  const { txData, route } = useSelector((state: RootState) => state.redeem);
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
@@ -31,14 +28,14 @@ function SendFrom() {
     <div>
       <InputContainer>
         <Header
-          network={txData.fromChain}
-          address={txData.sender}
-          txHash={txData.sendTx}
+          network={txData!.fromChain}
+          address={txData!.sender}
+          txHash={txData!.sendTx}
         />
         <RenderRows rows={rows} />
       </InputContainer>
-      {!transferComplete && !messageInfo && (
-        <Confirmations chain={txData.fromChain} blockHeight={txData.block} />
+      {!transferComplete && !txData && (
+        <Confirmations chain={txData!.fromChain} blockHeight={txData!.block} />
       )}
     </div>
   );

--- a/wormhole-connect/src/views/Redeem/SendFrom.tsx
+++ b/wormhole-connect/src/views/Redeem/SendFrom.tsx
@@ -10,7 +10,9 @@ import Confirmations from './Confirmations';
 import Header from './Header';
 
 function SendFrom() {
-  const { txData, route } = useSelector((state: RootState) => state.redeem);
+  const { txData, route, signedMessage } = useSelector(
+    (state: RootState) => state.redeem,
+  );
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
@@ -34,7 +36,7 @@ function SendFrom() {
         />
         <RenderRows rows={rows} />
       </InputContainer>
-      {!transferComplete && !txData && (
+      {!transferComplete && !signedMessage && (
         <Confirmations chain={txData!.fromChain} blockHeight={txData!.block} />
       )}
     </div>

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -56,14 +56,14 @@ function SendTo() {
   // get the redeem tx, for automatic transfers only
   const getRedeemTx = useCallback(async () => {
     if (redeemTx) return redeemTx;
-    if (txData) {
-      const redeemed = await fetchRedeemTx(txData);
+    if (signedMessage) {
+      const redeemed = await fetchRedeemTx(signedMessage);
       if (redeemed) {
         dispatch(setRedeemTx(redeemed.transactionHash));
         return redeemed.transactionHash;
       }
     }
-  }, [redeemTx, txData, dispatch]);
+  }, [redeemTx, signedMessage, dispatch]);
 
   useEffect(() => {
     if (!txData) return;

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -27,10 +27,10 @@ import Header from './Header';
 function SendTo() {
   const dispatch = useDispatch();
   const {
-    messageInfo,
     redeemTx,
     transferComplete,
     route: routeType,
+    signedMessage,
   } = useSelector((state: RootState) => state.redeem);
   const txData = useSelector((state: RootState) => state.redeem.txData)!;
   const wallet = useSelector((state: RootState) => state.wallet.receiving);
@@ -56,14 +56,14 @@ function SendTo() {
   // get the redeem tx, for automatic transfers only
   const getRedeemTx = useCallback(async () => {
     if (redeemTx) return redeemTx;
-    if (messageInfo) {
+    if (txData) {
       const redeemed = await fetchRedeemTx(txData);
       if (redeemed) {
         dispatch(setRedeemTx(redeemed.transactionHash));
         return redeemed.transactionHash;
       }
     }
-  }, [redeemTx, messageInfo, txData, dispatch]);
+  }, [redeemTx, txData, dispatch]);
 
   useEffect(() => {
     if (!txData) return;
@@ -108,7 +108,7 @@ function SendTo() {
       const txId = await new Operator().redeem(
         routeType,
         txData.toChain,
-        messageInfo,
+        signedMessage!,
         wallet.address,
       );
       dispatch(setRedeemTx(txId));

--- a/wormhole-connect/src/views/Redeem/Stepper.tsx
+++ b/wormhole-connect/src/views/Redeem/Stepper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useSelector } from 'react-redux';
 
 import { RootState } from '../../store';
-import { MessageInfo } from '../../utils/routes';
+import { UnsignedMessage } from '../../utils/routes';
 
 import Stepper from '../../components/Stepper/Stepper';
 import SendFrom from './SendFrom';
@@ -10,13 +10,13 @@ import SendTo from './SendTo';
 import BridgeComplete from './BridgeComplete';
 
 export default function MilestoneStepper() {
-  const messageInfo: MessageInfo | undefined = useSelector(
-    (state: RootState) => state.redeem.messageInfo,
+  const txData: UnsignedMessage | undefined = useSelector(
+    (state: RootState) => state.redeem.txData,
   );
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
-  const activeStep = transferComplete ? 4 : !!messageInfo ? 2 : 1;
+  const activeStep = transferComplete ? 4 : !!txData ? 2 : 1;
 
   const steps = [
     {

--- a/wormhole-connect/src/views/Redeem/Stepper.tsx
+++ b/wormhole-connect/src/views/Redeem/Stepper.tsx
@@ -10,13 +10,13 @@ import SendTo from './SendTo';
 import BridgeComplete from './BridgeComplete';
 
 export default function MilestoneStepper() {
-  const txData: UnsignedMessage | undefined = useSelector(
-    (state: RootState) => state.redeem.txData,
+  const signedMessage: UnsignedMessage | undefined = useSelector(
+    (state: RootState) => state.redeem.signedMessage,
   );
   const transferComplete = useSelector(
     (state: RootState) => state.redeem.transferComplete,
   );
-  const activeStep = transferComplete ? 4 : !!txData ? 2 : 1;
+  const activeStep = transferComplete ? 4 : !!signedMessage ? 2 : 1;
 
   const steps = [
     {

--- a/wormhole-connect/src/views/TxSearch.tsx
+++ b/wormhole-connect/src/views/TxSearch.tsx
@@ -7,7 +7,7 @@ import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import { CHAINS_ARR } from '../config';
 import { isValidTxId } from '../utils';
 import Operator from '../utils/routes';
-import { setTxDetails, setRoute as setRedeemRoute } from '../store/redeem';
+import { setRoute as setRedeemRoute, setTxDetails } from '../store/redeem';
 import { setRoute as setAppRoute } from '../store/router';
 import PageHeader from '../components/PageHeader';
 import Search from '../components/Search';
@@ -71,13 +71,11 @@ function TxSearch() {
         state.tx,
         state.chain as ChainName,
       );
-      const messageInfo = await operator.getMessageInfo(
+      const message = await operator.getMessage(
         route,
         state.tx,
         state.chain as ChainName,
-        true, // don't need to get the signed attestation
       );
-      const message = await operator.parseMessage(route, messageInfo!);
       setError('');
       dispatch(setTxDetails(message));
       dispatch(setRedeemRoute(route));


### PR DESCRIPTION
Should address #903.

Revert some changes made during the [routes refactor](https://github.com/wormhole-foundation/wormhole-connect/pull/710) which caused the Bridge UI to wait for a VAA to be emitted before proceeding to the Redeem stage (in some chains it'd take a long time, for example 30 minutes on Ethereum).

The split to `parseMessageFromTx` into `getVaa` and `parseMessage` was reverted back, now under the name `getMessage`.

Adapted the logic and interfaces to include the CCTP routes, which were developed after the routes refactor. 