### PR TITLE
Update RPC warning and documentation

### DIFF
--- a/builder/src/App.tsx
+++ b/builder/src/App.tsx
@@ -438,7 +438,7 @@ function App() {
   const config: WormholeConnectConfig = useMemo(
     () => ({
       env: "testnet", // always testnet for the builder
-      rpcs: testnetRpcs,
+      rpc: testnetRpcs,
       networks: testnetNetworks, // always testnet for the builder
       tokens: testnetTokens, // always testnet for the builder
       mode,

--- a/sdk/src/config/DEVNET.ts
+++ b/sdk/src/config/DEVNET.ts
@@ -81,7 +81,7 @@ const env: Environment = 'DEVNET';
  */
 const DEVNET_CONFIG: WormholeConfig = {
   env,
-  rpcs: {
+  rpc: {
     ethereum: 'http://localhost:8545',
     wormchain: 'http://localhost:26659',
     osmosis: 'http://localhost:33043',

--- a/sdk/src/config/MAINNET.ts
+++ b/sdk/src/config/MAINNET.ts
@@ -252,7 +252,7 @@ const env: Environment = 'MAINNET';
  */
 const MAINNET_CONFIG: WormholeConfig = {
   env,
-  rpcs: {
+  rpc: {
     ethereum: 'https://rpc.ankr.com/eth',
     solana: 'https://api.mainnet-beta.solana.com',
     polygon: 'https://rpc.ankr.com/polygon',

--- a/sdk/src/config/TESTNET.ts
+++ b/sdk/src/config/TESTNET.ts
@@ -257,7 +257,7 @@ const env: Environment = 'TESTNET';
  */
 const TESTNET_CONFIG: WormholeConfig = {
   env,
-  rpcs: {
+  rpc: {
     goerli: 'https://rpc.ankr.com/eth_goerli',
     mumbai: 'https://polygon-mumbai.blockpi.network/v1/rpc/public',
     bsc: 'https://data-seed-prebsc-1-s3.binance.org:8545',

--- a/sdk/src/contexts/aptos/context.ts
+++ b/sdk/src/contexts/aptos/context.ts
@@ -44,7 +44,7 @@ export class AptosContext<
   constructor(context: T, foreignAssetCache: ForeignAssetCache) {
     super();
     this.context = context;
-    const rpc = context.conf.rpcs.aptos;
+    const rpc = context.conf.rpc.aptos;
     if (rpc === undefined) throw new Error('No Aptos rpc configured');
     this.aptosClient = new AptosClient(rpc);
     this.coinClient = new CoinClient(this.aptosClient);

--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -570,7 +570,7 @@ export class CosmosContext<
       return CosmosContext.CLIENT_MAP[name];
     }
 
-    const rpc = this.context.conf.rpcs[name];
+    const rpc = this.context.conf.rpc[name];
     if (!rpc) throw new Error(`${chain} RPC not configured`);
 
     CosmosContext.FETCHING_TM_CLIENT = true;

--- a/sdk/src/contexts/nearContext.ts
+++ b/sdk/src/contexts/nearContext.ts
@@ -23,7 +23,7 @@
 //     senderAddr: string,
 //   ): Promise<Account> {
 //     const networkName = this.context.resolveDomainName(chain) as ChainName;
-//     const rpc = this.context.conf.rpcs[networkName];
+//     const rpc = this.context.conf.rpc[networkName];
 //     if (!rpc) throw new Error(`No connection available for ${networkName}`);
 //     const provider = (
 //       await connect({

--- a/sdk/src/contexts/sei/context.ts
+++ b/sdk/src/contexts/sei/context.ts
@@ -936,11 +936,8 @@ export class SeiContext<
 
   private async getCosmWasmClient(): Promise<CosmWasmClient> {
     if (!this.wasmClient) {
-      if (!this.context.conf.rpcs.sei)
-        throw new Error('Sei RPC not configured');
-      this.wasmClient = await CosmWasmClient.connect(
-        this.context.conf.rpcs.sei,
-      );
+      if (!this.context.conf.rpc.sei) throw new Error('Sei RPC not configured');
+      this.wasmClient = await CosmWasmClient.connect(this.context.conf.rpc.sei);
     }
     return this.wasmClient;
   }

--- a/sdk/src/contexts/solana/context.ts
+++ b/sdk/src/contexts/solana/context.ts
@@ -96,7 +96,7 @@ export class SolanaContext<
     this.context = context;
     const tag = context.environment === 'MAINNET' ? 'mainnet-beta' : 'devnet';
     this.connection = new Connection(
-      context.conf.rpcs.solana || clusterApiUrl(tag),
+      context.conf.rpc.solana || clusterApiUrl(tag),
     );
     this.contracts = new SolContracts(context);
     this.foreignAssetCache = foreignAssetCache;

--- a/sdk/src/contexts/sui/context.ts
+++ b/sdk/src/contexts/sui/context.ts
@@ -49,7 +49,7 @@ export class SuiContext<
   constructor(context: T, foreignAssetCache: ForeignAssetCache) {
     super();
     this.context = context;
-    const connection = context.conf.rpcs.sui;
+    const connection = context.conf.rpc.sui;
     if (connection === undefined) throw new Error('no connection');
     this.provider = new JsonRpcProvider(
       new Connection({ fullnode: connection }),

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -64,7 +64,7 @@ export type ChainConfig = {
 
 export type WormholeConfig = {
   env: Environment;
-  rpcs: ChainResourceMap;
+  rpc: ChainResourceMap;
   rest: ChainResourceMap;
   wormholeHosts: string[];
   chains: {

--- a/sdk/src/wormhole.ts
+++ b/sdk/src/wormhole.ts
@@ -85,7 +85,7 @@ export class WormholeContext extends MultiProvider<Domain> {
    * Registers evm providers
    */
   registerProviders() {
-    for (const network of Object.keys(this.conf.rpcs)) {
+    for (const network of Object.keys(this.conf.rpc)) {
       const n = network as ChainName;
       const chains =
         this.conf.env === 'MAINNET'
@@ -102,8 +102,8 @@ export class WormholeContext extends MultiProvider<Domain> {
         name: network,
       });
       // register RPC provider
-      if (this.conf.rpcs[n]) {
-        this.registerRpcProvider(network, this.conf.rpcs[n]!);
+      if (this.conf.rpc[n]) {
+        this.registerRpcProvider(network, this.conf.rpc[n]!);
       }
     }
   }

--- a/wormhole-connect-loader/README.md
+++ b/wormhole-connect-loader/README.md
@@ -4,7 +4,8 @@ Integration does not get easier than this. Wormhole Connect is an easy seamless 
 
 ## Integrate with script/link tags
 
-> IMPORTANT! For the best performance and functionality, you should provide your own custom rpc endpoints for each supported network.
+> We recommend that you configure your own custom RPC endpoints for each used network for the best performance. The default public RPCs may be throttled or rate limited.  
+
 > Osmosis support is in beta, reach out to a Wormhole contributor for early access.
 
 ### 1. (Optional) Create a JSON config with customized values:

--- a/wormhole-connect-loader/src/types.ts
+++ b/wormhole-connect-loader/src/types.ts
@@ -55,7 +55,7 @@ export interface BridgeDefaults {
 // TODO: move to a shared package
 export interface WormholeConnectConfig {
   env?: "mainnet" | "testnet" | "devnet";
-  rpcs?: Rpcs;
+  rpc?: Rpcs;
   rest?: Rpcs;
   networks?: ChainName[];
   tokens?: string[];

--- a/wormhole-connect/src/config/devnet/index.ts
+++ b/wormhole-connect/src/config/devnet/index.ts
@@ -13,7 +13,7 @@ const DEVNET: NetworkData = {
   chains: DEVNET_CHAINS,
   tokens: DEVNET_TOKENS,
   gasEstimates: DEVNET_GAS_ESTIMATES,
-  rpcs: DEVNET_RPC_MAPPING,
+  rpc: DEVNET_RPC_MAPPING,
   rest: DEVNET_REST_MAPPING,
 };
 

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -82,9 +82,9 @@ export const ROUTES =
   config && config.routes ? config.routes : Object.values(Route);
 
 export const RPCS =
-  config && config.rpcs
-    ? Object.assign({}, sdkConfig.rpcs, NETWORK_DATA.rpcs, config.rpcs)
-    : Object.assign({}, sdkConfig.rpcs, NETWORK_DATA.rpcs);
+  config && config.rpc
+    ? Object.assign({}, sdkConfig.rpc, NETWORK_DATA.rpc, config.rpc)
+    : Object.assign({}, sdkConfig.rpc, NETWORK_DATA.rpc);
 
 export const REST =
   config && config.rest

--- a/wormhole-connect/src/config/mainnet/index.ts
+++ b/wormhole-connect/src/config/mainnet/index.ts
@@ -13,7 +13,7 @@ const MAINNET: NetworkData = {
   chains: MAINNET_CHAINS,
   tokens: MAINNET_TOKENS,
   gasEstimates: MAINNET_GAS_ESTIMATES,
-  rpcs: MAINNET_RPC_MAPPING,
+  rpc: MAINNET_RPC_MAPPING,
   rest: MAINNET_REST_MAPPING,
 };
 

--- a/wormhole-connect/src/config/testnet/index.ts
+++ b/wormhole-connect/src/config/testnet/index.ts
@@ -13,7 +13,7 @@ const TESTNET: NetworkData = {
   chains: TESTNET_CHAINS,
   tokens: TESTNET_TOKENS,
   gasEstimates: TESTNET_GAS_ESTIMATES,
-  rpcs: TESTNET_RPC_MAPPING,
+  rpc: TESTNET_RPC_MAPPING,
   rest: TESTNET_REST_MAPPING,
 };
 

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -57,7 +57,7 @@ export interface BridgeDefaults {
 // TODO: move to a shared package
 export interface WormholeConnectConfig {
   env?: 'mainnet' | 'testnet' | 'devnet';
-  rpcs?: ChainResourceMap;
+  rpc?: ChainResourceMap;
   rest?: ChainResourceMap;
   networks?: ChainName[];
   tokens?: string[];
@@ -132,6 +132,6 @@ export type NetworkData = {
   chains: ChainsConfig;
   tokens: TokensConfig;
   gasEstimates: GasEstimates;
-  rpcs: RpcMapping;
+  rpc: RpcMapping;
   rest: RpcMapping;
 };

--- a/wormhole-connect/src/config/utils.ts
+++ b/wormhole-connect/src/config/utils.ts
@@ -4,7 +4,11 @@ import { BridgeDefaults } from './types';
 import { config, NETWORK_DATA, CHAINS, ROUTES } from '.';
 
 const error = (msg: string) => {
-  console.error(`Wormhole Connect:\n${msg}`);
+  console.error(`Wormhole Connect: ${msg}`);
+};
+
+const info = (msg: string) => {
+  console.info(`Wormhole Connect: ${msg}`);
 };
 
 export const populateRpcField = (
@@ -15,10 +19,10 @@ export const populateRpcField = (
   return { [chainName]: rpc };
 };
 
-export const validateResourceMap = (field: 'rpcs' | 'rest') => {
+export const validateResourceMap = (field: 'rpc' | 'rest') => {
   if (!config || !config[field]) {
-    error(
-      `WARNING! No custom ${field} provided. It is strongly recommended that you provide your own ${field} for the best performance and functionality`,
+    info(
+      `No custom ${field} endpoints provided. We recommended that you configure your own ${field} endpoints for the best performance.`,
     );
     return;
   }
@@ -27,15 +31,15 @@ export const validateResourceMap = (field: 'rpcs' | 'rest') => {
   const chains = Object.keys(CHAINS) as ChainName[];
   for (let chain of chains) {
     if (resourceMap[chain] === defaultResourceMap[chain]) {
-      error(
-        `WARNING! No custom ${field} provided for ${chain}. It is strongly recommended that you provide your own ${field} for the best performance and functionality`,
+      info(
+        `No custom ${field} endpoint provided for ${chain}. We recommended that you provide your own ${field} endpoint for the best performance.`,
       );
     }
   }
 };
 
 export const validateChainResources = () => {
-  validateResourceMap('rpcs');
+  validateResourceMap('rpc');
   validateResourceMap('rest');
 };
 

--- a/wormhole-connect/src/utils/sdk.ts
+++ b/wormhole-connect/src/utils/sdk.ts
@@ -36,7 +36,7 @@ export const wh: WormholeContext = new WormholeContext(
   ENV as Environment,
   {
     ...sdkConfig,
-    ...{ rpcs: RPCS },
+    ...{ rpc: RPCS },
   },
   foreignAssetCache,
 );


### PR DESCRIPTION
1) Update custom RPC console.error warning -> console.info 
2) Update NPM README for custom RPCs
3) Fix inconsistent rpcs/rpc configs and types

Reviewers:
- Please check & provide feedback for updated language
- Please check whether I changed `rpcs` -> `rpc` in the right locations. Since our public config interface uses `rpc`, I updated `rpcs` -> `rpc` where it made sense.
- How can we only show the informational console log during development and not in production builds? IMO, we should only show log critical warnings in production builds and avoid surfacing integrator feedback to end users