### PR TITLE
connect: proceed to Redeem screen as soon as the transaction on the cosmos source is completed

### DIFF
--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -1,29 +1,114 @@
 import { CHAIN_ID_WORMCHAIN, ChainId, cosmos } from '@certusone/wormhole-sdk';
-import { IndexedTx, logs as cosmosLogs } from '@cosmjs/stargate';
+import { logs as cosmosLogs } from '@cosmjs/stargate';
 import {
   ChainName,
   CosmosContext,
-  searchCosmosLogs,
   WormholeContext,
+  searchCosmosLogs,
 } from '@wormhole-foundation/wormhole-connect-sdk';
+import { BigNumber, utils } from 'ethers';
 import { arrayify, base58 } from 'ethers/lib/utils.js';
 import { ParsedMessage, wh } from 'utils/sdk';
-import { adaptParsedMessage } from '../../utils';
+import { isGatewayChain } from '../../../utils/cosmos';
 import { UnsignedMessage } from '../../types';
-import { getCosmWasmClient } from '../utils';
+import { adaptParsedMessage } from '../../utils';
 import {
   FromCosmosPayload,
   GatewayTransferMsg,
   IBCTransferData,
 } from '../types';
+import { getCosmWasmClient } from '../utils';
 import {
   findDestinationIBCTransferTx,
   getIBCTransferInfoFromLogs,
 } from './transaction';
-import { BigNumber, utils } from 'ethers';
-import { isGatewayChain } from '../../../utils/cosmos';
 
-export async function getMessageFromNonCosmos(
+export async function getUnsignedMessageFromCosmos(
+  hash: string,
+  chain: ChainName,
+): Promise<ParsedMessage> {
+  // Get tx on the source chain (e.g. osmosis)
+  const sourceClient = await getCosmWasmClient(chain);
+  const tx = await sourceClient.getTx(hash);
+  if (!tx) {
+    throw new Error(`Transaction ${hash} not found on chain ${chain}`);
+  }
+
+  const logs = cosmosLogs.parseRawLog(tx.rawLog);
+  const sender = searchCosmosLogs('sender', logs);
+  if (!sender) throw new Error('Missing sender in transaction logs');
+
+  // get the information of the ibc transfer started by the source chain
+  const ibcPacketInfo = getIBCTransferInfoFromLogs(tx, 'send_packet');
+
+  const data: IBCTransferData = JSON.parse(ibcPacketInfo.data);
+  const payload: FromCosmosPayload = JSON.parse(data.memo);
+
+  const destChain = wh.toChainName(
+    payload.gateway_ibc_token_bridge_payload.gateway_transfer.chain,
+  );
+  const destContext = wh.getContext(destChain);
+  const payloadRecipient =
+    payload.gateway_ibc_token_bridge_payload.gateway_transfer.recipient;
+  const recipient = isGatewayChain(destChain)
+    ? // cosmos addresses are base64 encoded
+      Buffer.from(payloadRecipient, 'base64').toString()
+    : // receiver is an external address, decode through the chain context
+      destContext.parseAddress(
+        '0x' + Buffer.from(payloadRecipient, 'base64').toString('hex'),
+      );
+
+  // transfer ibc denom follows the scheme {port}/{channel}/{denom}
+  // with denom as {tokenfactory}/{ibc shim}/{bas58 cw20 address}
+  // so 5 elements total
+  const parts = data.denom.split('/');
+  if (parts.length !== 5) {
+    throw new Error(`Unexpected transfer denom ${data.denom}`);
+  }
+  const denom = parts.slice(2).join('/');
+  const cw20 = factoryToCW20(denom);
+  const context = wh.getContext(
+    CHAIN_ID_WORMCHAIN,
+  ) as CosmosContext<WormholeContext>;
+  const { chainId, assetAddress: tokenAddressBytes } =
+    await context.getOriginalAsset(CHAIN_ID_WORMCHAIN, cw20);
+  const tokenChain = wh.toChainName(chainId as ChainId); // wormhole-sdk adds 0 (unset) as a chainId
+  const tokenContext = wh.getContext(tokenChain);
+  const tokenAddress = await tokenContext.parseAssetAddress(
+    utils.hexlify(tokenAddressBytes),
+  );
+
+  const base = await adaptParsedMessage({
+    // TODO: this is here so that adaptParsedMessage doesn't throw when fetching the decimals, we should properly implement decimal fetching
+    // for the Cosmos context when the chain is not wormchain
+    // (this would require decoding the IBC denom to retrieve the tokenfactory and then get the CW20) gets replaced later
+    fromChain: wh.toChainName(CHAIN_ID_WORMCHAIN),
+    sendTx: tx.hash,
+    toChain: destChain,
+    amount: BigNumber.from(data.amount),
+    recipient,
+    block: tx.height,
+    sender: data.sender,
+    gasFee: BigNumber.from(tx.gasUsed.toString()),
+    payloadID: 3, // should not be required for this case
+    tokenChain,
+    tokenAddress,
+    tokenId: {
+      address: tokenAddress,
+      chain: tokenChain,
+    },
+    emitterAddress: '',
+    sequence: BigNumber.from(0),
+  });
+
+  return {
+    ...base,
+    fromChain: chain,
+    sender,
+  };
+}
+
+export async function getUnsignedMessageFromNonCosmos(
   hash: string,
   chain: ChainName,
 ): Promise<UnsignedMessage> {
@@ -53,13 +138,6 @@ export async function getMessageFromNonCosmos(
   };
 }
 
-async function parseWormchainBridgeMessage(
-  wormchainTx: IndexedTx,
-): Promise<ParsedMessage> {
-  const message = await wh.getMessage(wormchainTx.hash, CHAIN_ID_WORMCHAIN);
-  return adaptParsedMessage(message);
-}
-
 function factoryToCW20(denom: string): string {
   if (!denom.startsWith('factory/')) return '';
   const encoded = denom.split('/')[2];
@@ -67,69 +145,7 @@ function factoryToCW20(denom: string): string {
   return cosmos.humanAddress('wormhole', base58.decode(encoded));
 }
 
-async function parseWormchainIBCForwardMessage(
-  wormchainTx: IndexedTx,
-): Promise<ParsedMessage> {
-  // get the information of the ibc transfer relayed by the packet forwarding middleware
-  const ibcFromSourceInfo = getIBCTransferInfoFromLogs(
-    wormchainTx,
-    'recv_packet',
-  );
-
-  const data: IBCTransferData = JSON.parse(ibcFromSourceInfo.data);
-  const payload: FromCosmosPayload = JSON.parse(data.memo);
-
-  const destChain = wh.toChainName(
-    payload.gateway_ibc_token_bridge_payload.gateway_transfer.chain,
-  );
-  const ibcToDestInfo = getIBCTransferInfoFromLogs(wormchainTx, 'send_packet');
-  const destTx = await findDestinationIBCTransferTx(destChain, ibcToDestInfo);
-  if (!destTx) {
-    throw new Error(`Transaction on destination ${destChain} not found`);
-  }
-
-  // transfer ibc denom follows the scheme {port}/{channel}/{denom}
-  // with denom as {tokenfactory}/{ibc shim}/{bas58 cw20 address}
-  // so 5 elements total
-  const parts = data.denom.split('/');
-  if (parts.length !== 5) {
-    throw new Error(`Unexpected transfer denom ${data.denom}`);
-  }
-  const denom = parts.slice(2).join('/');
-  const cw20 = factoryToCW20(denom);
-  const context = wh.getContext(
-    CHAIN_ID_WORMCHAIN,
-  ) as CosmosContext<WormholeContext>;
-  const { chainId, assetAddress: tokenAddressBytes } =
-    await context.getOriginalAsset(CHAIN_ID_WORMCHAIN, cw20);
-  const tokenChain = wh.toChainName(chainId as ChainId); // wormhole-sdk adds 0 (unset) as a chainId
-  const tokenContext = wh.getContext(tokenChain);
-  const tokenAddress = await tokenContext.parseAssetAddress(
-    utils.hexlify(tokenAddressBytes),
-  );
-
-  return adaptParsedMessage({
-    fromChain: wh.toChainName(CHAIN_ID_WORMCHAIN), // gets replaced later
-    sendTx: wormchainTx.hash, // gets replaced later
-    toChain: destChain,
-    amount: BigNumber.from(data.amount),
-    recipient: data.receiver,
-    block: destTx.height,
-    sender: data.sender,
-    gasFee: BigNumber.from(destTx.gasUsed.toString()),
-    payloadID: 3, // should not be required for this case
-    tokenChain,
-    tokenAddress,
-    tokenId: {
-      address: tokenAddress,
-      chain: tokenChain,
-    },
-    emitterAddress: '',
-    sequence: BigNumber.from(0),
-  });
-}
-
-export async function getMessageFromCosmos(
+export async function getMessageFromWormchain(
   hash: string,
   chain: ChainName,
 ): Promise<UnsignedMessage> {
@@ -161,14 +177,8 @@ export async function getMessageFromCosmos(
     );
   }
 
-  // TODO: refactor these two lines (repeated in parseWormchainIBCForwardMessage)
-  const data: IBCTransferData = JSON.parse(ibcInfo.data);
-  const payload: FromCosmosPayload = JSON.parse(data.memo);
-  const parsed = await (isGatewayChain(
-    payload.gateway_ibc_token_bridge_payload.gateway_transfer.chain,
-  )
-    ? parseWormchainIBCForwardMessage(destTx)
-    : parseWormchainBridgeMessage(destTx));
+  const message = await wh.getMessage(destTx.hash, CHAIN_ID_WORMCHAIN);
+  const parsed = await adaptParsedMessage(message);
 
   return {
     ...parsed,

--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -64,10 +64,7 @@ export async function getUnsignedMessageFromCosmos(
   );
 
   const base = await adaptParsedMessage({
-    // TODO: this is here so that adaptParsedMessage doesn't throw when fetching the decimals, we should properly implement decimal fetching
-    // for the Cosmos context when the chain is not wormchain
-    // (this would require decoding the IBC denom to retrieve the tokenfactory and then get the CW20) gets replaced later
-    fromChain: wh.toChainName(CHAIN_ID_WORMCHAIN),
+    fromChain: chain,
     sendTx: tx.hash,
     toChain: destChain,
     amount: BigNumber.from(data.amount),


### PR DESCRIPTION
The behaviour of the `GatewayRoute.getMessage` method for gateway transfers from a Cosmos chain would wait until one of the following cases:

1. If the destination is another Cosmos chain, it would wait until the funds actually reached the destination chain
2. If the destination is an external chain, it would wait until the IBC transfer reached Wormchain, the IBC shim contract was executed, and a VAA was emitted

This would cause the application to wait until the "SendFrom" step was completed and then proceed to the Redeem page, instead of advancing as soon as the initial transaction was accepted by the chain, which is the default behaviour for other chains.

Should fix #1139 and #1128