### PR TITLE
Switch cosmos chain when changing the from/to network

### DIFF
--- a/wormhole-connect/src/store/wallet.ts
+++ b/wormhole-connect/src/store/wallet.ts
@@ -87,11 +87,12 @@ export const walletSlice = createSlice({
       const { type, error } = payload;
       state[type].error = error;
     },
-    setCurrentAddress: (
+    setAddress: (
       state: WalletState,
       { payload }: PayloadAction<{ type: TransferWallet; address: string }>,
     ) => {
       const { type, address } = payload;
+      state[type].address = address;
       state[type].currentAddress = address;
     },
     clearWallets: (state: WalletState) => {
@@ -121,7 +122,7 @@ export const {
   connectWallet,
   connectReceivingWallet,
   clearWallet,
-  setCurrentAddress,
+  setAddress,
   setWalletError,
   clearWallets,
   disconnectWallet,

--- a/wormhole-connect/src/utils/wallet.ts
+++ b/wormhole-connect/src/utils/wallet.ts
@@ -177,7 +177,7 @@ export const registerWalletSigner = (
 export const switchChain = async (
   chainId: number | string,
   type: TransferWallet,
-) => {
+): Promise<string | undefined> => {
   const w: Wallet = walletConnection[type]! as any;
   if (!w) throw new Error('must connect wallet');
 
@@ -196,6 +196,7 @@ export const switchChain = async (
   if (config.context === Context.COSMOS) {
     await (w as CosmosWallet).switchChain(chainId as string);
   }
+  return w.getAddress();
 };
 
 export const disconnect = async (type: TransferWallet) => {


### PR DESCRIPTION
Cosmos accounts have different address format for each chain (e.g. `osmo1lez...`, `evmos1q9x...`) derived from a public key and a prefix. When changing the network, the asset balances are fetched for the new chain, but requests will fail due to the invalid format of the queried account (e.g. Evmos will return an error when querying balances for `osmo1lez...`).

This PR makes it so that when changing cosmos networks it will request the wallet for a network switch to the new chain and update the store with the new address. I tried decoding the address back to the public key and reencoding for the new chain, but evm cosmos chains use a different account scheme so re-encoding is not correct for some transitions (e.g. Osmosis to Evmos).

Should address #1136 