### PR TITLE
Fix for #975 - Decimals of native gas token fix

### DIFF
--- a/wormhole-connect/src/config/mainnet/chains.ts
+++ b/wormhole-connect/src/config/mainnet/chains.ts
@@ -42,7 +42,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     displayName: 'Avalanche',
     explorerUrl: 'https://snowtrace.io/',
     explorerName: 'Snowtrace',
-    gasToken: 'WAVAX',
+    gasToken: 'AVAX',
     chainId: 43114,
     icon: Icon.AVAX,
     automaticRelayer: true,

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -395,7 +395,7 @@ export const MAINNET_TOKENS: TokensConfig = {
   },
   ETHarbitrum: {
     key: 'ETHarbitrum',
-    symbol: 'ETH',
+    symbol: 'ETH (Arbitrum)',
     nativeChain: 'arbitrum',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -408,7 +408,7 @@ export const MAINNET_TOKENS: TokensConfig = {
   },
   WETHarbitrum: {
     key: 'WETHarbitrum',
-    symbol: 'WETH',
+    symbol: 'WETH (Arbitrum)',
     nativeChain: 'arbitrum',
     icon: Icon.ETH,
     tokenId: {
@@ -439,7 +439,7 @@ export const MAINNET_TOKENS: TokensConfig = {
   },
   ETHoptimism: {
     key: 'ETHoptimism',
-    symbol: 'ETH',
+    symbol: 'ETH (Optimism)',
     nativeChain: 'optimism',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -452,7 +452,7 @@ export const MAINNET_TOKENS: TokensConfig = {
   },
   WETHoptimism: {
     key: 'WETHoptimism',
-    symbol: 'WETH',
+    symbol: 'WETH (Optimism)',
     nativeChain: 'optimism',
     icon: Icon.ETH,
     tokenId: {
@@ -499,7 +499,7 @@ export const MAINNET_TOKENS: TokensConfig = {
 
   ETHbase: {
     key: 'ETHbase',
-    symbol: 'ETH',
+    symbol: 'ETH (Base)',
     nativeChain: 'base',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -512,7 +512,7 @@ export const MAINNET_TOKENS: TokensConfig = {
   },
   WETHbase: {
     key: 'WETHbase',
-    symbol: 'WETH',
+    symbol: 'WETH (Base)',
     nativeChain: 'base',
     icon: Icon.ETH,
     tokenId: {

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -363,7 +363,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   ETHarbitrum: {
     key: 'ETHarbitrum',
-    symbol: 'ETH',
+    symbol: 'ETH (Arbitrum)',
     nativeChain: 'arbitrumgoerli',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -376,7 +376,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   WETHarbitrum: {
     key: 'WETHarbitrum',
-    symbol: 'WETH',
+    symbol: 'WETH (Arbitrum)',
     nativeChain: 'arbitrumgoerli',
     icon: Icon.ETH,
     tokenId: {
@@ -407,7 +407,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   ETHoptimism: {
     key: 'ETHoptimism',
-    symbol: 'ETH',
+    symbol: 'ETH (Optimism)',
     nativeChain: 'optimismgoerli',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -420,7 +420,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   WETHoptimism: {
     key: 'WETHoptimism',
-    symbol: 'WETH',
+    symbol: 'WETH (Optimism)',
     nativeChain: 'optimismgoerli',
     icon: Icon.ETH,
     tokenId: {
@@ -451,7 +451,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   ETHbase: {
     key: 'ETHbase',
-    symbol: 'ETH',
+    symbol: 'ETH (Base)',
     nativeChain: 'basegoerli',
     icon: Icon.ETH,
     coinGeckoId: 'ethereum',
@@ -464,7 +464,7 @@ export const TESTNET_TOKENS: TokensConfig = {
   },
   WETHbase: {
     key: 'WETHbase',
-    symbol: 'WETH',
+    symbol: 'WETH (Base)',
     nativeChain: 'basegoerli',
     icon: Icon.ETH,
     tokenId: {

--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -106,7 +106,17 @@ export function getTokenDecimals(
   }
 
   const tokenConfig = getTokenById(tokenId);
-  if (!tokenConfig) throw new Error('token config not found');
+  if (!tokenConfig) {
+    console.log(
+      `Looking up token ${
+        tokenId ? tokenId.address : 'native'
+      } on chain ${chain} - the token's native chain is ${
+        tokenId ? tokenId.chain : 'native'
+      }`,
+    );
+    console.log(JSON.stringify(tokenId));
+    throw new Error('token config not found');
+  }
 
   const decimals = tokenConfig.decimals;
   return decimals[chainConfig.context] || decimals.default;

--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -309,11 +309,11 @@ export class BridgeRoute extends BaseRoute {
       txData.tokenDecimals,
       MAX_DECIMALS,
     );
-    const { gasToken: sourceGasTokenSymbol } = CHAINS[txData.fromChain]!;
-    const sourceGasToken = TOKENS[sourceGasTokenSymbol];
+    const { gasToken: sourceGasTokenKey } = CHAINS[txData.fromChain]!;
+    const sourceGasToken = TOKENS[sourceGasTokenKey];
     const decimals = getTokenDecimals(
       toChainId(sourceGasToken.nativeChain),
-      sourceGasToken.tokenId,
+      'native',
     );
     const formattedGas =
       txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
@@ -327,7 +327,7 @@ export class BridgeRoute extends BaseRoute {
       {
         title: 'Gas fee',
         value: formattedGas
-          ? `${formattedGas} ${sourceGasTokenSymbol}`
+          ? `${formattedGas} ${sourceGasToken.symbol}`
           : NO_INPUT,
       },
     ];

--- a/wormhole-connect/src/utils/routes/cctpManual.ts
+++ b/wormhole-connect/src/utils/routes/cctpManual.ts
@@ -582,11 +582,11 @@ export class CCTPManualRoute extends BaseRoute {
       txData.tokenDecimals,
       MAX_DECIMALS,
     );
-    const { gasToken: sourceGasTokenSymbol } = CHAINS[txData.fromChain]!;
-    const sourceGasToken = TOKENS[sourceGasTokenSymbol];
+    const { gasToken: sourceGasTokenKey } = CHAINS[txData.fromChain]!;
+    const sourceGasToken = TOKENS[sourceGasTokenKey];
     const decimals = getTokenDecimals(
       toChainId(sourceGasToken.nativeChain),
-      sourceGasToken.tokenId,
+      'native',
     );
     const formattedGas =
       txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
@@ -600,7 +600,7 @@ export class CCTPManualRoute extends BaseRoute {
       {
         title: 'Gas fee',
         value: formattedGas
-          ? `${formattedGas} ${sourceGasTokenSymbol}`
+          ? `${formattedGas} ${sourceGasToken.symbol}`
           : NO_INPUT,
       },
     ];

--- a/wormhole-connect/src/utils/routes/cctpRelay.ts
+++ b/wormhole-connect/src/utils/routes/cctpRelay.ts
@@ -14,7 +14,6 @@ import {
   getTokenDecimals,
   toNormalizedDecimals,
   fromNormalizedDecimals,
-  getWrappedTokenId,
   getTokenById,
 } from 'utils';
 import {
@@ -501,7 +500,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
     const sourceGasToken = TOKENS[sourceGasTokenSymbol];
     const decimals = getTokenDecimals(
       toChainId(sourceGasToken.nativeChain),
-      sourceGasToken.tokenId,
+      'native',
     );
     const formattedGas =
       txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
@@ -536,7 +535,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
       },
       {
         title: 'Convert to native gas token',
-        value: `≈ ${formattedToNative} ${token.symbol} \u2192 ${gasToken}`,
+        value: `≈ ${formattedToNative} ${token.symbol} \u2192 ${TOKENS[gasToken].symbol}`,
       },
     ];
   }
@@ -552,7 +551,6 @@ export class CCTPRelayRoute extends CCTPManualRoute {
 
     // calculate the amount of native gas received
     let nativeGasAmt: string | undefined;
-    const nativeGasToken = TOKENS[gasToken];
     if (receiveTx) {
       let nativeSwapAmount: any;
       try {
@@ -563,7 +561,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
       if (nativeSwapAmount) {
         const decimals = getTokenDecimals(
           wh.toChainId(txData.toChain),
-          nativeGasToken.tokenId,
+          'native',
         );
         nativeGasAmt = toDecimals(nativeSwapAmount, decimals, MAX_DECIMALS);
       }
@@ -588,7 +586,7 @@ export class CCTPRelayRoute extends CCTPManualRoute {
       // get the decimals on the target chain
       const nativeGasTokenDecimals = getTokenDecimals(
         wh.toChainId(txData.toChain),
-        getWrappedTokenId(nativeGasToken),
+        'native',
       );
       nativeGasAmt = toDecimals(
         amount.toString(),

--- a/wormhole-connect/src/utils/routes/cosmosGateway.ts
+++ b/wormhole-connect/src/utils/routes/cosmosGateway.ts
@@ -650,11 +650,11 @@ export class CosmosGatewayRoute extends BaseRoute {
       txData.tokenDecimals,
       MAX_DECIMALS,
     );
-    const { gasToken: sourceGasTokenSymbol } = CHAINS[txData.fromChain]!;
-    const sourceGasToken = TOKENS[sourceGasTokenSymbol];
+    const { gasToken: sourceGasTokenKey } = CHAINS[txData.fromChain]!;
+    const sourceGasToken = TOKENS[sourceGasTokenKey];
     const decimals = getTokenDecimals(
       toChainId(sourceGasToken.nativeChain),
-      sourceGasToken.tokenId,
+      'native',
     );
     const formattedGas =
       txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
@@ -667,7 +667,7 @@ export class CosmosGatewayRoute extends BaseRoute {
       },
       {
         title: 'Gas fee',
-        value: formattedGas ? `${formattedGas} ${sourceGasTokenSymbol}` : '—',
+        value: formattedGas ? `${formattedGas} ${sourceGasToken.symbol}` : '—',
       },
     ];
   }

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -436,11 +436,11 @@ export class RelayRoute extends BridgeRoute {
       txData.tokenDecimals,
       MAX_DECIMALS,
     );
-    const { gasToken: sourceGasTokenSymbol } = CHAINS[txData.fromChain]!;
-    const sourceGasToken = TOKENS[sourceGasTokenSymbol];
+    const { gasToken: sourceGasTokenKey } = CHAINS[txData.fromChain]!;
+    const sourceGasToken = TOKENS[sourceGasTokenKey];
     const decimals = getTokenDecimals(
       toChainId(sourceGasToken.nativeChain),
-      sourceGasToken.tokenId,
+      'native',
     );
     const formattedGas =
       txData.gasFee && toDecimals(txData.gasFee, decimals, MAX_DECIMALS);
@@ -466,7 +466,7 @@ export class RelayRoute extends BridgeRoute {
       {
         title: 'Gas fee',
         value: formattedGas
-          ? `${formattedGas} ${sourceGasTokenSymbol}`
+          ? `${formattedGas} ${sourceGasToken.symbol}`
           : NO_INPUT,
       },
       {
@@ -475,7 +475,7 @@ export class RelayRoute extends BridgeRoute {
       },
       {
         title: 'Convert to native gas token',
-        value: `≈ ${formattedToNative} ${token.symbol} \u2192 ${gasToken}`,
+        value: `≈ ${formattedToNative} ${token.symbol} \u2192 ${TOKENS[gasToken].symbol}`,
       },
     ];
   }

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -101,7 +101,7 @@ function Bridge() {
         throw new Error('Could not get native gas token config');
       const decimals = getTokenDecimals(
         toChainId(tokenConfig.nativeChain),
-        tokenConfig.tokenId,
+        'native',
       );
       dispatch(setReceiverNativeBalance(toDecimals(res, decimals, 6)));
     });

--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -9,7 +9,7 @@ import { useDebounce } from 'use-debounce';
 import { CHAINS, TOKENS } from 'config';
 import { TokenConfig, Route } from 'config/types';
 import { RoutesConfig } from 'config/routes';
-import { getTokenDecimals, getWrappedTokenId } from 'utils';
+import { getTokenDecimals } from 'utils';
 import { wh } from 'utils/sdk';
 import { getConversion, toDecimals, toFixedDecimals } from 'utils/balance';
 import RouteOperator from 'utils/routes/operator';
@@ -258,10 +258,9 @@ function GasSlider(props: { disabled: boolean }) {
         receivingWallet.address,
       );
       if (cancelled) return;
-      const nativeGasTokenId = getWrappedTokenId(nativeGasToken);
       const nativeGasTokenToChainDecimals = getTokenDecimals(
         wh.toChainId(toChain!),
-        nativeGasTokenId,
+        'native',
       );
       const formattedNativeAmt = Number.parseFloat(
         toDecimals(nativeGasAmt.toString(), nativeGasTokenToChainDecimals, 6),


### PR DESCRIPTION
The problem was in various places, we requested the 'decimals' of the 'gas token'

When USDC is the only thing enabled, we can't get the decimals of the gas token - hence errors + disappearing things

fixes #975 