### PR TITLE
connect: better state syncing / debouncing

### DIFF
--- a/wormhole-connect/src/components/InputTransparent.tsx
+++ b/wormhole-connect/src/components/InputTransparent.tsx
@@ -1,6 +1,5 @@
 import { makeStyles } from 'tss-react/mui';
 import React from 'react';
-import { debounce } from 'utils';
 
 type StyleProps = {
   align?: 'center' | 'right';
@@ -38,11 +37,6 @@ type Props = {
       | React.ChangeEvent<HTMLTextAreaElement>,
   ) => void;
   onEnter?: React.KeyboardEventHandler;
-  onPause?: (
-    e?:
-      | React.ChangeEvent<HTMLInputElement>
-      | React.ChangeEvent<HTMLTextAreaElement>,
-  ) => void;
   disabled?: boolean;
   value?: string | number;
 };
@@ -69,12 +63,6 @@ function InputTransparent(props: Props) {
     }
   };
 
-  const handleKeyUp = debounce(() => {
-    if (props.onPause) {
-      props.onPause();
-    }
-  }, 1000);
-
   return (
     <input
       ref={props.inputRef}
@@ -86,7 +74,6 @@ function InputTransparent(props: Props) {
       step={props.step}
       onChange={onChange}
       onKeyDown={handleKeyDown}
-      onKeyUp={handleKeyUp}
       readOnly={props.disabled}
       value={props.value}
     />

--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -173,16 +173,6 @@ export function isValidTxId(chain: string, tx: string) {
   }
 }
 
-export function debounce(callback: any, wait: number) {
-  let timeout: any;
-  return (...args: any) => {
-    clearTimeout(timeout);
-    timeout = setTimeout(function (this: any) {
-      callback.apply(this, args);
-    }, wait);
-  };
-}
-
 export function usePrevious(value: any) {
   const ref = useRef();
   useEffect(() => {

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -12,16 +12,15 @@ import {
   setSupportedSourceTokens,
   setSupportedDestTokens,
   setAllSupportedDestTokens,
-  setTransferRoute,
   TransferInputState,
 } from 'store/transferInput';
 import { CHAINS, TOKENS, pageHeader } from 'config';
-import { TokenConfig, Route } from 'config/types';
+import { TokenConfig } from 'config/types';
 import { getTokenDecimals, getWrappedToken } from 'utils';
 import { wh, toChainId } from 'utils/sdk';
 import { joinClass } from 'utils/style';
 import { toDecimals } from 'utils/balance';
-import { isTransferValid, validate } from 'utils/transferValidation';
+import { isTransferValid, useValidate } from 'utils/transferValidation';
 import RouteOperator from 'routes/operator';
 
 import GasSlider from './NativeGasSlider';
@@ -78,27 +77,22 @@ function Bridge() {
   const theme = useTheme();
   const dispatch = useDispatch();
   const {
-    validate: showValidationState,
+    showValidationState,
     validations,
     fromChain,
     toChain,
     token,
     destToken,
     route,
-    foreignAsset,
-    associatedTokenAddress,
     isTransactionInProgress,
     amount,
-    availableRoutes,
   }: TransferInputState = useSelector(
     (state: RootState) => state.transferInput,
   );
   const { toNativeToken, relayerFee } = useSelector(
     (state: RootState) => state.relay,
   );
-  const { sending, receiving } = useSelector(
-    (state: RootState) => state.wallet,
-  );
+  const { receiving } = useSelector((state: RootState) => state.wallet);
 
   // check destination native balance
   useEffect(() => {
@@ -184,39 +178,6 @@ function Bridge() {
   }, [route, token, fromChain, toChain, dispatch]);
 
   useEffect(() => {
-    const establishRoute = async () => {
-      if (!showValidationState || !availableRoutes) {
-        dispatch(setTransferRoute(undefined));
-        return;
-      }
-      const routeOrderOfPreference = [
-        Route.CosmosGateway,
-        Route.CCTPRelay,
-        Route.CCTPManual,
-        Route.Relay,
-        Route.Bridge,
-      ];
-      for (const r of routeOrderOfPreference) {
-        if (availableRoutes.includes(r)) {
-          dispatch(setTransferRoute(r));
-          return;
-        }
-      }
-      dispatch(setTransferRoute(undefined));
-    };
-    establishRoute();
-  }, [
-    showValidationState,
-    availableRoutes,
-    fromChain,
-    toChain,
-    token,
-    destToken,
-    amount,
-    dispatch,
-  ]);
-
-  useEffect(() => {
     const recomputeReceive = async () => {
       if (!route) return;
       const newReceiveAmount = await RouteOperator.computeReceiveAmount(
@@ -230,22 +191,7 @@ function Bridge() {
   }, [amount, toNativeToken, relayerFee, route, dispatch]);
 
   // validate transfer inputs
-  useEffect(() => {
-    validate(dispatch);
-  }, [
-    sending,
-    receiving,
-    fromChain,
-    toChain,
-    token,
-    destToken,
-    route,
-    toNativeToken,
-    relayerFee,
-    foreignAsset,
-    associatedTokenAddress,
-    dispatch,
-  ]);
+  useValidate();
   const valid = isTransferValid(validations);
   const disabled = !valid || isTransactionInProgress;
   // if the dest token is the wrapped gas token, then disable the gas slider,

--- a/wormhole-connect/src/views/Bridge/Inputs/AmountInput.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/AmountInput.tsx
@@ -1,8 +1,7 @@
 import React, { useRef } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { RootState } from 'store';
-import { validate } from 'utils/transferValidation';
 import { toFixedDecimals } from 'utils/balance';
 import { NO_INPUT } from 'utils/style';
 
@@ -15,10 +14,9 @@ type Props = {
   disabled?: boolean;
 };
 function AmountInput(props: Props) {
-  const dispatch = useDispatch();
   const amountEl = useRef(null);
   const {
-    validate: showErrors,
+    showValidationState: showErrors,
     validations,
     token,
     isTransactionInProgress,
@@ -38,9 +36,6 @@ function AmountInput(props: Props) {
 
     props.handleAmountChange(value);
   }
-  const validateAmount = () => {
-    validate(dispatch);
-  };
 
   const focus = () => {
     if (amountEl.current) {
@@ -64,7 +59,6 @@ function AmountInput(props: Props) {
           min={0}
           step={0.1}
           onChange={handleAmountChange}
-          onPause={validateAmount}
           disabled={isTransactionInProgress || props.disabled}
           value={props.value}
         />

--- a/wormhole-connect/src/views/Bridge/Inputs/From.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/From.tsx
@@ -30,7 +30,7 @@ function FromInputs() {
   );
   const wallet = useSelector((state: RootState) => state.wallet.sending);
   const {
-    validate: showErrors,
+    showValidationState: showErrors,
     validations,
     route,
     fromChain,

--- a/wormhole-connect/src/views/Bridge/Inputs/Inputs.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/Inputs.tsx
@@ -122,9 +122,8 @@ type Props = {
 function Inputs(props: Props) {
   const { classes } = useStyles();
 
-  const { validate: showErrors, isTransactionInProgress } = useSelector(
-    (state: RootState) => state.transferInput,
-  );
+  const { showValidationState: showErrors, isTransactionInProgress } =
+    useSelector((state: RootState) => state.transferInput);
 
   const chainConfig = props.chain && CHAINS[props.chain];
   const selectedChain = chainConfig

--- a/wormhole-connect/src/views/Bridge/Inputs/To.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/To.tsx
@@ -25,7 +25,7 @@ function ToInputs() {
   const [showChainsModal, setShowChainsModal] = useState(false);
 
   const {
-    validate: showErrors,
+    showValidationState: showErrors,
     validations,
     fromChain,
     toChain,

--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -102,12 +102,13 @@ function GasSlider(props: { disabled: boolean }) {
   const { token, toChain, amount, route, destToken } = useSelector(
     (state: RootState) => state.transferInput,
   );
+  const [debouncedAmount] = useDebounce(amount, 500);
   const { maxSwapAmt, relayerFee } = useSelector(
     (state: RootState) => state.relay,
   );
   const amountNum = useMemo(() => {
-    return Number.parseFloat(amount) - (relayerFee || 0);
-  }, [amount, relayerFee]);
+    return Number.parseFloat(debouncedAmount) - (relayerFee || 0);
+  }, [debouncedAmount, relayerFee]);
   const { receiving: receivingWallet } = useSelector(
     (state: RootState) => state.wallet,
   );
@@ -117,7 +118,7 @@ function GasSlider(props: { disabled: boolean }) {
   const nativeGasToken = TOKENS[destConfig?.gasToken!];
 
   const [state, setState] = useState(INITIAL_STATE);
-  const [debouncedSwapAmt] = useDebounce(state.swapAmt, 250);
+  const [debouncedSwapAmt] = useDebounce(state.swapAmt, 500);
 
   const [gasSliderCollapsed, setGasSliderCollapsed] = useState(props.disabled);
 

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -251,7 +251,7 @@ function RouteOptions() {
   const onSelect = (value: Route) => {
     dispatch(setTransferRoute(value));
   };
-  const [debouncedAmount] = useDebounce(amount, 250);
+  const [debouncedAmount] = useDebounce(amount, 500);
 
   useEffect(() => {
     if (!fromChain || !toChain || !token || !destToken || !debouncedAmount)

--- a/wormhole-connect/src/views/Bridge/ValidationError.tsx
+++ b/wormhole-connect/src/views/Bridge/ValidationError.tsx
@@ -34,7 +34,7 @@ function ValidationError(props: Props) {
   const { classes } = useStyles();
   const dispatch = useDispatch();
   const showErrors = useSelector(
-    (state: RootState) => state.transferInput.validate,
+    (state: RootState) => state.transferInput.showValidationState,
   );
   const { route } = useSelector((state: RootState) => state.transferInput);
   const { toNativeToken, relayerFee } = useSelector(


### PR DESCRIPTION
This PR addresses several bugs related to the state syncing of validation checks and state-based calculations.

## Change 1 - Consistent Validation

After Initially debugging #868, I found the cause was due to `validate` not getting triggered after `setAvailableRoutes`. The `availableRoutes` dependency was not included in the dependency array, but furthermore the `route` would not be "established" until `validate` was triggered with "all of the fields filled out". For now, I kept the one-shot triggering of showing validation errors (where the errors won't show until after the first time the form is filled out), but switched it to take the state dependencies as parameters and created a more appropriate hook to trigger it. This hook debounces the relevant state so that, in a future PR, we can hide errors or display a loader while the validation is waiting to be executed.

### Before

`validate` was not firing after the resolution of the available routes.

![Screenshot from 2023-10-24 21-17-21](https://github.com/wormhole-foundation/wormhole-connect/assets/56235822/5c49bf88-7888-4eec-a113-33d76ddb891f)

### Proper `useValidate`, without debounce

Setting the correct dependencies in the hook caused several more updates, but fired correctly.

![Screenshot from 2023-10-24 21-20-11](https://github.com/wormhole-foundation/wormhole-connect/assets/56235822/27efe59d-96cb-4e78-9aae-59cc02592f87)

### `useValidate` with debounce

Debouncing the state used by the `validate` method reduced the calls back to the previous number + 1, as expected. Now that this debouncing was in place and handled properly calling `validate` on any dependent state updates, the `onPause` effect of the amount input was no longer needed.

![Screenshot from 2023-10-24 21-30-14](https://github.com/wormhole-foundation/wormhole-connect/assets/56235822/aaf6e54c-0dd2-4adf-92db-b533affb07d5)


## Change 2 - Simplify `establishRoute`

Selection of a route was handled by a hook with an overly broad dependency array. Furthermore, the only effective change was when the available routes changed. To avoid two renders, it appeared more effective to move this calculation into the state update of `setAvailableRoutes`.

## Change 3 - Reduce network spam on amount change

As I was testing, I was typing in the amount and every key press was firing off network calls. I identified two culprits:

1. `setSendingGas` - the source chain gas estimation
2. Calculations in the native gas slider

Switching both to a debounced amount cleared up the network calls.

## Future improvements

I believe this PR is an improvement over the previous situation, in that the state more consistently syncs / validates / fires effects and more of the network-call-inducing effects are debounced. However, the user is still subjected to every intermediate state / error while these resolve. Ideally, these intermediate state transitions / errors would be hidden from the user until all of the calls are settled. This could be done by debouncing the errors that are displayed, setting some loading flags, comparing the debounced and non-debounced values, or some combination of these as appropriate.