### PR TITLE
token approval checks

### DIFF
--- a/sdk/src/contexts/eth/context.ts
+++ b/sdk/src/contexts/eth/context.ts
@@ -34,6 +34,7 @@ import { arrayify } from 'ethers/lib/utils';
 import { ForeignAssetCache, chunkArray } from '../../utils';
 
 export const NO_VAA_FOUND = 'No message publish found in logs';
+export const INSUFFICIENT_ALLOWANCE = 'Insufficient token allowance';
 
 export class EthContext<
   T extends WormholeContext,
@@ -288,6 +289,15 @@ export class EthContext<
         overrides,
       );
       await tx.wait();
+      // Metamask allows users to set a different amount than specified above
+      // Check to make sure that the amount set was at least the requested amount
+      const nowApproved = await tokenImplementation.allowance(
+        senderAddress,
+        contractAddress,
+      );
+      if (nowApproved.lt(approveAmount)) {
+        throw new Error(INSUFFICIENT_ALLOWANCE);
+      }
     }
   }
 

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -1,6 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Context } from '@wormhole-foundation/wormhole-connect-sdk';
+import {
+  Context,
+  INSUFFICIENT_ALLOWANCE,
+} from '@wormhole-foundation/wormhole-connect-sdk';
 import { makeStyles } from 'tss-react/mui';
 
 import { CHAINS, TOKENS } from 'config';
@@ -138,9 +141,13 @@ function Send(props: { valid: boolean }) {
       dispatch(setRedeemRoute(route));
       dispatch(setAppRoute('redeem'));
       setSendError('');
-    } catch (e) {
+    } catch (e: any) {
       dispatch(setIsTransactionInProgress(false));
-      setSendError('Error sending transfer, please try again');
+      setSendError(
+        e?.message === INSUFFICIENT_ALLOWANCE
+          ? 'Error due to insufficient token allowance, please try again'
+          : 'Error with transfer, please try again',
+      );
       console.error(e);
     }
   }


### PR DESCRIPTION
Metamask allows users to change the token allowance. This may result in users who end up setting the allowance smaller than the transfer. This change explicitly checks that the allowance is at least large enough for the transfer, otherwise it will show a more specific error.

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/56235822/c2c444f2-900f-41ee-8e64-01e9212e0fb9)

My only hesitancy about performing the check directly after the `.wait()` is that it is theoretically possible to hit a node 
(via the UI) on the subsequent request that is behind the node (via the wallet) which confirmed the tx. In this case, the error may be displayed when the user had approved the correct amount. Still, I didn't run into this given a few tests and I'm not sure the likeliness vs resolving the identified issue.