### PR TITLE
fix sizing with default bg

### DIFF
--- a/wormhole-connect/src/components/Background/BackgroundImage.tsx
+++ b/wormhole-connect/src/components/Background/BackgroundImage.tsx
@@ -25,7 +25,6 @@ const useStyles = makeStyles()(() => ({
     overflow: 'hidden',
     width: '100%',
     height: '100%',
-    minHeight: '100vh',
   },
   circles: {
     position: 'absolute',


### PR DESCRIPTION
When using the default background, the widget container was unneccessarily set to 100vh.