### PR TITLE
Aptos rpc errors

### DIFF
--- a/sdk/src/wormhole.ts
+++ b/sdk/src/wormhole.ts
@@ -103,7 +103,9 @@ export class WormholeContext extends MultiProvider<Domain> {
       });
       // register RPC provider
       if (this.conf.rpcs[n]) {
-        this.registerRpcProvider(network, this.conf.rpcs[n]!);
+        if (this.conf.chains[n]?.context === Context.ETH) {
+          this.registerRpcProvider(network, this.conf.rpcs[n]!);
+        }
       }
     }
   }


### PR DESCRIPTION
We were calling `registerProvider` on the Aptos RPC upon initialization.  This attempted to create an ethers JSON rpc provider and call `detectNetwork`.  This resulted in a 405 error because it is not compatible with the Aptos rpc.  Resolved by only registering EVM chain providers.

TODO:
- [ ] Still investigating CORS errors