### PR TITLE
Disable native eth arbitrum

### DIFF
--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -55,6 +55,14 @@ export class BridgeRoute extends BaseRoute {
       return false;
     // TODO: probably not true for Solana
     if (destToken === 'native') return false;
+
+    // Special case: Native eth cannot be sent on arbitrum
+    if (
+      (sourceToken === 'ETHarbitrum' || sourceToken === 'native') &&
+      (sourceChain === 'arbitrum' || sourceChain === 'arbitrumgoerli')
+    )
+      return false;
+
     if (!!sourceTokenConfig.tokenId && sourceToken === destToken) return true;
     if (
       !sourceTokenConfig.tokenId &&


### PR DESCRIPTION
addresses the latter issue in #827 (not the former one)

The problem is that there is no 'WETH' contract set on arbitrum token bridge. So, this should be disabled in the Bridge route.