### PR TITLE
pre-populate foreign asset cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,18 @@ jobs:
       - run: npm ci
       - run: npm run build -w sdk
       - run: npm test -w wormhole-connect
+  check-token-list:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build -w sdk
+      - run: cd wormhole-connect && npx ts-node scripts/checkForeignAssetsConfig.ts
   build:
     runs-on: ubuntu-latest
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -19,6 +19,7 @@ export * from './contexts/aptos';
 export * from './contexts/sei';
 export * from './contexts/cosmos';
 export * from './abis';
+export * from './utils';
 
 export const CONFIG = {
   MAINNET: MAINNET_CONFIG,

--- a/sdk/src/wormhole.ts
+++ b/sdk/src/wormhole.ts
@@ -56,10 +56,14 @@ import { ForeignAssetCache } from './utils';
  * )
  */
 export class WormholeContext extends MultiProvider<Domain> {
-  private foreignAssetCache: ForeignAssetCache = new ForeignAssetCache();
+  private foreignAssetCache: ForeignAssetCache;
   readonly conf: WormholeConfig;
 
-  constructor(env: Environment, conf?: WormholeConfig) {
+  constructor(
+    env: Environment,
+    conf?: WormholeConfig,
+    foreignAssetCache?: ForeignAssetCache,
+  ) {
     super();
 
     if (conf) {
@@ -67,6 +71,8 @@ export class WormholeContext extends MultiProvider<Domain> {
     } else {
       this.conf = WormholeContext.getConfig(env);
     }
+
+    this.foreignAssetCache = foreignAssetCache || new ForeignAssetCache();
 
     this.registerProviders();
   }

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -29,6 +29,58 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      bsc: {
+        address: '0x4DB5a66E937A9F4473fA95b1cAF1d1E1D62E29EA',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x11CD37bb86F65419713f30673A480EA33c826872',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0x8b82A291F83ca07Af22120ABa21632088fC92931',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x2A126f043BDEBe5A0A9841c51915E562D9B07289',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x66803FB87aBd4aaC3cbB3fAd7C3aa01f6F3FB207',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xab3f0245B83feB11d15AAffeFD7AD465a59817eD',
+        decimals: 18,
+      },
+      solana: {
+        address: '7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xaf8cd5edc19c4512f4259f0bee101a40d41ebed738ade5874359610ef8eeced5::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xcc8a89c8dce9693d354449f1f73e60e14e347417854f029db5bc8e7454008abb::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x71b35ECb35104773537f849FBC353F81303A5860',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0xD8369C2EDA18dD6518eABb1F85BD60606dEb39Ec',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0xb47bC3ed6D70F04fe759b2529c9bc7377889678f',
+        decimals: 18,
+      },
+    },
   },
   USDCeth: {
     key: 'USDCeth',
@@ -43,6 +95,58 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#ffffff',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      bsc: {
+        address: '0xB04906e95AB5D797aDA81508115611fee694c2b3',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0x4318CB63A2b8edf2De971E2F17F77097e499459D',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0xB24CA28D4e2742907115fECda335b40dbda07a4C',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x2Ec752329c3EB419136ca5e4432Aa2CDb1eA23e6',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x37f750B7cC259A2f741AF45294f6a16572CF5cAd',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0x931715FEE2d06333043d11F658C8CE934aC61D0c',
+        decimals: 6,
+      },
+      solana: {
+        address: 'A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0x5d4b302506645c37ff133b98c4b50a5ae14841659738d6d733d59d0d217a93bf::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0x5e156f1207d0ebfa19a9eeff00d62a282278fb8719f4fab3a586a0a2c0fffbea::coin::T',
+        decimals: 6,
+      },
+      base: {
+        address: '0xec267C53f53807c2337C257f8AC3Fc3cC07cc0ed',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0xC96F2715E2a242d50D1b0bC923dbe1740b8eCf18',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0x711e53D031ea9B0bb0C24dD506df11b41AEA419e',
+        decimals: 6,
+      },
     },
   },
   WBTC: {
@@ -59,6 +163,58 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       default: 8,
     },
+    foreignAssets: {
+      bsc: {
+        address: '0x43359676E1A3F9FbB5de095333f8e9c1B46dFA44',
+        decimals: 8,
+      },
+      polygon: {
+        address: '0x5D49c278340655B56609FdF8976eb0612aF3a0C3',
+        decimals: 8,
+      },
+      avalanche: {
+        address: '0x1C0e79C5292c59bbC13C9F9f209D204cf4d65aD6',
+        decimals: 8,
+      },
+      fantom: {
+        address: '0x87e9E225aD8a0755B9958fd95BE43DD6A91FF3A7',
+        decimals: 8,
+      },
+      celo: {
+        address: '0xd71Ffd0940c920786eC4DbB5A12306669b5b81EF',
+        decimals: 8,
+      },
+      moonbeam: {
+        address: '0xE57eBd2d67B462E9926e04a8e33f01cD0D64346D',
+        decimals: 8,
+      },
+      solana: {
+        address: '3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x27792d9fed7f9844eb4839566001bb6f6cb4804f66aa2da6fe1ee242d896881::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xae478ff7d83ed072dbc5e264250e67ef58f57c99d89b447efd8a0a2e8b2be76e::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0xE6396f780b543dF16ee3b784D789c75B68319db0',
+        decimals: 8,
+      },
+      arbitrum: {
+        address: '0x397846a8078d4845c7f5c6Ca76aeBbcFDc044fAe',
+        decimals: 8,
+      },
+      optimism: {
+        address: '0xB214C19d81c99E75e84706a3aa0A757319023e26',
+        decimals: 8,
+      },
+    },
   },
   USDT: {
     key: 'USDT',
@@ -73,6 +229,54 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#ffffff',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      bsc: {
+        address: '0x524bC91Dc82d6b90EF29F76A3ECAaBAffFD490Bc',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0x9417669fBF23357D2774e9D421307bd5eA1006d2',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0x9d228444FC4B7E15A2C481b48E10247A03351FD8',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x14BCb86aEed6a74D3452550a25D37f1c30AA0A66',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x617f3112bf5397D0467D315cC709EF968D9ba546',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0xc30E9cA94CF52f3Bf5692aaCF81353a27052c46f',
+        decimals: 6,
+      },
+      solana: {
+        address: 'Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xc060006111016b8a020ad5b33834984a437aaa7d3c74c18e09a95d48aceab08c::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0xa2eda21a58856fda86451436513b867c97eecb4ba099da5775520e0f7492e852::coin::T',
+        decimals: 6,
+      },
+      base: {
+        address: '0xFf0C62A4979400841eFaA6faADb07Ac7d5C98b27',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0xE4728F3E48E94C6DA2B53610E677cc241DAFB134',
+        decimals: 6,
+      },
     },
   },
   DAI: {
@@ -90,6 +294,53 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      bsc: {
+        address: '0x3413a030EF81a3dD5a302F4B4D11d911e12ed337',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x732EB1747ecCFC431fF19bc359ffc83755B1918c',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0xca319f81D147559e19A522A0a0310Dd43A96cA0F',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xEE786D3D73Ea645365c7248E4e40eDba08B1169F',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x97926a82930bb7B33178E3c2f4ED1BFDc91A9FBF',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0x06e605775296e851FF43b4dAa541Bb0984E9D6fD',
+        decimals: 18,
+      },
+      solana: {
+        address: 'EjmyN6qEC1Tf1JxiG1ae7UTJhUxSwk1TCWNWqxWV4J6o',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x407a220699982ebb514568d007938d2447d33667e4418372ffec1ddb24491b6c::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x617Edadb51BfB43A44Bb91C7402129C23bA52381',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x5c4f2FEFB97F7DF09E762d95C83f0Ccf8bCe8234',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x098EA47D630b46df1E08e389e5e4466119c7dd30',
+        decimals: 18,
+      },
+    },
   },
   BUSD: {
     key: 'BUSD',
@@ -105,6 +356,33 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      bsc: {
+        address: '0x035de3679E692C471072d1A09bEb9298fBB2BD31',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x95ea750420da26bE1Ab0891e209e921bCd84763f',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x1dd42c0785ca90B677adc2ABad01dfc5ECcD0b4d',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xa2284e1F98E4d0B7Eb6a6b4f3C57f1b209C755F3',
+        decimals: 18,
+      },
+      solana: {
+        address: '33fsBLA8djQm82RpHmE3SuVrPGtZBWNYExsEUeKX1HXX',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x77400d2f56a01bad2d7c8c6fa282f62647ce3c03f43f2a8742e47ea01a91e24a::coin::T',
+        decimals: 8,
+      },
     },
   },
   MATIC: {
@@ -135,6 +413,54 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x7c9f4C87d911613Fe9ca58b579f737911AAD2D43',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0xc836d8dC361E44DbE64c4862D55BA041F88Ddd39',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0xf2f13f0B7008ab2FA4A2418F4ccC3684E49D20Eb',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xb88A6064B1F3FF5B9AE4A82fFD52560b0dF9FBD3',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x9C234706292b1144133ED509ccc5B3CD193BF712',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0x82DbDa803bb52434B1f4F41A6F0Acb1242A7dFa3',
+        decimals: 18,
+      },
+      solana: {
+        address: 'Gz7VkD4MacbEB6yC5XD3HcumEiYx2EtDYYrfikGsvopG',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xdbe380b13a6d0f5cdedd58de8f04625263f113b3f9db32b3e1983f49e2841676::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x6781088e2a1629d38eda521467af4a8ca7bfa7e5516338017940389595c85c0f::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0xc863399E5c5C4011B1DC3fB602902C77BA72B709',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x3ab0E28C3F56616aD7061b4db38aE337E3809AEA',
+        decimals: 18,
+      },
+    },
   },
   USDCpolygon: {
     key: 'USDCpolygon',
@@ -149,6 +475,54 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x566957eF80F9fd5526CD2BEF8BE67035C0b81130',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x672147dD47674757C457eB155BAA382cc10705Dd',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0x543672E9CBEC728CBBa9C3Ccd99ed80aC3607FA8',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x6e0e8cf6Ad151e1260A4D398faaEDFC450A9f00a',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x0E21B5BdFb6eDBa7d903a610d4DE2F8c72586017',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0x530E29eD727800e04bCd28B588775D50DE59097C',
+        decimals: 6,
+      },
+      solana: {
+        address: 'E2VmbootbVCBkMNNxKQgCLMS1X3NoGMaYAsufaAsf7M',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xcf72ec52c0f8ddead746252481fb44ff6e8485a39b803825bde6b00d77cdb0bb::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0xc7160b1c2415d19a88add188ec726e62aab0045f0aed798106a2ef2994a9101e::coin::T',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0x9A3Fba8a0870Fb9765023681DAa5390C7919C916',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0x8ab72605E48C1f70A20BdD2B3A217FEc24d777f9',
+        decimals: 6,
+      },
     },
   },
   BNB: {
@@ -179,6 +553,54 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x418D75f65a02b3D53B2418FB8E1fe493759c7605',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0xeCDCB5B88F8e3C15f95c720C51c71c9E2080525d',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0x442F7f22b1EE2c842bEAFf52880d4573E9201158',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xc033551e05907Ddd643AE14b6D4a9CA72BfF509B',
+        decimals: 18,
+      },
+      celo: {
+        address: '0xBf2554ce8A4D1351AFeB1aC3E5545AaF7591042d',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xE3b841C3f96e647E6dc01b468d6D0AD3562a9eeb',
+        decimals: 18,
+      },
+      solana: {
+        address: '9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xb848cce11ef3a8f62eccea6eb5b35a12c4c2b1ee1af7755d02d7bd6218e8226f::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x6312bc0a484bc4e37013befc9949df2d7c8a78e01c6fe14a34018449d136ba86::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x7fdAa50d7399ac436943028edA6ed9a1BD89509f',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x7AF00405916D823eDb1121546EfA6F4972B51b84',
+        decimals: 18,
+      },
+    },
   },
   USDCbnb: {
     key: 'USDCbnb',
@@ -194,6 +616,58 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x7cd167B101D2808Cfd2C45d17b2E7EA9F46b74B6',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x4B3a922c773BDCF3BA8f1A4FDAc2029E1D0E9868',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0x6145E8a910aE937913426BF32De2b26039728ACF',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x0FcbDAC44c67A43607D3E95886dB19871ADc985F',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x9d9abAE97a9344e3854527b4efbB366a1564bfEb',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0x7f433E22366E03a3758CE22cCf82887d828078f8',
+        decimals: 18,
+      },
+      solana: {
+        address: 'FCqfQSujuPxy6V42UvafBhsysWtEq1vhjfMN1PUbgaxA',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x909cba62ce96d54de25bec9502de5ca7b4f28901747bbf96b76c2e63ec5f1cba::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x79a6ed7a0607fdad2d18d67d1a0e552d4b09ebce5951f1e5c851732c02437595::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x68E2b07F92ed506f92935d7359ECA84D5342dbb4',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x1a0590F951bc9C3818Ce75ba5Bbe92831b2cf57e',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x1C15057d1F3794C934a6cBC1f7EceE934050F219',
+        decimals: 18,
+      },
     },
   },
   AVAX: {
@@ -224,6 +698,58 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x85f138bfEE4ef8e540890CFb48F620571d67Eda3',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x96412902aa9aFf61E13f085e70D3152C6ef2a817',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x7Bb11E7f8b10E9e571E5d8Eace04735fDFB2358a',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x358CE030DC6116Cc296E8B9F002728e65459C146',
+        decimals: 18,
+      },
+      celo: {
+        address: '0xFFdb274b4909fC2efE26C8e4Ddc9fe91963cAA4d',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xd4937A95BeC789CC1AE1640714C61c160279B22F',
+        decimals: 18,
+      },
+      solana: {
+        address: 'KgV1GvrHQmRBY8sHQQeUKwTm2r2h8t4C8qt12Cw1HVE',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x1e8b532cca6569cab9f9b9ebc73f8c13885012ade714729aa3b450e0339ac766::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x5b1bbc25524d41b17a95dac402cf2f584f56400bf5cc06b53c36b331b1ec6e8f::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0xc449A60A31E1eebFE83c42E9465fd4Dc318aE9a7',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x565609fAF65B92F7be02468acF86f8979423e514',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x8418C1d909842f458c9394886b83F19d62bF1A0D',
+        decimals: 18,
+      },
+    },
   },
   USDCavax: {
     key: 'USDCavax',
@@ -238,6 +764,54 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x39EbF69137D98FB7659Ef8D4ea21ec26394389d7',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0xc88Dc63bf0c8c8198C97Db0945E3eF25Ca89A8e4',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0xAEA5CC14DefbC1b845FDE729E563B717Ee6825ae',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0xEfE7701cb2B80664385Be226d0300912CA92f66A',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x62FFf2D2D1692D52eAf043AeeC727F7918d269D3',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0xd4918c40cA9f02d42Cb53d06587aF42017Bc345D',
+        decimals: 6,
+      },
+      solana: {
+        address: 'FHfba3ov5P3RjaiLVgh8FTv4oirxQDoVXuoUUDvHuXax',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xe596782fbaebef51ae99ffac8731aed98a80642b9dc193ed659c97fbc2cc0f84::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0x39d84c2af3b0c9895b45d4da098049e382c451ba63bec0ce0396ff7af4bb5dff::coin::T',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0x93e0FcbEd43CD6fC30DF00CcBD4669718dc74e77',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0x355f0a8a7ecAeD971b8Fbd50994558291ff2413a',
+        decimals: 6,
+      },
     },
   },
   FTM: {
@@ -268,6 +842,58 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x4cD2690d86284e044cb63E60F1EB218a825a7e92',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0xbF8413EE8612E0E4f66Aa63B5ebE27f3C5883d47',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x3726831304D77f585f1Aca9d9841cc3Ef80dAa62',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0xd19abc09B7b36F7558929b97a866f499a26c2f83',
+        decimals: 18,
+      },
+      celo: {
+        address: '0xd1A342eE2210238233a347FEd61EE7Faf9f251ce',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0x609AedD990bf45926bca9E4eE988b4Fb98587D3A',
+        decimals: 18,
+      },
+      solana: {
+        address: 'DRQBDBEWmwWGK13fRTLhSPzjbvMSUavhV6nW4RUH8W6T',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x6081300950a4f1e2081580e919c210436a1bed49080502834950d31ee55a2396::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xd1aa2ff36a0e93e1b4e4fecdecf8bb95bc5de399061c5e84b515281f48718842::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x936Fa2DE8380Dc5BF34C80F1BaD53a9f3630263B',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x7f7dcDb91930033a4Eb269196EBb6fd5f0644E4B',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x0b0ecbe5C3995541876d27633B63296570FB34Af',
+        decimals: 18,
+      },
+    },
   },
   CELO: {
     key: 'CELO',
@@ -283,6 +909,58 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x3294395e62F4eB6aF3f1Fcf89f5602D90Fb3Ef69',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x2A335e327a55b177f5B40132fEC5D7298aa0D7e6',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x922F49a9911effc034eE756196E59BE7b90D43b3',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0x494317B8521c5a5287a06DEE467dd6fe285dA4a8',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xF432490C6c96C9d3bF523a499a1CEaFd8208A373',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xc1a792041985F65c17Eb65E66E254DC879CF380b',
+        decimals: 18,
+      },
+      solana: {
+        address: '9kvAcwQbqejuJMd59mKuw2bfSsLRaQ7zuvaTVHEeBBec',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xa198f3be41cda8c07b3bf3fee02263526e535d682499806979a111e88a5a8d0f::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xac0c3c35d50f6ef00e3b4db6998732fe9ed6331384925fe8ec95fcd7745a9112::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x74df3823aA29D278cAD0A3632fCB56C896a38eD4',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x4E51aC49bC5e2d87e0EF713E9e5AB2D71EF4F336',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x9b88D293b7a791E40d36A39765FFd5A1B9b5c349',
+        decimals: 18,
+      },
     },
   },
   GLMR: {
@@ -312,6 +990,58 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x93d3696A9F879b331f40CB5059e37015423A3Bd0',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x1C063db3c621BF901FC6C1D03328b08b2F9bbfba',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0xcC48d6CF842083fEc0E01d913fB964b585975F05',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0x375aA6C67BF499fBf01804A9f92C03c0776F372d',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xBF227E92D6754EB4BFE26C40cb299ff2809Da45f',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x383A5513AbE4Fe36e0E00d484F710148E348Aa9D',
+        decimals: 18,
+      },
+      solana: {
+        address: '7ixSaXGsHAFy34wogPk2YXiUX3BMmQMFdercdaHLnBby',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x66f87084e49c38f76502d17f87d17f943f183bb94117561eb573e075fdc5ff75::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x7ab1283a7b13c4254d4e1f803d7ce6578442c1d7a40d0faee41cd48ba4884c8a::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0xfdB7311BeC3b2CcCF8407d0585f81B97b3b5eff1',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x944C5b67a03e6Cb93Ae1E4B70081f13b04CDB6Bd',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0xbffD46DFDb8d3a02b8D2E0F864a2cD712090a4D3',
+        decimals: 18,
+      },
     },
   },
   SOL: {
@@ -344,6 +1074,58 @@ export const MAINNET_TOKENS: TokensConfig = {
       Solana: 9,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0xD31a59c85aE9D8edEFeC411D448f90841571b89c',
+        decimals: 9,
+      },
+      bsc: {
+        address: '0xfA54fF1a158B5189Ebba6ae130CEd6bbd3aEA76e',
+        decimals: 9,
+      },
+      polygon: {
+        address: '0xd93f7E271cB87c23AaA73edC008A79646d1F9912',
+        decimals: 9,
+      },
+      avalanche: {
+        address: '0xFE6B19286885a4F7F55AdAD09C3Cd1f906D2478F',
+        decimals: 9,
+      },
+      fantom: {
+        address: '0xd99021C2A33e4Cf243010539c9e9b7c52E0236c1',
+        decimals: 9,
+      },
+      celo: {
+        address: '0x4581E64115d46CcdeE65Be2336bEc86c9BA54C01',
+        decimals: 9,
+      },
+      moonbeam: {
+        address: '0x99Fec54a5Ad36D50A4Bba3a41CAB983a5BB86A7d',
+        decimals: 9,
+      },
+      sui: {
+        address:
+          '0xb7844e289a8410e50fb3ca48d69eb9cf29e27d223ef90353fe1bd8e27ff8f3f8::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xdd89c0e695df0692205912fb69fc290418bed0dbe6e4573d744a6d5e6bab6c13::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x1C61629598e4a901136a81BC138E5828dc150d67',
+        decimals: 9,
+      },
+      arbitrum: {
+        address: '0x2bcC6D6CdBbDC0a4071e48bb3B969b06B3330c07',
+        decimals: 9,
+      },
+      optimism: {
+        address: '0xba1Cf949c382A32a09A17B2AdF3587fc7fA664f1',
+        decimals: 9,
+      },
+    },
   },
   USDCsol: {
     key: 'USDCsol',
@@ -358,6 +1140,54 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x41f7B8b9b897276b7AAE926a9016935280b44E97',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x91Ca579B0D47E5cfD5D0862c21D5659d39C8eCf0',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0x576Cf361711cd940CD9C397BB98C4C896cBd38De',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0x0950Fc1AD509358dAeaD5eB8020a3c7d8b43b9DA',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0xb8398DA4FB3BC4306B9D9d9d13d9573e7d0E299f',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x8B6eef6C449D3Ac723a9C06a9eaE2dCd7d308BA9',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0x098d6eE48341D6a0a0A72dE5baaF80A10E0F6082',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xb231fcda8bbddb31f2ef02e6161444aec64a514e2c89279584ac9806ce9cf037::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0xc91d826e29a3183eb3b6f6aa3a722089fdffb8e9642b94c5fcd4c48d035c0080::coin::T',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0x3870546cfd600ba87e4180686d29dC993A45d3B7',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0x6F974A6dfD5B166731704Be226795901c45Bb815',
+        decimals: 6,
+      },
     },
   },
   SUI: {
@@ -376,6 +1206,57 @@ export const MAINNET_TOKENS: TokensConfig = {
       Sui: 9,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x84074EA631dEc7a4edcD5303d164D5dEa4c653D6',
+        decimals: 9,
+      },
+      bsc: {
+        address: '0x8314f6Bf1B4dd8604A0fC33C84F9AF2fc07AABC8',
+        decimals: 9,
+      },
+      polygon: {
+        address: '0x34bE049fEbfc6C64Ffd82Da08a8931A9a45f2cc8',
+        decimals: 9,
+      },
+      avalanche: {
+        address: '0x1703CB0F762D2a435199B64Ea47E5349B7C17480',
+        decimals: 9,
+      },
+      fantom: {
+        address: '0xC277423a21F6e32D886BF85Ef6cCB945d5D28347',
+        decimals: 9,
+      },
+      celo: {
+        address: '0x1Cb9859B1A16A67ef83A0c7b9A21eeC17d9a97Dc',
+        decimals: 9,
+      },
+      moonbeam: {
+        address: '0x484eCCE6775143D3335Ed2C7bCB22151C53B9F49',
+        decimals: 9,
+      },
+      solana: {
+        address: 'G1vJEgzepqhnVu35BN4jrkv3wVwkujYWFFCxhbEZ1CZr',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xa72a97e872be9ee3d2f14d56fd511eb7e4a53f4055be3a267d8602e7685b41c0::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x36c6FBF7B49bF65f5F82b674af219C05b2a4aDD1',
+        decimals: 9,
+      },
+      arbitrum: {
+        address: '0xCF79d86B8a830030aF6D835737d6eac3bE823fD7',
+        decimals: 9,
+      },
+      optimism: {
+        address: '0x27A533e438892DA192725b4C9AcA51447F457212',
+        decimals: 9,
+      },
+    },
   },
   APT: {
     key: 'APT',
@@ -391,6 +1272,57 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 8,
       default: 8,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x8CDf7AF57E4c8B930e1B23c477c22f076530585e',
+        decimals: 8,
+      },
+      bsc: {
+        address: '0x2Ba98cf7Edd2c5C794e21bc3Dc6973D3C2585eE3',
+        decimals: 8,
+      },
+      polygon: {
+        address: '0xa4ef199d3ad524E9C3C51Ac46B303B103A307Cef',
+        decimals: 8,
+      },
+      avalanche: {
+        address: '0x43c588459b3243fA541B98CC4B2E995b3de553A2',
+        decimals: 8,
+      },
+      fantom: {
+        address: '0x3Cd9162Ca5256b8E26A0e3Ad14CCfF7C0Da0F174',
+        decimals: 8,
+      },
+      celo: {
+        address: '0x89F2b718Ca518db39d377F0ABBa6B42582b549F7',
+        decimals: 8,
+      },
+      moonbeam: {
+        address: '0x25331575641d35D9765e1934acC8F0991c58e904',
+        decimals: 8,
+      },
+      solana: {
+        address: '6LNeTYMqtNm1pBFN8PfhQaoLyegAH8GD32WmHU9erXKN',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x3a5143bb1196e3bcdfab6203d1683ae29edd26294fc8bfeafe4aaa9d2704df37::coin::COIN',
+        decimals: 8,
+      },
+      base: {
+        address: '0x1d36126289Be1658297A35CC3EB2BB80A7D7A04b',
+        decimals: 8,
+      },
+      arbitrum: {
+        address: '0x4EdeF400eDe5309240814b5FC403F224504604e9',
+        decimals: 8,
+      },
+      optimism: {
+        address: '0xC5B3AC2DF8D8D7AC851F763a5b3Ff23B4A696d59',
+        decimals: 8,
+      },
     },
   },
   ETHarbitrum: {
@@ -423,6 +1355,54 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0xb945E3F853B5f8033C8513Cf3cE9F8AD9beBB1c9',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0xaA1eEdABC48D078350ccBdD620bD088848e299E5',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x6a5c59AB16268d2c872916054C50440B999e417C',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0xDfDA518A1612030536bD77Fd67eAcbe90dDC52Ab',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xE8367853A0823515D37b1538331B4704089becb4',
+        decimals: 18,
+      },
+      celo: {
+        address: '0xc6F962fCcb140ece554AfD0E589f971532A57f14',
+        decimals: 18,
+      },
+      solana: {
+        address: 'CSD6JQMvLi46psjHdpfFdr826mF336pEVMJgjwcoS1m4',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x33744e7df340a4d01c23f6b18c13563f767545ea95f976f8045f056358419da3::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x0e977796d7bfb3263609b90dffd264c7bd078ce35dac42b55302858d9fa3452b::coin::T',
+        decimals: 8,
+      },
+      base: {
+        address: '0x9D36e0edb8BBaBeec5edE8a218dc2B9a6Fce494F',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x825206E1D29456337769e6f1384101E997C6A732',
+        decimals: 18,
+      },
+    },
   },
   USDCarbitrum: {
     key: 'USDCarbitrum',
@@ -437,6 +1417,46 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0xCFc006a32a98031C2338BF9d5ff8ED2c0Cae4a9e',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x5caa170b465122D15a6D20FD9A804a9613CE7882',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0x7800FE8951cdc1cDea748d878fAce63018D97960',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0x4b5fE357Eb11c735078e47526D6e853DBff18541',
+        decimals: 6,
+      },
+      celo: {
+        address: '0xA41a62567d9eb960D84b72663FdaeBE0BCdE2683',
+        decimals: 6,
+      },
+      solana: {
+        address: 'CR4xnGrhsu1fWNPoX4KbTUUtqGMF3mzRLfj4S6YEs1Yo',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xc3f8927de33d3deb52c282a836082a413bc73c6ee0bd4d7ec7e3b6b4c28e9abf::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0xca3a2c28bc8c6c762f752dd2a4ebbfd00356ca99977ce6636e3af5897124a87a::coin::T',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0xa6252F56cc6eEA21165d56744C795F91c8a3Cf68',
+        decimals: 6,
+      },
     },
   },
   ETHoptimism: {
@@ -469,6 +1489,34 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      fantom: {
+        address: '0xe8E8f941377A955bFA72880ec0dc2319dbC827a8',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x8d53771b1Ec7461f8e45Bca2609c45bC0bbd0677',
+        decimals: 18,
+      },
+      solana: {
+        address: '8M6d63oL7dvMZ1gNbgGe3h8afMSWJEKEhtPTFM2u8h3c',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xaab14ec22908de73d1b0619f5e03842398f8e68262981bd35ef44b42d22b23a::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x6a7a7f36ef5e2d0e65fcf72669c20d514d68298b0f76c7554517208f73260aaf::coin::T',
+        decimals: 8,
+      },
+      arbitrum: {
+        address: '0xB1fC645a86fB5085e12D8BDDb77702F728D2A26F',
+        decimals: 18,
+      },
+    },
   },
   USDCoptimism: {
     key: 'USDCoptimism',
@@ -483,6 +1531,24 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      fantom: {
+        address: '0x385b219f0C4fa2e84EfE5aaf9692a821C57B8248',
+        decimals: 6,
+      },
+      celo: {
+        address: '0xEe48963C003e21EaCEdFA8a0A19BB3cbF7E776Fe',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0x7143e8EA96e158381057a58AfdDF44601c7e532C',
+        decimals: 6,
+      },
+      base: {
+        address: '0xc6bfBeb3002aD563D2d1f72614C61C83Bf147Acd',
+        decimals: 6,
+      },
     },
   },
   // SEI: {
@@ -531,6 +1597,58 @@ export const MAINNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      ethereum: {
+        address: '0x1D4241F7370253C0f12EFC536B7e16E462Fb3526',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x9dc152F4941cE1A138326e70c3600385bf0C22dD',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x5BCf8d8c097FbB35C371F921E3FF3e6F6Eb54B41',
+        decimals: 18,
+      },
+      avalanche: {
+        address: '0xFA83178c66fE51ee99109b5cC912f8098Ff812eF',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xd3365E7355230c78098b44B172eE27DAB95B041A',
+        decimals: 18,
+      },
+      celo: {
+        address: '0x905CADB645684140E285e2D09D39dF5a2082BC87',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0x6C6f83366A42fcA4D30a2D3f1914284de995Ac3a',
+        decimals: 18,
+      },
+      solana: {
+        address: 'DWXe1hxpnb8LAH21iyXcjvMbiAGzoYyuCVQtRLvZdLYd',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xaecbc804fa7ca7cffc74c9a05eb6ae86fda0c68375b5c1724204a1065bcb239a::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x5b5f14781164cf77185a7b6acd8e4f3cbb7e7cfb1cd5760d2b8af81075fc153d::coin::T',
+        decimals: 8,
+      },
+      arbitrum: {
+        address: '0xBAfbCB010D920e0Dab9DFdcF634De1B777028a85',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x3F369a664fa665e01e8EB9f20bFcE03A0CAb8971',
+        decimals: 18,
+      },
+    },
   },
   OSMO: {
     key: 'OSMO',
@@ -562,6 +1680,41 @@ export const MAINNET_TOKENS: TokensConfig = {
       default: 8,
       Ethereum: 18,
     },
+    foreignAssets: {
+      polygon: {
+        address: '0x3362b2B92b331925F09F9E5bCA3E8C43921a435C',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xeE27799cF29D7F64647B92f47d543B382B49f83E',
+        decimals: 18,
+      },
+      moonbeam: {
+        address: '0xeCd65E4B89495Ae63b4f11cA872a23680A7c419c',
+        decimals: 18,
+      },
+      solana: {
+        address: '25rXTx9zDZcHyTav5sRqM6YBvTGu9pPH9yv83uAEqbgG',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xbc3a676894871284b3ccfb2eec66f428612000e2a6e6d23f592ce8833c27c973::coin::COIN',
+        decimals: 8,
+      },
+      base: {
+        address: '0x9EE95E6Bd1B3C5740F105d6fb06b8BDeF64Eec70',
+        decimals: 18,
+      },
+      arbitrum: {
+        address: '0x57723abc582DBfE11Ea01f1A1f48aEE20bD65D73',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0xeC0a755664271b87002dDa33CA2484B24aF68912',
+        decimals: 18,
+      },
+    },
   },
   wstETH: {
     key: 'wstETH',
@@ -578,6 +1731,16 @@ export const MAINNET_TOKENS: TokensConfig = {
       default: 8,
       Ethereum: 18,
     },
+    foreignAssets: {
+      polygon: {
+        address: '0xe082a7Fc696De18172Ad08D956569Ee80BC37f06',
+        decimals: 18,
+      },
+      solana: {
+        address: 'ZScHuTtqZukUrtZS43teTKGs2VqkKL8k4QCouR2n6Uo',
+        decimals: 8,
+      },
+    },
   },
   BONK: {
     key: 'BONK',
@@ -592,6 +1755,38 @@ export const MAINNET_TOKENS: TokensConfig = {
     color: '#FC8E03',
     decimals: {
       default: 5,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0x1151CB3d861920e07a38e03eEAd12C32178567F6',
+        decimals: 5,
+      },
+      bsc: {
+        address: '0xA697e272a73744b343528C3Bc4702F2565b2F422',
+        decimals: 5,
+      },
+      polygon: {
+        address: '0xe5B49820e5A1063F6F4DdF851327b5E8B2301048',
+        decimals: 5,
+      },
+      avalanche: {
+        address: '0xC07C98a93591504584738e4569928DDb3b9f12A7',
+        decimals: 5,
+      },
+      sui: {
+        address:
+          '0x6907963ca849faff0957b9a8269a7a07065e3def2eef49cc33b50ab946ea5a9f::coin::COIN',
+        decimals: 5,
+      },
+      aptos: {
+        address:
+          '0x2a90fae71afc7460ee42b20ee49a9c9b29272905ad71fef92fbd8b3905a24b56::coin::T',
+        decimals: 5,
+      },
+      arbitrum: {
+        address: '0x09199d9A5F4448D0848e4395D065e1ad9c4a1F74',
+        decimals: 5,
+      },
     },
   },
 };

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -29,6 +29,63 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      mumbai: {
+        address: '0xc6735cc74553Cc2caeB9F5e1Ea0A4dAe12ef4632',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x064a85eac6b4Bd7190BCAd3458dBD9459989c37B',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0xbB5A2dC896Ec4E2fa77F40FA630582ed9c6D0172',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x758FEebDDeC06f4bCcEc8F756C8efBD35d5b7124',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x898471a82737dFFfB61915F9e8381e279076D72b',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0xd27d8883E31FAA11B2613b14BE83ad8951C8783C',
+        decimals: 18,
+      },
+      solana: {
+        address: '7VPWjBhCXrpYYBiRKZh1ubh9tLZZNkZGp2ReRphEV4Mc',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x72831f626b1f0e11be201893d5cb641917730b1ccac778e4a77f8ab2052f0784::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x381775005cb32cdd3dbf935ae1b978ed40d309c72b009cd4a812aab6d991418a::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x44D627f900da8AdaC7561bD73aA745F132450798',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei13pzlt9etk44hj22lckncvampq2qu2gxv6r6774f3hma4vc07wqgsmftjx7',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0x285d75E04D78F53f4Ed29A506a7e8479EEf3035f',
+        decimals: 18,
+      },
+      optimismgoerli: {
+        address: '0x33Db338718aC89Cd8DB13B56af05be3a3029BBE5',
+        decimals: 18,
+      },
+    },
   },
   USDCeth: {
     key: 'USDCeth',
@@ -43,6 +100,53 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      mumbai: {
+        address: '0x543237045a106D7fd2eE3e2B44b5728e70BDe9c3',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x861B5C16A2EcED022241072A7beA9D530b99EB6f',
+        decimals: 6,
+      },
+      fuji: {
+        address: '0x63A30f239DC8d1c17Bf6653a68Fc6C2F83641E6d',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0xDF7928AF5B33F7de592594958D8d6Ff8472Eb407',
+        decimals: 6,
+      },
+      alfajores: {
+        address: '0xB0524bEF6c61c6150B340b2828a890fD8dEa60C0',
+        decimals: 6,
+      },
+      moonbasealpha: {
+        address: '0xE5dE10C4b744bac6b783fAF8d9B9fDFF14Acc3c9',
+        decimals: 6,
+      },
+      solana: {
+        address: '2BAqec7Qof3Y7VJatwFsRHUNSQBSkzaEsT1V5bW6dbZY',
+        decimals: 6,
+      },
+      basegoerli: {
+        address: '0x5010B0988a035915C91a2a432085824FcB3D8d3f',
+        decimals: 6,
+      },
+      sei: {
+        address:
+          'sei1nj32y0h0vzam33ay42h2majlfk7tdkqcuk84srn0v2a52kmujgfsyfe78f',
+        decimals: 6,
+      },
+      arbitrumgoerli: {
+        address: '0x42A212A2E7eA8feF4ED28F439F16A6ABDd34DA35',
+        decimals: 6,
+      },
+      optimismgoerli: {
+        address: '0x0382F518AcE1a86224c78B7CDfa67B9774055A1b',
+        decimals: 6,
+      },
     },
   },
   WBTC: {
@@ -74,6 +178,24 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       default: 6,
     },
+    foreignAssets: {
+      mumbai: {
+        address: '0x02E30E84161BE1aBfcBB2b154B11De4C2b5E0a32',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0xe94AaBAdB6F833f65B8A9AdDD030985B775188c9',
+        decimals: 6,
+      },
+      moonbasealpha: {
+        address: '0x7f5Ca1bcFb38fDF4c0E0646FCbf3FA87740ff65D',
+        decimals: 6,
+      },
+      arbitrumgoerli: {
+        address: '0x2B732F5ad6117818Ad3b7aC73C16033F6ECD78E5',
+        decimals: 6,
+      },
+    },
   },
   DAI: {
     key: 'DAI',
@@ -89,6 +211,40 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      mumbai: {
+        address: '0x87374d35C5F1bD78c2b1da383F460e154e7D3E5e',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x45082C9Fc6BBCa72288F47Fad21dE0BECC75759E',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x3989C9c4bdd30400E6Aa90990683EAd6a1638A16',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xE4FE5DF2084f9D81595e4fcba2399020FBE7b233',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0xeBB3fF6E5d61d3793Fdb60f7942BA78E636019f6',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0xc31EC0108D8e886be58808B4C2C53f8365f1885D',
+        decimals: 18,
+      },
+      solana: {
+        address: '3WK3mEDNPrNuQReBvM28NcsqrExMnPxD9pPJmgrUeKKH',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x31B2BAEE47Dc5Fc06baEC1BF73C124031b44fB97',
+        decimals: 18,
+      },
     },
   },
   MATIC: {
@@ -119,6 +275,63 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x7cd0e8ff09cEB653813bD3d63d0554c1CB4BFdf6',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x7FCDA925f0994121752ca14C334297BeC3d0eA9E',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x78554394273957d7e55afC841aeA27Cce469AEd4',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x47a4C4c0f96D6CBe5b5C0A46CB0E22d6A17F1430',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x7a56409988BBF8758b3ba412b9c7E3FE504C8544',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0xD2888f015BcB76CE3d27b6024cdEFA16836d0dbb',
+        decimals: 18,
+      },
+      solana: {
+        address: 'ACbmcQxbbhiXWM1GmapUSMmBYKMvnFLfAAXKqdo8xKwo',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xa516bcbf83b29a2944bb53ec9f934ea7d78c3626d3ae411d2fb9dcb977522e67::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x5f229253e2b2d03fb909f565feca49452582bd633a5816e5ce30aa593cb49d8a::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0xFFB5d863d5132523d013338845A1Bb01EDd440f4',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1dc94as3vgxn3qkr5h0lnnrep69mtfku6jg4t94gfkunuyzr5g5eqyqvj9p',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0x50FD4064cC536a964E2E0Dc7B3fE2313Ab386bEA',
+        decimals: 18,
+      },
+      optimismgoerli: {
+        address: '0x427B5a0b0384D7FD3AF81805A166a2d9C1116D7d',
+        decimals: 18,
+      },
+    },
   },
   USDCpolygon: {
     key: 'USDCpolygon',
@@ -133,6 +346,42 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xB3658B4C6704356F155c369F4583aF68424128e9',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x88B8b85ED6d39E613d2d1449e1c1B808d505D561',
+        decimals: 6,
+      },
+      fuji: {
+        address: '0xFB2C24197A92598C633Ed8eE60ee90b104d7B145',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x450dC724a1793b0E2182d09Eb883ad76f7F4C0Aa',
+        decimals: 6,
+      },
+      alfajores: {
+        address: '0x4364bb251a0F33914AAb2088ed435122694Ce2BD',
+        decimals: 6,
+      },
+      moonbasealpha: {
+        address: '0x5366c7204A49D6CdD6A99e647aE695Cb0866FD5e',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0xe1deb395283034cbfc81c5acb4c89d3223e5165b5384282c73963aa5262a4993::coin::COIN',
+        decimals: 6,
+      },
+      sei: {
+        address:
+          'sei1vccw9g60mphsaj9t96vru53mjje3vmxcl49lg8lfqdh0zgmq6zsqf03y9n',
+        decimals: 6,
+      },
     },
   },
   BNB: {
@@ -163,6 +412,59 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0xB19693FEB013Bab65866dE0a845a9511064230cE',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0x0C63D8ADB69204b2946DcB945a6f16d97C255eE2',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x10F1053bF2884b28ee0Bd7a2dDBa237Af3511d29',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xfB174b43228950C2055CFc25AE93f2DCe8E2beF0',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0xa8050be9389466c3c524F10F131f244ACbf21A0D',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0x6097E80331B0c6aF4F74D7F2363E70Cb2Fd078A5',
+        decimals: 18,
+      },
+      solana: {
+        address: 'BaGfF51MQ3a61papTRDYaNefBgTQ9ywnVne5fCff4bxT',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xddcf8680a8a4b8a527d8c85ec203274991590c2ea898d1c4635b70164d9c584b::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xa5894f5ddb8647e6143102aa336ff07374f7b32e88c1c703aef5b7c9a370bf80::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x9DeF11E63C23c71dE3716b81dD2Fdad2B24b8b7F',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei10a7see3f9t2j9l8fdweur3aqy4zgvz583a268hhhln3yzps6l5mqnl4ua6',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xB039aC4Fa8Ed99d30C2f7D791294A9d5FAd698eF',
+        decimals: 18,
+      },
+    },
   },
   AVAX: {
     key: 'AVAX',
@@ -192,6 +494,59 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x4C1b727f6df3B075E682C41a25687A69846aaC04',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0x51f3D34651523dD8CC4872ee261A1B0B3f73AceF',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x6cE9E2c8b59bbcf65dA375D3d8AB503c8524caf7',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x0f545Be981C37fB15ab7c65404648761e99016e4',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x502c8C83008D9Dd812a7C5fB886C063060C73Dbf',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0x2E8afeCC19842229358f3650cc3F091908dcbaB4',
+        decimals: 18,
+      },
+      solana: {
+        address: '3Ftc5hTz9sG4huk79onufGiebJNDMZNL8HYgdMJ9E7JR',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xa600741c469fb57ed01497ddf101e798fa79a9c529bd176675c5c4d970811f80::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xbe8f4301c0b54e870902b9a23eeb95ce74ac190531782aa3262337ceb145401a::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x410B0EE532EFfB18fa4d90cc095B1CD58aC43d5a',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1mgpq67pj7p2acy5x7r5lz7fulxmuxr3uh5f0szyvqgvru3glufzsxk8tnx',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0x92b0C4D27a05921Ded4BB117755990F567aEe049',
+        decimals: 18,
+      },
+    },
   },
   USDCavax: {
     key: 'USDCavax',
@@ -206,6 +561,59 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xF6699D3f725C4b64Cc6010F2DF77B4B05C76Cd5C',
+        decimals: 6,
+      },
+      mumbai: {
+        address: '0xcc048C353Fdc2f5c378B7BCab9B240Ca2b619f1c',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x1cfeCf72bcBE1E429A21A5B11E708C7c397AaC54',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x6BC4E8D8c1d54656D1DeBCa96efc53aFd1408aD2',
+        decimals: 6,
+      },
+      alfajores: {
+        address: '0xDDB349c976cA2C873644F21f594767Eb5390C831',
+        decimals: 6,
+      },
+      moonbasealpha: {
+        address: '0x6533CE14804D113b1F494dC56c5D60A43cb5C3b5',
+        decimals: 6,
+      },
+      solana: {
+        address: 'GQtMXZxnuacCFTXVeTvyHi6P9F6chbtzhVc8JgD8hv7c',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0x2aa8c885d04e676c4e87b7d0f94d4f3b243b1b5d93239d1cc41d5528ce1714c1::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0x02ef7697bdb33361ca39d228671203afc0dea3202e792d79d2072b761d87c834::coin::T',
+        decimals: 6,
+      },
+      basegoerli: {
+        address: '0x4C5208246676486064c501E1DAF2dD21596Bc5f5',
+        decimals: 6,
+      },
+      sei: {
+        address:
+          'sei1uyce5s6cc8hveg0maq2lg7wm6v6fvwqmznypj559nzf9wr9tmw3qnd3ce7',
+        decimals: 6,
+      },
+      arbitrumgoerli: {
+        address: '0xb39697B8BA5df91A169690DfEf88B911436619F2',
+        decimals: 6,
+      },
     },
   },
   FTM: {
@@ -236,6 +644,54 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x0d7A9Cdbb7C21E64825cF81750A5081a32aFb5d4',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0x84aa9100a36D6c3514605F62342abF3cE77D5b97',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x9aB305B792DBdb8253bEE909E7006611Cb45175b',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x094cB577C21Ab1360178beE74B9591fa12216dAD',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0xE6F8710cA14CFe7F5aAAD3A799C3d1D92dCba938',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0x566c1cebc6A4AFa1C122E039C4BEBe77043148Ee',
+        decimals: 18,
+      },
+      solana: {
+        address: 'DMw2tLaq1bVoAEKtkoUtieSk9bfCPUvubYLatTMsSVop',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x14e756ff65e0ac810a5f69ca5276ef5b899a6df3c4717de1f85559d8b5ae6ea6::coin::COIN',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0xB4808E58713112AbAbB8167C7187F8988df38bbD',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1cr3j7rxq0dhq04ksftmj8n2w096w9g7ck8fngkvk2lrmy3qwz56q9thu9u',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xa507f7566B8aDE000E886166B95964677ef3b3Ef',
+        decimals: 18,
+      },
+    },
   },
   CELO: {
     key: 'CELO',
@@ -251,6 +707,59 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xe092525a787CD56B901279b5864a224c22B95B72',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0xAd027790A64331A11bd1b651739450cC9Dc0098F',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x1471698cBD9cAB0228F2EEA9303A2b3aA0ABDC2B',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0xC66d9c2b33c347d4A4441975f4688fcD5DD4c441',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0xB18E73a69c3Aaea39a610372537Cf8482622d199',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0x3406a9b09adf0cb36DC04c1523C4b294C6b79513',
+        decimals: 18,
+      },
+      solana: {
+        address: '84F2QX9278ToDmA98u4A86xSV9hz1ovazr8zwGaX6qjS',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x81868174a6b11e1acc337b3414f9912455435d486609fb8d50b34312865085f2::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xecbb0f7e7d049499ca83ca1358344f56557886f6f7adc740d6734cce7bfc9a14::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x72C56041ea5fe8bDE99b2A123fb5964cDE8C7FE9',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1yw4wv2zqg9xkn67zvq3azye0t8h0x9kgyg3d53jym24gxt49vdyswk5upj',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0x9592eE6eD1D9E611b7aa6F20CCbD7Ba571Be8bdd',
+        decimals: 18,
+      },
     },
   },
   GLMR: {
@@ -280,6 +789,54 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0x0dc83BB61008A5E1194fe50fA9E474713C1AEcD7',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0x693b9AC2199d989bDA8C9C5b5d7A3680B4f40dAa',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x5C31B36599ED7f06b09c0ffC7A2F928cE496F046',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0xf080782DF38eD5228D2FC2882d13D56c8f1D6f21',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x41E3CFDFC255A4bF3C8D3560Bc8D3D9b5080338e',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x132D2172D89cd9CfD480A8887c6bF92360fB460e',
+        decimals: 18,
+      },
+      solana: {
+        address: '8987WGkYa5viiZ9DD8sS3PB5XghKmWjkEgmzvwDuoAEc',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xeffae382de96981f7ddd2d294429924827e8f325d612487a12d6a0b249171002::coin::COIN',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0xCEc03b5710a464F4354AF35ebD0310238F656DFf',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei140m6xagmw0zesejzhsvk46zprgscr7tu94h36rwsutcsxcs4fmds9sevym',
+        decimals: 8,
+      },
+      optimismgoerli: {
+        address: '0x99436d62259532E0407A7aE78A3b48D119B13903',
+        decimals: 18,
+      },
     },
   },
   SOL: {
@@ -312,6 +869,59 @@ export const TESTNET_TOKENS: TokensConfig = {
       Solana: 9,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x494701CE895389d917a938f0ea202D4eB9684Eab',
+        decimals: 9,
+      },
+      mumbai: {
+        address: '0x0284B4994456Fae4cb56E4d33228d51B674EAD1b',
+        decimals: 9,
+      },
+      bsc: {
+        address: '0x30f19eBba919954FDc020B8A20aEF13ab5e02Af0',
+        decimals: 9,
+      },
+      fuji: {
+        address: '0xb10563644a6AB8948ee6d7f5b0a1fb15AaEa1E03',
+        decimals: 9,
+      },
+      fantom: {
+        address: '0xED1a08Fc69A7008d225890A96aaE258c465CC7ad',
+        decimals: 9,
+      },
+      alfajores: {
+        address: '0x05EEF2AE1A7A938D78598F7d9e8b97A9bED0c9eC',
+        decimals: 9,
+      },
+      sui: {
+        address:
+          '0xbc03aaab4c11eb84df8bf39fdc714fa5d5b65b16eb7d155e22c74a68c8d4e17f::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0xdd89c0e695df0692205912fb69fc290418bed0dbe6e4573d744a6d5e6bab6c13::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x6Fb1dE2372e48fe66c84cf37cc2fb54EaEe62988',
+        decimals: 9,
+      },
+      sei: {
+        address:
+          'sei1at3xuugacwgu3ppx7fxzmtr3q6m3ztjuean9r2mwcnqupw28yezs7unxgz',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xF8cbdc4E54281b801f182039c250Ad6d13818250',
+        decimals: 9,
+      },
+      optimismgoerli: {
+        address: '0x06EcAF6638070Ccf3b3dEA421b3becAA57f3e559',
+        decimals: 9,
+      },
+    },
   },
   USDCsol: {
     key: 'USDCsol',
@@ -326,6 +936,12 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      bsc: {
+        address: '0x51a3cc54eA30Da607974C5D07B8502599801AC08',
+        decimals: 6,
+      },
     },
   },
   SUI: {
@@ -344,6 +960,54 @@ export const TESTNET_TOKENS: TokensConfig = {
       Sui: 9,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x70F7360C49D227ccBbb98fB7B69B7CDB651195bb',
+        decimals: 9,
+      },
+      mumbai: {
+        address: '0x3dadA6f29f80A0427C4989E17a5a2ada17441841',
+        decimals: 9,
+      },
+      bsc: {
+        address: '0x5A73D76e09Af2E428EC64aE10F91B78AC990B298',
+        decimals: 9,
+      },
+      fuji: {
+        address: '0xfc5128F8556a6F059466E67740e6cC31EE5C2C47',
+        decimals: 9,
+      },
+      fantom: {
+        address: '0xd882AB49372eC093E8697B5153f54ab5e7738e3b',
+        decimals: 9,
+      },
+      alfajores: {
+        address: '0xa40d9E69ca9867C4bFbeC11Ce79C939991e9bf26',
+        decimals: 9,
+      },
+      solana: {
+        address: 'BJZ72CjPQojVoH68mzrd4VQ4nr6KuhbAGnhZEZCujKxY',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x7b22d0e02f653d4fd1caddcfa4719a2b329da56eb81d8f27db703f02466c26a5::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0xEe0fC8BECD593B41AACBd93936fDAbc2A444370A',
+        decimals: 9,
+      },
+      sei: {
+        address:
+          'sei1rhpcprr2pffe6ydf078a0qeslhnlywxh2t3wjax4489z0m29cj9swj5khc',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xe64e2139fdf6Ee7e3795FE51955e21bA3d9eB9F7',
+        decimals: 9,
+      },
+    },
   },
   APT: {
     key: 'APT',
@@ -359,6 +1023,53 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 8,
       default: 8,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xd7A89a8DD20Cb4F252c7FB96B6421b37d82cE506',
+        decimals: 8,
+      },
+      mumbai: {
+        address: '0x226B436043B537BD158e84fA199E2Aa36bf364f8',
+        decimals: 8,
+      },
+      bsc: {
+        address: '0x4A7Bd5E135f421057F97BbA8BCeeE5c18334f454',
+        decimals: 8,
+      },
+      fuji: {
+        address: '0x996a3f12C1FcD7339Ea8801f629201e4d42EAD04',
+        decimals: 8,
+      },
+      fantom: {
+        address: '0xAb2297E8994149BA91737944E40891881aF762a4',
+        decimals: 8,
+      },
+      alfajores: {
+        address: '0xAC0a2fF7DD597de863878a3372142b07B614C125',
+        decimals: 8,
+      },
+      moonbasealpha: {
+        address: '0xCaa2A1d3BbbA0D1466571e83b4E2CbE04252593D',
+        decimals: 8,
+      },
+      solana: {
+        address: '7EvFD3JKCJVdtkAYdaSVKJsrPEJCzy2neJha7TREGrCa',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0xd934A15FfA3945DD0Ba2cb7b4174024261A14874',
+        decimals: 8,
+      },
+      sei: {
+        address:
+          'sei1em74y5sts4h8y5zuhfdn4w5g8zs285qld3kczpk6rh32jpvjyqqsvv0pdt',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xa81C3BEf2d6f10213b860458DC119666C0ba13bf',
+        decimals: 8,
+      },
     },
   },
   ETHarbitrum: {
@@ -391,6 +1102,33 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      bsc: {
+        address: '0x60845E2503Fcd945b3A6f0bC077a31CC913E654D',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x36Bd1562F874941eE62Ebb2b3A45B4A88A9df90e',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x456e08952f9091B6c268dC0cECad53d141152C59',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0x15025b956969DD8F1d0CD69959Ad97128F8f6D69',
+        decimals: 18,
+      },
+      basegoerli: {
+        address: '0x8eD43aBdc4f836aa60933177B31AC358ea09f27E',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1pf5j3dgngm8yj2xkwmvmvt87g4vyc0szpjz92q8ly9erh23ytn4s983htv',
+        decimals: 8,
+      },
+    },
   },
   USDCarbitrum: {
     key: 'USDCarbitrum',
@@ -405,6 +1143,16 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xd962F26D93c4eF609Ba00Ed6101326A1490B9489',
+        decimals: 6,
+      },
+      alfajores: {
+        address: '0x0C4AbF95Ff3d82d1F02f55e65050eA5bA062606E',
+        decimals: 6,
+      },
     },
   },
   ETHoptimism: {
@@ -436,6 +1184,28 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       Ethereum: 18,
       default: 8,
+    },
+    foreignAssets: {
+      mumbai: {
+        address: '0xC77d781f38Cf52F8Ea0b4c0F22312bB9A34911b5',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x301587BF484756441de43E522027e3751871237B',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x28E768a51D19dcB753a24B79D1e89c92fee094Ba',
+        decimals: 18,
+      },
+      basegoerli: {
+        address: '0x5c443C05C72F0660502d88642c807020cc9b71A2',
+        decimals: 18,
+      },
+      arbitrumgoerli: {
+        address: '0xFd903eA23Bf65f26FdAf2eeb589cf007b108882E',
+        decimals: 18,
+      },
     },
   },
   USDCoptimism: {
@@ -483,6 +1253,46 @@ export const TESTNET_TOKENS: TokensConfig = {
       Ethereum: 18,
       default: 8,
     },
+    foreignAssets: {
+      goerli: {
+        address: '0x76e39239e40857030D6f4D8545EFbd71F904d344',
+        decimals: 18,
+      },
+      mumbai: {
+        address: '0x68C4365d5229A44D9A59058B65500365492b5307',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x63108fC941F3cCE0B484De19746B5Af949EAF6eE',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0xc07c754ef7473d315D973F7D9F7858C2eCe0a0a6',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x01950A33DfFa63E6Bc23b5dB440505581A4cc0e7',
+        decimals: 18,
+      },
+      solana: {
+        address: 'EKZqcBZ3Y7YTDinpecA7SxRp9B4s1m99VHJ9jpvyTwzW',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x5b5f14781164cf77185a7b6acd8e4f3cbb7e7cfb1cd5760d2b8af81075fc153d::coin::T',
+        decimals: 8,
+      },
+      arbitrumgoerli: {
+        address: '0xbC4CB3CD7186fD457C072298C48d0eDf7213CAEa',
+        decimals: 18,
+      },
+      sei: {
+        address:
+          'sei1kdqylzcv86t7slg8m30mlfgna9xsrusghdgnavvurkv0rku7jvqqta7lka',
+        decimals: 8,
+      },
+    },
   },
   OSMO: {
     key: 'OSMO',
@@ -514,6 +1324,58 @@ export const TESTNET_TOKENS: TokensConfig = {
       default: 8,
       Ethereum: 18,
     },
+    foreignAssets: {
+      mumbai: {
+        address: '0xf6CC0Cc8D54a4b1A63a0E9745663e0c844Ee4D48',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0xE7176110261ef2FfC885dd568C1093f58F0aEee9',
+        decimals: 18,
+      },
+      fuji: {
+        address: '0x7E1779F65B644E5f98DdC4D2cB0A0106a7E6d9e1',
+        decimals: 18,
+      },
+      fantom: {
+        address: '0x66E080407407620844fE2083c33108BE55E087bc',
+        decimals: 18,
+      },
+      alfajores: {
+        address: '0x01a050Fc725F4E99aAD43Eb6f8481f38ee6231aD',
+        decimals: 18,
+      },
+      moonbasealpha: {
+        address: '0xf82E21cE03471983Afb9c2E3789Aa13a2d7242E8',
+        decimals: 18,
+      },
+      solana: {
+        address: 'FMYvcyMJJ22whB9m3T5g1oPKwM6jpLnFBXnrY6eXmCrp',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0xacf6784120b221a077ab0b84acc0b76930779eb55f157ea2492be4a60b808f6::coin::COIN',
+        decimals: 8,
+      },
+      aptos: {
+        address:
+          '0x6e2d5d1a6d6d0e0c5db506ce64ead0530847a48b96516abbb08cdebe43fe3036::coin::T',
+        decimals: 8,
+      },
+      basegoerli: {
+        address: '0x0219441240d89fAc3fD708d06d8fD3A072C02FB6',
+        decimals: 18,
+      },
+      arbitrumgoerli: {
+        address: '0x97B5fE27a82b2B187D9a19C5782d9eB93B82DaC3',
+        decimals: 18,
+      },
+      optimismgoerli: {
+        address: '0x5D89a5BcB86F15a2CCAb05e7E3bEE23fDF246a64',
+        decimals: 18,
+      },
+    },
   },
   wstETH: {
     key: 'wstETH',
@@ -544,6 +1406,62 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#FFFFFF',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      goerli: {
+        address: '0xd68df72136207E9471C915cf1B6Cf43D587D4E0A',
+        decimals: 6,
+      },
+      mumbai: {
+        address: '0xc5C0229B38564E1E8083031405Be8d6E6e3Bc462',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x79A8FFFCED130314eCC8782C846c4d8d4867A900',
+        decimals: 6,
+      },
+      fuji: {
+        address: '0xfe2eCDD1708aaebf1cF802C6124fAFb18B22dfEE',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x832e8050D6c64724500DE9B0ffe1CAc6c570a26d',
+        decimals: 6,
+      },
+      alfajores: {
+        address: '0x05Efb4aC79ef48a4830f517834c6f5f039F16832',
+        decimals: 6,
+      },
+      moonbasealpha: {
+        address: '0x1EdDe35B7e058194B457B8621285EaFA710f01ea',
+        decimals: 6,
+      },
+      solana: {
+        address: '8LFdfuhbfdH8oBzSKDgfPAxvLW24dCM9ttjBrBobURuk',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0x22c5cdaabaae4b6d3351f9bba9511b0aebb0662a6c209a360f0776e1e77a8438::coin::COIN',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0xcae0ba0b7a435730ab65f1c8357d213e5cf9d4b377b96761745a8edaf9c9df6d::coin::T',
+        decimals: 6,
+      },
+      basegoerli: {
+        address: '0x7B5edB2B3d2BeA8057a736B82AC6EF35c70bdadD',
+        decimals: 6,
+      },
+      arbitrumgoerli: {
+        address: '0x90eC817A1f7C1Eb18dD2985C534A78dD88747F47',
+        decimals: 6,
+      },
+      optimismgoerli: {
+        address: '0xE12be3D96fE101246bF2d290184B0eC6D35d02CA',
+        decimals: 6,
+      },
     },
   },
 };

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -85,6 +85,12 @@ export type TokenConfig = {
   decimals: DecimalsMap;
   wrappedAsset?: string;
   displayName?: string;
+  foreignAssets?: {
+    [chainName in ChainName]?: {
+      address: string;
+      decimals: number;
+    };
+  };
 };
 
 export type TokensConfig = { [key: string]: TokenConfig };

--- a/wormhole-connect/tests/config.test.ts
+++ b/wormhole-connect/tests/config.test.ts
@@ -37,5 +37,13 @@ envTests.forEach((env) => {
         }
       });
     });
+
+    test('tokens with tokenIds match nativeChain', () => {
+      Object.values(TOKENS).forEach((token) => {
+        if (token.tokenId) {
+          expect(token.tokenId.chain).toBe(token.nativeChain);
+        }
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR adds `foreignAsset` to the `tokensConfig` in order to avoid looking up wrapped asset addresses we can pre-calculate. It also includes a check which ensures there are no errors in the `foreignAsset` data and alerts when updates can be made to the config.

The check is run in CI, but can be run manually with the following command (please be patient, as it makes requests slowly in order to avoid getting rate limited).
```
cd wormhole-connect && npx ts-node scripts/checkForeignAssetsConfig.ts
```