### PR TITLE
Refactor: get redeem tx logic

### DIFF
--- a/wormhole-connect/src/utils/routes/bridge.ts
+++ b/wormhole-connect/src/utils/routes/bridge.ts
@@ -33,7 +33,7 @@ import {
   TransferInfoBaseParams,
 } from './types';
 import { isCosmWasmChain } from '../cosmos';
-import { fetchVaa } from '../vaa';
+import { fetchGlobalTx, fetchVaa } from '../vaa';
 import { formatGasFee } from './utils';
 
 export class BridgeRoute extends BaseRoute {
@@ -400,6 +400,11 @@ export class BridgeRoute extends BaseRoute {
   }
 
   async tryFetchRedeemTx(txData: UnsignedMessage): Promise<string | undefined> {
-    return undefined; // only for automatic routes
+    try {
+      return await fetchGlobalTx(txData);
+    } catch (_) {
+      // There is no redeem event emitted for Token Bridge transfers, so return undefined
+      return undefined;
+    }
   }
 }

--- a/wormhole-connect/src/utils/routes/cctpRelay.ts
+++ b/wormhole-connect/src/utils/routes/cctpRelay.ts
@@ -666,12 +666,11 @@ export class CCTPRelayRoute extends CCTPManualRoute {
   async tryFetchRedeemTx(
     txData: RelayCCTPMessage,
   ): Promise<string | undefined> {
-    let redeemTx: string | undefined = undefined;
     try {
-      redeemTx = await fetchRedeemedEvent(txData);
-    } catch {}
-
-    return redeemTx;
+      return await fetchRedeemedEvent(txData);
+    } catch (_) {
+      return undefined;
+    }
   }
 }
 

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -577,23 +577,11 @@ export class RelayRoute extends BridgeRoute {
     ];
   }
 
-  // async tryFetchRedeemTx(message: SignedMessage): Promise<string | undefined> {
-  //   if (!isSignedWormholeMessage(message)) {
-  //     throw new Error('Signed message is not for relay');
-  //   }
-
-  //   // if this is an automatic transfer and the transaction hash was not found,
-  //   // then try to fetch the redeemed event
-  //   let redeemTx: string | undefined = undefined;
-  //   try {
-  //     const res = await fetchRedeemedEvent(message);
-  //     redeemTx = res?.transactionHash;
-  //   } catch {}
   async tryFetchRedeemEvent(
-    txData: SignedMessage,
+    message: SignedMessage,
   ): Promise<string | undefined> {
     try {
-      const res = await fetchRedeemedEvent(txData);
+      const res = await fetchRedeemedEvent(message);
       return res?.transactionHash;
     } catch (_) {
       return undefined;
@@ -605,11 +593,11 @@ export class RelayRoute extends BridgeRoute {
       throw new Error('Signed message is not for relay');
     }
     try {
-      const tx = await fetchGlobalTx(txData);
+      const tx = await fetchGlobalTx(message);
       if (!tx) throw new Error('Could not fetch global tx');
       return tx;
     } catch (_) {
-      return await this.tryFetchRedeemEvent(txData);
+      return await this.tryFetchRedeemEvent(message);
     }
   }
 }

--- a/wormhole-connect/src/utils/routes/relay.ts
+++ b/wormhole-connect/src/utils/routes/relay.ts
@@ -43,7 +43,7 @@ import {
   SignedMessage,
   TransferInfoBaseParams,
 } from './types';
-import { fetchRelayGlobalTx, fetchVaa } from '../vaa';
+import { fetchGlobalTx, fetchVaa } from '../vaa';
 
 export type RelayOptions = {
   relayerFee?: number;

--- a/wormhole-connect/src/utils/routes/routeAbstract.ts
+++ b/wormhole-connect/src/utils/routes/routeAbstract.ts
@@ -12,7 +12,6 @@ import {
   TransferDisplayData,
   TransferInfoBaseParams,
 } from './types';
-import { ParsedRelayerMessage, ParsedMessage } from 'utils/sdk';
 
 export default abstract class RouteAbstract {
   abstract readonly NATIVE_GAS_DROPOFF_SUPPORTED: boolean;
@@ -172,6 +171,6 @@ export default abstract class RouteAbstract {
   ): Promise<BigNumber>;
 
   abstract tryFetchRedeemTx(
-    txData: ParsedMessage | ParsedRelayerMessage,
+    txData: UnsignedMessage,
   ): Promise<string | undefined>;
 }

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -254,23 +254,3 @@ export const fetchGlobalTx = async (
       throw error;
     });
 };
-
-export const fetchRelayGlobalTx = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
-): Promise<string | undefined> => {
-  const messageId = getEmitterAndSequence(txData);
-  const { emitterChain, emitterAddress, sequence } = messageId;
-
-  const url = `${WORMHOLE_API}api/v1/relays/${emitterChain}/${emitterAddress}/${sequence}`;
-  return axios
-    .get(url)
-    .then(function (response: any) {
-      const data = response.data;
-      console.log(response.data);
-      if (!data || !data.toTxHash) return undefined;
-      return data.toTxHash;
-    })
-    .catch(function (error) {
-      throw error;
-    });
-};

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -12,6 +12,7 @@ import {
   isEvmChain,
   wh,
 } from './sdk';
+import { SignedMessage, UnsignedMessage } from './routes';
 
 export const WORMHOLE_RPC_HOSTS =
   ENV === 'MAINNET'
@@ -237,9 +238,9 @@ export const fetchIsVAAEnqueued = async (
 };
 
 export const fetchGlobalTx = async (
-  txData: ParsedMessage | ParsedRelayerMessage,
+  message: UnsignedMessage | SignedMessage,
 ): Promise<string | undefined> => {
-  const messageId = getEmitterAndSequence(txData);
+  const messageId = getEmitterAndSequence(message);
   const { emitterChain, emitterAddress, sequence } = messageId;
 
   const url = `${WORMHOLE_API}api/v1/global-tx/${emitterChain}/${emitterAddress}/${sequence}`;

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -254,3 +254,23 @@ export const fetchGlobalTx = async (
       throw error;
     });
 };
+
+export const fetchRelayGlobalTx = async (
+  txData: ParsedMessage | ParsedRelayerMessage,
+): Promise<string | undefined> => {
+  const messageId = getEmitterAndSequence(txData);
+  const { emitterChain, emitterAddress, sequence } = messageId;
+
+  const url = `${WORMHOLE_API}api/v1/relays/${emitterChain}/${emitterAddress}/${sequence}`;
+  return axios
+    .get(url)
+    .then(function (response: any) {
+      const data = response.data;
+      console.log(response.data);
+      if (!data || !data.toTxHash) return undefined;
+      return data.toTxHash;
+    })
+    .catch(function (error) {
+      throw error;
+    });
+};


### PR DESCRIPTION
Pending #915 
Originally, the motivation was to use the new `/relays` endpoint from the wormholescan api.  However, I wonder if that might have been for generic relays, because I discovered that the regular endpoint actually now picks up token bridge relays as well.  Still, I think the refactor makes sense to move more of this logic into the routes