### PR TITLE
Cctp qa

### DIFF
--- a/wormhole-connect/src/config/mainnet.ts
+++ b/wormhole-connect/src/config/mainnet.ts
@@ -42,7 +42,7 @@ export const MAINNET_NETWORKS: NetworksConfig = {
     displayName: 'Avalanche',
     explorerUrl: 'https://snowtrace.io/',
     explorerName: 'Snowtrace',
-    gasToken: 'WAVAX',
+    gasToken: 'AVAX',
     chainId: 43114,
     icon: Icon.AVAX,
     automaticRelayer: true,

--- a/wormhole-connect/src/config/routes.ts
+++ b/wormhole-connect/src/config/routes.ts
@@ -10,6 +10,7 @@ export type RouteData = {
   providedBy: string;
   link: string;
   icon: () => JSX.Element;
+  pendingMessage: string;
 };
 
 export const ROUTES: {
@@ -21,6 +22,7 @@ export const ROUTES: {
     providedBy: 'Wormhole',
     link: 'https://wormhole.com/',
     icon: WormholeIcon,
+    pendingMessage: 'Waiting for Wormhole network consensus . . .',
   },
   [Route.RELAY]: {
     route: Route.RELAY,
@@ -28,6 +30,7 @@ export const ROUTES: {
     providedBy: 'xLabs',
     link: 'https://xlabs.xyz',
     icon: XLabsIcon,
+    pendingMessage: 'Waiting for Wormhole network consensus . . .',
   },
   [Route.HASHFLOW]: {
     route: Route.HASHFLOW,
@@ -35,6 +38,7 @@ export const ROUTES: {
     providedBy: 'Hashflow',
     link: 'https://www.hashflow.com/',
     icon: HashflowIcon,
+    pendingMessage: 'Waiting for Wormhole network consensus . . .',
   },
   [Route.CCTPManual]: {
     route: Route.CCTPManual,
@@ -42,6 +46,7 @@ export const ROUTES: {
     providedBy: 'Circle',
     link: 'https://www.circle.com/en/cross-chain-transfer-protocol',
     icon: CCTPIcon,
+    pendingMessage: 'Waiting for Circle attestation . . .',
   },
   [Route.CCTPRelay]: {
     route: Route.CCTPRelay,
@@ -49,6 +54,7 @@ export const ROUTES: {
     providedBy: 'Circle',
     link: 'https://www.circle.com/en/cross-chain-transfer-protocol',
     icon: CCTPIcon,
+    pendingMessage: 'Waiting for Circle attestation . . .',
   },
   [Route.COSMOS_GATEWAY]: {
     route: Route.COSMOS_GATEWAY,
@@ -56,5 +62,6 @@ export const ROUTES: {
     providedBy: 'Wormhole',
     link: 'https://wormhole.com/',
     icon: WormholeIcon,
+    pendingMessage: 'Waiting for Wormhole network consensus . . .',
   },
 };

--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -204,6 +204,12 @@ export class BridgeRoute extends BaseRoute {
     const receipientChainName = wh.toChainName(receipientChain);
     const sourceGasToken = CHAINS[sendingChainName]?.gasToken;
     const destinationGasToken = CHAINS[receipientChainName]?.gasToken;
+    const sourceGasTokenSymbol = sourceGasToken
+      ? TOKENS[sourceGasToken].symbol
+      : '';
+    const destinationGasTokenSymbol = destinationGasToken
+      ? TOKENS[destinationGasToken].symbol
+      : '';
     return [
       {
         title: 'Amount',
@@ -213,19 +219,19 @@ export class BridgeRoute extends BaseRoute {
         title: 'Total fee estimates',
         value:
           sendingGasEst && claimingGasEst
-            ? `${sendingGasEst} ${sourceGasToken} & ${claimingGasEst} ${destinationGasToken}`
+            ? `${sendingGasEst} ${sourceGasTokenSymbol} & ${claimingGasEst} ${destinationGasTokenSymbol}`
             : '',
         rows: [
           {
             title: 'Source chain gas estimate',
             value: sendingGasEst
-              ? `~ ${sendingGasEst} ${sourceGasToken}`
+              ? `~ ${sendingGasEst} ${sourceGasTokenSymbol}`
               : 'Not available',
           },
           {
             title: 'Destination chain gas estimate',
             value: claimingGasEst
-              ? `~ ${claimingGasEst} ${destinationGasToken}`
+              ? `~ ${claimingGasEst} ${destinationGasTokenSymbol}`
               : 'Not available',
           },
         ],

--- a/wormhole-connect/src/utils/routes/cctpManual.ts
+++ b/wormhole-connect/src/utils/routes/cctpManual.ts
@@ -441,7 +441,12 @@ export class CCTPManualRoute extends BaseRoute {
     const receipientChainName = wh.toChainName(receipientChain);
     const sourceGasToken = CHAINS[sendingChainName]?.gasToken;
     const destinationGasToken = CHAINS[receipientChainName]?.gasToken;
-
+    const sourceGasTokenSymbol = sourceGasToken
+      ? TOKENS[sourceGasToken].symbol
+      : '';
+    const destinationGasTokenSymbol = destinationGasToken
+      ? TOKENS[destinationGasToken].symbol
+      : '';
     return [
       {
         title: 'Amount',
@@ -451,19 +456,19 @@ export class CCTPManualRoute extends BaseRoute {
         title: 'Total fee estimates',
         value:
           sendingGasEst && claimingGasEst
-            ? `${sendingGasEst} ${sourceGasToken} & ${claimingGasEst} ${destinationGasToken}`
+            ? `${sendingGasEst} ${sourceGasTokenSymbol} & ${claimingGasEst} ${destinationGasTokenSymbol}`
             : '',
         rows: [
           {
             title: 'Source chain gas estimate',
             value: sendingGasEst
-              ? `~ ${sendingGasEst} ${sourceGasToken}`
+              ? `~ ${sendingGasEst} ${sourceGasTokenSymbol}`
               : 'Not available',
           },
           {
             title: 'Destination chain gas estimate',
             value: claimingGasEst
-              ? `~ ${claimingGasEst} ${destinationGasToken}`
+              ? `~ ${claimingGasEst} ${destinationGasTokenSymbol}`
               : 'Not available',
           },
         ],

--- a/wormhole-connect/src/utils/routes/cctpRelay.ts
+++ b/wormhole-connect/src/utils/routes/cctpRelay.ts
@@ -318,7 +318,12 @@ export class CCTPRelayRoute extends CCTPManualRoute {
     const sourceGasToken = CHAINS[sendingChainName]?.gasToken;
     const destinationGasToken = CHAINS[receipientChainName]?.gasToken;
     const { relayerFee, receiveNativeAmt } = routeOptions;
-
+    const sourceGasTokenSymbol = sourceGasToken
+      ? TOKENS[sourceGasToken].symbol
+      : '';
+    const destinationGasTokenSymbol = destinationGasToken
+      ? TOKENS[destinationGasToken].symbol
+      : '';
     const isNative = token.symbol === sourceGasToken;
 
     let totalFeesText = '';
@@ -329,7 +334,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
       );
       totalFeesText = isNative
         ? `${fee} ${token.symbol}`
-        : `${sendingGasEst} ${sourceGasToken} & ${fee} ${token.symbol}`;
+        : `${sendingGasEst} ${sourceGasTokenSymbol} & ${fee} ${token.symbol}`;
     }
 
     const receiveAmt = await this.computeReceiveAmount(amount, routeOptions);
@@ -343,7 +348,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
         title: 'Native gas on destination',
         value:
           receiveNativeAmt !== undefined
-            ? `${receiveNativeAmt} ${destinationGasToken}`
+            ? `${receiveNativeAmt} ${destinationGasTokenSymbol}`
             : NO_INPUT,
       },
       {
@@ -353,7 +358,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
           {
             title: 'Source chain gas estimate',
             value: sendingGasEst
-              ? `~ ${sendingGasEst} ${sourceGasToken}`
+              ? `~ ${sendingGasEst} ${sourceGasTokenSymbol}`
               : NO_INPUT,
           },
           {

--- a/wormhole-connect/src/utils/routes/cctpRelay.ts
+++ b/wormhole-connect/src/utils/routes/cctpRelay.ts
@@ -322,7 +322,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
     const isNative = token.symbol === sourceGasToken;
 
     let totalFeesText = '';
-    if (sendingGasEst && relayerFee) {
+    if (sendingGasEst && relayerFee !== undefined) {
       const fee = toFixedDecimals(
         `${relayerFee + (isNative ? sendingGasEst : 0)}`,
         6,
@@ -358,7 +358,10 @@ export class CCTPRelayRoute extends CCTPManualRoute {
           },
           {
             title: 'Relayer fee',
-            value: relayerFee ? `${relayerFee} ${token.symbol}` : NO_INPUT,
+            value:
+              relayerFee !== undefined
+                ? `${relayerFee} ${token.symbol}`
+                : NO_INPUT,
           },
         ],
       },

--- a/wormhole-connect/src/utils/routes/cctpRelay.ts
+++ b/wormhole-connect/src/utils/routes/cctpRelay.ts
@@ -342,7 +342,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
       {
         title: 'Native gas on destination',
         value:
-          receiveNativeAmt > 0
+          receiveNativeAmt !== undefined
             ? `${receiveNativeAmt} ${destinationGasToken}`
             : NO_INPUT,
       },

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -388,7 +388,9 @@ export class CosmosGatewayRoute extends BaseRoute {
   ): Promise<TransferDisplayData> {
     const sendingChainName = wh.toChainName(sendingChain);
     const sourceGasToken = CHAINS[sendingChainName]?.gasToken;
-
+    const sourceGasTokenSymbol = sourceGasToken
+      ? TOKENS[sourceGasToken].symbol
+      : '';
     return [
       {
         title: 'Amount',
@@ -396,11 +398,13 @@ export class CosmosGatewayRoute extends BaseRoute {
       },
       {
         title: 'Total fee estimates',
-        value: `${sendingGasEst} ${sourceGasToken}`,
+        value: `${sendingGasEst} ${sourceGasTokenSymbol}`,
         rows: [
           {
             title: 'Source chain gas estimate',
-            value: sendingGasEst ? `~ ${sendingGasEst} ${sourceGasToken}` : '—',
+            value: sendingGasEst
+              ? `~ ${sendingGasEst} ${sourceGasTokenSymbol}`
+              : '—',
           },
         ],
       },

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -311,7 +311,7 @@ export class RelayRoute extends BridgeRoute {
     const isNative = token.symbol === sourceGasToken;
 
     let totalFeesText = '';
-    if (sendingGasEst && relayerFee) {
+    if (sendingGasEst && relayerFee !== undefined) {
       const fee = toFixedDecimals(
         `${relayerFee + (isNative ? Number.parseFloat(sendingGasEst) : 0)}`,
         6,
@@ -347,7 +347,10 @@ export class RelayRoute extends BridgeRoute {
           },
           {
             title: 'Relayer fee',
-            value: relayerFee ? `${relayerFee} ${token.symbol}` : NO_INPUT,
+            value:
+              relayerFee !== undefined
+                ? `${relayerFee} ${token.symbol}`
+                : NO_INPUT,
           },
         ],
       },

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -307,6 +307,12 @@ export class RelayRoute extends BridgeRoute {
     const receipientChainName = wh.toChainName(receipientChain);
     const sourceGasToken = CHAINS[sendingChainName]?.gasToken;
     const destinationGasToken = CHAINS[receipientChainName]?.gasToken;
+    const sourceGasTokenSymbol = sourceGasToken
+      ? TOKENS[sourceGasToken].symbol
+      : '';
+    const destinationGasTokenSymbol = destinationGasToken
+      ? TOKENS[destinationGasToken].symbol
+      : '';
     const { relayerFee, receiveNativeAmt } = routeOptions;
     const isNative = token.symbol === sourceGasToken;
 
@@ -318,7 +324,7 @@ export class RelayRoute extends BridgeRoute {
       );
       totalFeesText = isNative
         ? `${fee} ${token.symbol}`
-        : `${sendingGasEst} ${sourceGasToken} & ${fee} ${token.symbol}`;
+        : `${sendingGasEst} ${sourceGasTokenSymbol} & ${fee} ${token.symbol}`;
     }
 
     const receiveAmt = await this.computeReceiveAmount(amount, routeOptions);
@@ -332,7 +338,7 @@ export class RelayRoute extends BridgeRoute {
         title: 'Native gas on destination',
         value:
           receiveNativeAmt !== undefined
-            ? `${receiveNativeAmt} ${destinationGasToken}`
+            ? `${receiveNativeAmt} ${destinationGasTokenSymbol}`
             : NO_INPUT,
       },
       {
@@ -342,7 +348,7 @@ export class RelayRoute extends BridgeRoute {
           {
             title: 'Source chain gas estimate',
             value: sendingGasEst
-              ? `~ ${sendingGasEst} ${sourceGasToken}`
+              ? `~ ${sendingGasEst} ${sourceGasTokenSymbol}`
               : NO_INPUT,
           },
           {

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -331,7 +331,7 @@ export class RelayRoute extends BridgeRoute {
       {
         title: 'Native gas on destination',
         value:
-          receiveNativeAmt > 0
+          receiveNativeAmt !== undefined
             ? `${receiveNativeAmt} ${destinationGasToken}`
             : NO_INPUT,
       },

--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -86,7 +86,8 @@ interface ThumbProps extends React.HTMLAttributes<unknown> {}
 
 function formatAmount(amount?: number): number {
   if (!amount) return 0;
-  const formatted = toFixedDecimals(`${amount}`, 6);
+  let formatted = toFixedDecimals(`${amount}`, 6);
+  if (amount < 0.000001) formatted = '0';
   return Number.parseFloat(formatted);
 }
 
@@ -271,6 +272,7 @@ function GasSlider(props: { disabled: boolean }) {
       setState((prevState) => ({
         ...prevState,
         nativeGas: formattedNativeAmt,
+        token: formatAmount(Number.parseFloat(amount) - debouncedSwapAmt),
       }));
     })();
     return () => {

--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -287,6 +287,7 @@ function GasSlider(props: { disabled: boolean }) {
     receivingToken,
     toNetwork,
     route,
+    amount,
   ]);
 
   const banner = !props.disabled && (

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -20,7 +20,6 @@ import TokenIcon from '../../icons/TokenIcons';
 import ArrowRightIcon from '../../icons/ArrowRight';
 import Options from '../../components/Options';
 import { isCosmWasmChain } from '../../utils/cosmos';
-import { BigNumber } from 'ethers';
 
 const useStyles = makeStyles()((theme: any) => ({
   link: {

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -12,12 +12,15 @@ import { isTransferValid } from '../../utils/transferValidation';
 import { toFixedDecimals } from '../../utils/balance';
 import { TOKENS } from '../../config';
 import { ROUTES, RouteData } from '../../config/routes';
-
+import { getTokenDecimals } from '../../utils';
+import { toDecimals } from '../../utils/balance';
+import { toChainId } from '../../utils/sdk';
 import BridgeCollapse, { CollapseControlStyle } from './Collapse';
 import TokenIcon from '../../icons/TokenIcons';
 import ArrowRightIcon from '../../icons/ArrowRight';
 import Options from '../../components/Options';
 import { isCosmWasmChain } from '../../utils/cosmos';
+import { BigNumber } from 'ethers';
 
 const useStyles = makeStyles()((theme: any) => ({
   link: {
@@ -140,30 +143,48 @@ function Tag(props: TagProps) {
   );
 }
 
-function RouteOption(props: { route: RouteData }) {
+function RouteOption(props: { route: RouteData; active: boolean }) {
   const { classes } = useStyles();
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
-  const { token, destToken, amount, toNetwork } = useSelector(
+  const { token, destToken, amount, fromNetwork, toNetwork } = useSelector(
     (state: RootState) => state.transferInput,
   );
-  const { toNativeToken, relayerFee } = useSelector(
-    (state: RootState) => state.relay,
-  );
+  const { toNativeToken } = useSelector((state: RootState) => state.relay);
   const [receiveAmt, setReceiveAmt] = useState<number | undefined>(undefined);
-
+  const [relayerFee, setRelayerFee] = useState<number>(0);
+  useEffect(() => {
+    async function getFee() {
+      if (!fromNetwork || !toNetwork) return;
+      try {
+        const fee = await new Operator().getRelayerFee(
+          props.route.route,
+          fromNetwork,
+          toNetwork,
+          token,
+        );
+        const decimals = getTokenDecimals(
+          toChainId(fromNetwork),
+          TOKENS[token].tokenId || 'native',
+        );
+        const formattedFee = Number.parseFloat(toDecimals(fee, decimals, 6));
+        setRelayerFee(formattedFee);
+      } catch {}
+    }
+    getFee();
+  }, [fromNetwork, toNetwork, token, props.route.route]);
   useEffect(() => {
     async function load() {
       const operator = new Operator();
       const receiveAmt = await operator.computeReceiveAmount(
         props.route.route,
         Number.parseFloat(amount),
-        { toNativeToken, relayerFee },
+        { toNativeToken: props.active ? toNativeToken : 0, relayerFee },
       );
       setReceiveAmt(Number.parseFloat(toFixedDecimals(`${receiveAmt}`, 6)));
     }
     load();
-  }, [props.route, amount, toNativeToken, relayerFee]);
+  }, [props.route, amount, toNativeToken, relayerFee, props.active]);
   const fromTokenConfig = TOKENS[token];
   const fromTokenIcon = fromTokenConfig && (
     <TokenIcon name={fromTokenConfig.icon} height={20} />
@@ -291,10 +312,12 @@ function RouteOptions() {
           collapsable
           collapsed={collapsed}
         >
-          {availableRoutes.map((route) => {
+          {availableRoutes.map((route_) => {
             return {
-              key: route,
-              child: <RouteOption route={ROUTES[route]} />,
+              key: route_,
+              child: (
+                <RouteOption route={ROUTES[route_]} active={route_ === route} />
+              ),
             };
           })}
         </Options>

--- a/wormhole-connect/src/views/Redeem/Confirmations.tsx
+++ b/wormhole-connect/src/views/Redeem/Confirmations.tsx
@@ -2,10 +2,13 @@ import { LinearProgress, linearProgressClasses } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import React, { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
 import { CHAINS } from '../../config';
 import { getCurrentBlock } from '../../utils/sdk';
+import { ROUTES } from '../../config/routes';
+import { RootState } from '../../store';
 
 const BorderLinearProgress = styled(LinearProgress)(({ theme }: any) => ({
   borderRadius: 5,
@@ -42,6 +45,9 @@ function Confirmations(props: Props) {
   const chainConfig = CHAINS[chain]!;
   const requiredHeight = blockHeight + chainConfig.finalityThreshold;
   const [currentBlock, setCurrentBlock] = useState(0);
+
+  const { route } = useSelector((state: RootState) => state.redeem);
+  console.log(`ROUTE: ${route}`);
 
   useEffect(() => {
     if (chainConfig.finalityThreshold === 0) {
@@ -84,7 +90,7 @@ function Confirmations(props: Props) {
             {confirmations} / {chainConfig.finalityThreshold} Confirmations
           </>
         ) : (
-          'Waiting for Wormhole Network consensus . . .'
+          ROUTES[route].pendingMessage
         )}
       </div>
     </div>

--- a/wormhole-connect/src/views/Redeem/Confirmations.tsx
+++ b/wormhole-connect/src/views/Redeem/Confirmations.tsx
@@ -47,7 +47,6 @@ function Confirmations(props: Props) {
   const [currentBlock, setCurrentBlock] = useState(0);
 
   const { route } = useSelector((state: RootState) => state.redeem);
-  console.log(`ROUTE: ${route}`);
 
   useEffect(() => {
     if (chainConfig.finalityThreshold === 0) {


### PR DESCRIPTION
Fixes #928 - the issue was just that it was rounding to 0, and then being shown as '-'
Fixes #926 - the issue was (also) just that it was rounding to 0, and then being shown as '-'
Fixes the issue of showing 'ETHarbitrum/ETHbase' - now correctly shows 'ETH'
Fixes the 'AVAX'/'WAVAX' issue of 'WAVAX' showing when 'AVAX' is supposed to show
Fixes #923 - the issue was the relayer fee was being drawn from state meaning it was always the same for each route
Adds a custom message per route when it is waiting for consensus (note - I left the custom message to be 'Waiting for Wormhole Network consensus' for non cctp routes - feel free to change this)

Doesn't fix #930 but perhaps this is not an issue? I think it is actually desirable to be able to edit the 'to' amount - currently it calculates the correct amount to put in the from field to match what you put into the 'to' field if you do edit it