### PR TITLE
fix version issue for loader react component

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run lint:ci
+      - run: |
+          IFS='@' read -a strarr <<< $(git describe --tags)
+          sed  -i "s/\"version\": .*/\"version\": \"${strarr[1]}$(echo $([ ${strarr[0]} == "production" ] && echo "" || echo "-${strarr[0]}"))\",/" wormhole-connect-loader/package.json
       - run: npm run build
       - run: |
           cd wormhole-connect-loader
-          IFS='@' read -a strarr <<< $(git describe --tags)
-          sed  -i "s/\"version\": .*/\"version\": \"${strarr[1]}$(echo $([ ${strarr[0]} == "production" ] && echo "" || echo "-${strarr[0]}"))\",/" package.json
           npm publish --tag $(echo $([ ${strarr[0]} == "production" ] && echo "latest" || echo ${strarr[0]})) --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Due to the order-of-operations in the publish workflow, the version in the react component of `@wormhole-foundation/wormhole-connect` was always being set to the version in the committed `package.json` as opposed to the version of the packages being published.