### PR TITLE
[#913][#914] Add logic to fetch the redeem transaction for cosmos gateway

### DIFF
--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -12,7 +12,6 @@ import {
   Coin,
   IbcExtension,
   QueryClient,
-  StargateClient,
   StdFee,
   calculateFee,
   logs as cosmosLogs,
@@ -117,13 +116,9 @@ export class CosmosContext<
     txId: string,
     chain: ChainName | ChainId,
   ): Promise<BigNumber | undefined> {
-    const chainName = this.context.toChainName(chain);
-    const rpc = this.context.conf.rpcs[chainName];
-    if (rpc) {
-      const client = await StargateClient.connect(rpc);
-      const transaction = await client.getTx(txId);
-      return BigNumber.from(transaction?.gasUsed || 0);
-    }
+    const client = await this.getCosmWasmClient(chain);
+    const transaction = await client.getTx(txId);
+    return BigNumber.from(transaction?.gasUsed || 0);
   }
 
   send(

--- a/wormhole-connect/src/utils/events.ts
+++ b/wormhole-connect/src/utils/events.ts
@@ -8,17 +8,18 @@ import {
   SolanaContext,
   WormholeContext,
 } from '@wormhole-foundation/wormhole-connect-sdk';
-import { ParsedMessage, ParsedRelayerMessage, wh } from './sdk';
+import { ParsedRelayerMessage, wh } from './sdk';
 import { fromNormalizedDecimals } from '.';
 import { CHAINS } from 'config';
 import { fetchGlobalTx, getEmitterAndSequence } from './vaa';
 import { isEvmChain } from 'utils/sdk';
 import RouteOperator from './routes/operator';
 import { Route } from 'config/types';
+import { SignedMessage } from './routes';
 
 export const fetchRedeemTx = async (
   route: Route,
-  txData: ParsedMessage | ParsedRelayerMessage,
+  txData: SignedMessage,
 ): Promise<{ transactionHash: string } | null> => {
   let transactionHash: string | undefined;
   if (txData.emitterAddress && txData.sequence) {
@@ -35,7 +36,7 @@ export const fetchRedeemTx = async (
 };
 
 export const fetchRedeemedEvent = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
+  txData: SignedMessage,
 ): Promise<{ transactionHash: string } | null> => {
   const messageId = getEmitterAndSequence(txData);
   const { emitterChain, emitterAddress, sequence } = messageId;

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -638,9 +638,7 @@ export class CosmosGatewayRoute extends BaseRoute {
     };
   }
 
-  async fetchRedeemedEvent(
-    message: SignedMessage,
-  ): Promise<string | null> {
+  async fetchRedeemedEvent(message: SignedMessage): Promise<string | null> {
     if (!isSignedWormholeMessage(message)) {
       throw new Error('Signed message is not for gateway');
     }

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -823,7 +823,8 @@ export class CosmosGatewayRoute extends BaseRoute {
     throw new Error('Native gas drop-off not supported by this route');
   }
 
-  async tryFetchRedeemTx(txData: UnsignedMessage): Promise<string | undefined> {
-    return undefined; // only for automatic routes
+  async tryFetchRedeemTx(txData: SignedMessage): Promise<string | undefined> {
+    const hash = await this.fetchRedeemedEvent(txData);
+    return hash || undefined;
   }
 }

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -23,6 +23,7 @@ import Spacer from 'components/Spacer';
 import WalletsModal from '../WalletModal';
 import Header from './Header';
 import { estimateClaimGas } from 'utils/gas';
+import { isCosmWasmChain } from '../../utils/cosmos';
 
 function SendTo() {
   const dispatch = useDispatch();
@@ -102,8 +103,11 @@ function SendTo() {
 
   const AUTOMATIC_DEPOSIT = useMemo(() => {
     if (!routeName) return false;
-    return RouteOperator.getRoute(routeName).AUTOMATIC_DEPOSIT;
-  }, [routeName]);
+    return (
+      RouteOperator.getRoute(routeName).AUTOMATIC_DEPOSIT ||
+      isCosmWasmChain(txData.toChain)
+    );
+  }, [routeName, txData]);
 
   const claim = async () => {
     setInProgress(true);


### PR DESCRIPTION
This PR adds the logic to retrieve the destination IBC transfer tx given a wh transfer. It also modifies the `isTransferComplete` method to check for this transaction to exist to avoid cases in which the user might receive the funds instantly when the wormchain redeem is completed.

Closes #913, #914

Depends on #909 