### PR TITLE
import ethers contracts from esm instead of cjs to reduce bundle size

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,7 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run build -w sdk
-      - run: cd wormhole-connect && npx ts-node scripts/checkForeignAssetsConfig.ts
+      - run: cd wormhole-connect && npx tsx scripts/checkForeignAssetsConfig.ts
   build:
     runs-on: ubuntu-latest
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -2,8 +2,15 @@
   "name": "@wormhole-foundation/wormhole-connect-sdk",
   "version": "0.1.0-beta.0",
   "private": true,
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "./dist/cjs/src/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/src/index.js",
+      "require": "./dist/cjs/src/index.js",
+      "types": "./dist/cjs/index.d.ts"
+    }
+  },
+  "sideEffects": false,
   "dependencies": {
     "@certusone/wormhole-sdk": "^0.10.2",
     "@cosmjs/cosmwasm-stargate": "^0.31.0",
@@ -43,7 +50,7 @@
     "lint": "npm run prettier && eslint --fix ./src",
     "lint:ci": "prettier -c ./src && eslint --max-warnings=0 ./src",
     "prettier": "prettier --write ./src",
-    "build": "tsc --build",
+    "build": "tsc -p tsconfig.cjs.json && tsc -p tsconfig.esm.json",
     "check": "tsc --noEmit",
     "doc": "typedoc src/index.ts --out ../docs"
   },

--- a/sdk/src/contexts/eth/context.ts
+++ b/sdk/src/contexts/eth/context.ts
@@ -1,7 +1,7 @@
 import {
   Implementation__factory,
   TokenImplementation__factory,
-} from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
+} from '@certusone/wormhole-sdk/lib/esm/ethers-contracts';
 import { createNonce } from '@certusone/wormhole-sdk';
 import {
   BigNumber,

--- a/sdk/src/contexts/eth/contracts.ts
+++ b/sdk/src/contexts/eth/contracts.ts
@@ -1,9 +1,9 @@
-import { ethers_contracts } from '@certusone/wormhole-sdk';
+import { ethers_contracts } from '@certusone/wormhole-sdk/lib/esm';
 import {
   Wormhole,
   Bridge,
   NFTBridge,
-} from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
+} from '@certusone/wormhole-sdk/lib/esm/ethers-contracts';
 
 import { ChainName, ChainId, Contracts, Context } from '../../types';
 import { TokenBridgeRelayer } from '../../abis/TokenBridgeRelayer';

--- a/sdk/src/contexts/solana/contracts.ts
+++ b/sdk/src/contexts/solana/contracts.ts
@@ -1,8 +1,8 @@
 import { Connection, clusterApiUrl } from '@solana/web3.js';
 import { Program } from '@project-serum/anchor';
-import { TokenBridge } from '@certusone/wormhole-sdk/lib/cjs/solana/types/tokenBridge';
-import { NftBridge } from '@certusone/wormhole-sdk/lib/cjs/solana/types/nftBridge';
-import { Wormhole } from '@certusone/wormhole-sdk/lib/cjs/solana/types/wormhole';
+import { TokenBridge } from '@certusone/wormhole-sdk/lib/esm/solana/types/tokenBridge';
+import { NftBridge } from '@certusone/wormhole-sdk/lib/esm/solana/types/nftBridge';
+import { Wormhole } from '@certusone/wormhole-sdk/lib/esm/solana/types/wormhole';
 
 import { ChainName, ChainId, Contracts, Context } from '../../types';
 import { ContractsAbstract } from '../abstracts/contracts';

--- a/sdk/src/contexts/sui/context.ts
+++ b/sdk/src/contexts/sui/context.ts
@@ -25,7 +25,7 @@ import {
   getPackageId,
   getTableKeyType,
   trimSuiType,
-} from '@certusone/wormhole-sdk/lib/cjs/sui';
+} from '@certusone/wormhole-sdk/lib/esm/sui';
 import { arrayify, hexlify } from 'ethers/lib/utils';
 import {
   ChainId,

--- a/sdk/src/contexts/sui/relayer.ts
+++ b/sdk/src/contexts/sui/relayer.ts
@@ -1,6 +1,6 @@
 import { JsonRpcProvider, TransactionBlock } from '@mysten/sui.js';
 import { BigNumber, BigNumberish } from 'ethers';
-import { getObjectFields } from '@certusone/wormhole-sdk/lib/cjs/sui';
+import { getObjectFields } from '@certusone/wormhole-sdk/lib/esm/sui';
 
 export interface TokenInfo {
   max_native_swap_amount: string;

--- a/sdk/tsconfig.base.json
+++ b/sdk/tsconfig.base.json
@@ -1,10 +1,5 @@
 {
-  "exclude": [
-    "dist",
-    "node_modules",
-    "tests",
-    "coverage"
-  ],
+  "exclude": ["dist", "node_modules", "tests", "coverage"],
   "include": ["src/**/*.ts", "src/**/*.json"],
   "compilerOptions": {
     "composite": true,
@@ -29,6 +24,6 @@
     "strict": true,
     "baseUrl": "./src",
     "skipLibCheck": true,
-    "outDir": "dist"
-  },
+    "outDir": "dist/cjs"
+  }
 }

--- a/sdk/tsconfig.cjs.json
+++ b/sdk/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "outDir": "dist/cjs"
+  }
+}

--- a/sdk/tsconfig.esm.json
+++ b/sdk/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ES6",
+    "outDir": "dist/esm"
+  }
+}

--- a/wormhole-connect/jest.config.js
+++ b/wormhole-connect/jest.config.js
@@ -2,6 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   transform: {
     '^.+\\.(ts|tsx)?$': 'ts-jest',
-    "^.+\\.(js|jsx)$": "babel-jest",
-  }
+    '^.+\\.(js|jsx)$': 'babel-jest',
+  },
+  moduleNameMapper: {
+    '^@certusone/wormhole-sdk/lib/esm': '@certusone/wormhole-sdk/lib/cjs',
+  },
 };

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -1,5 +1,5 @@
 import { getSignedVAA, parseTokenTransferVaa } from '@certusone/wormhole-sdk';
-import { Implementation__factory } from '@certusone/wormhole-sdk/lib/cjs/ethers-contracts';
+import { Implementation__factory } from '@certusone/wormhole-sdk/lib/esm/ethers-contracts';
 import { utils, providers, BigNumberish } from 'ethers';
 import axios from 'axios';
 import { ChainId, ChainName } from '@wormhole-foundation/wormhole-connect-sdk';


### PR DESCRIPTION
Bundle size before:
![Screenshot from 2023-10-06 11-22-48](https://github.com/wormhole-foundation/wormhole-connect/assets/96065607/d2b387b4-5779-4e3e-9d36-fdae22bba5d9)
Bundle size after:
![Screenshot from 2023-10-06 11-23-03](https://github.com/wormhole-foundation/wormhole-connect/assets/96065607/0e21f613-465d-44e7-8a1c-97a07d320974)
We shave off ~500KB in gzipped bundle size 