### PR TITLE
[Refactor] Optimizations for cosmos getTokenBalances

### DIFF
--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -38,3 +38,23 @@ export class ForeignAssetCache {
     this.cache[assetChain]![assetAddress]![foreignChain] = address;
   }
 }
+
+export const waitFor = (
+  condition: () => Promise<boolean>,
+  ms: number = 1000,
+  tries: number = 100,
+): Promise<void> => {
+  let count = 0;
+  return new Promise((resolve) => {
+    const interval = setInterval(async () => {
+      try {
+        if ((await condition()) || tries <= count) {
+          clearInterval(interval);
+          resolve();
+        }
+      } catch (e) {}
+
+      count++;
+    }, ms);
+  });
+};


### PR DESCRIPTION
 * Reduce the amount of calls to fetch balances to just one for all instead of one per asset
 * Fix issue where the foreign asset cache would not be populated for other chains than wormchain
 * Reduce the overhead created by multiple promises trying to create a Tendermint Client when doing it once would be enough. Leverage the single-threaded nature of JS to control the access to the creation logic through a hacky pseudo-condvar and a static variable.