### PR TITLE
connect: update foreign assets cache and script to include gateway chains

### DIFF
--- a/wormhole-connect/scripts/checkForeignAssetsConfig.ts
+++ b/wormhole-connect/scripts/checkForeignAssetsConfig.ts
@@ -70,7 +70,7 @@ const checkEnvConfig = async (
               }
             }
             if (foreignAddress) {
-              let foreignDecimals;
+              let foreignDecimals: number | undefined;
               try {
                 foreignDecimals = await wh.fetchTokenDecimals(
                   tokenConfig.tokenId,
@@ -89,7 +89,10 @@ const checkEnvConfig = async (
                   throw new Error(
                     `❌ Invalid foreign address detected! Env: ${env}, Key: ${tokenKey}, Chain: ${chain}, Expected: ${foreignAddress}, Received: ${configForeignAddress.address}`,
                   );
-                } else if (configForeignAddress.decimals !== foreignDecimals) {
+                } else if (
+                  foreignDecimals &&
+                  configForeignAddress.decimals !== foreignDecimals
+                ) {
                   throw new Error(
                     `❌ Invalid foreign decimals detected! Env: ${env}, Key: ${tokenKey}, Chain: ${chain}, Expected: ${foreignDecimals}, Received: ${configForeignAddress.decimals}`,
                   );

--- a/wormhole-connect/scripts/checkForeignAssetsConfig.ts
+++ b/wormhole-connect/scripts/checkForeignAssetsConfig.ts
@@ -29,6 +29,12 @@ import { TESTNET_TOKENS } from '../src/config/testnet/tokens';
 import { ChainsConfig, TokensConfig } from '../src/config/types';
 import { Network } from '@certusone/wormhole-sdk';
 
+const WORMCHAIN_ERROR_MESSAGES = [
+  '3104 RPC not configured',
+  'wormchain RPC not configured',
+  'Query failed with (18): alloc::string::String not found: query wasm contract failed: invalid request',
+];
+
 // warning: be careful optimizing the RPC calls in this script, you may 429 yourself
 // slow and steady, or something like that
 const checkEnvConfig = async (
@@ -58,12 +64,7 @@ const checkEnvConfig = async (
                 chain,
               );
             } catch (e: any) {
-              if (
-                e?.message === '3104 RPC not configured' ||
-                e?.message === 'wormchain RPC not configured' ||
-                e?.message ===
-                  'Query failed with (18): alloc::string::String not found: query wasm contract failed: invalid request'
-              ) {
+              if (WORMCHAIN_ERROR_MESSAGES.includes(e?.message)) {
                 // do not throw on wormchain errors
               } else {
                 throw e;

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -636,6 +636,10 @@ export const MAINNET_TOKENS: TokensConfig = {
           'ibc/B8381EAF6D22EB6FDA639A94CF67DAF25159D5B96AAAABE8AF7EA3E18A0533E3',
         decimals: 6,
       },
+      base: {
+        address: '0x59f4f969dd3A91A943651C9625E96822DC84Ef94',
+        decimals: 6,
+      },
     },
   },
   BNB: {
@@ -992,6 +996,10 @@ export const MAINNET_TOKENS: TokensConfig = {
       osmosis: {
         address:
           'ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43',
+        decimals: 6,
+      },
+      base: {
+        address: '0xD83385fE100E20c269a5975D4Bf92525BcE09F87',
         decimals: 6,
       },
     },
@@ -1757,6 +1765,10 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xa6252F56cc6eEA21165d56744C795F91c8a3Cf68',
         decimals: 6,
       },
+      base: {
+        address: '0xb96B82Cd6D45d98Fb6897D16A5E4EE888329C513',
+        decimals: 6,
+      },
     },
   },
   ETHoptimism: {
@@ -2030,6 +2042,31 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x55CaD531c8E303Cab8B3BE4bB4744Db4f896ac81',
         decimals: 6,
       },
+      optimism: {
+        address: '0xb931c7BbD87A6e249EaA7355B13927F9c99Bce87',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0x8619F97D4d08382548F536E5CE1D3e0D9bA40326',
+        decimals: 6,
+      },
+      polygon: {
+        address: '0x1eeCaB0F75fE93abbFa0cDFfb4fB13d1dC8706c8',
+        decimals: 6,
+      },
+      avalanche: {
+        address: '0xab933e939a9236BD439F7d29b87CE712f42bAC06',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0xd9E4C283d8A49Dc3767A6F5a4dFdc1d0cEf21604',
+        decimals: 6,
+      },
+      sui: {
+        address:
+          '0x7e3e74afcc1913aa9491c8cee89b02131a6e5519b090f16b54321835c1241cfb::coin::COIN',
+        decimals: 6,
+      },
     },
   },
   OSMO: {
@@ -2105,6 +2142,14 @@ export const MAINNET_TOKENS: TokensConfig = {
         address:
           'ibc/6207D35D2C08F2162575C3C4BFD524226E50639121A273045F1B393AF67DCEB3',
         decimals: 8,
+      },
+      avalanche: {
+        address: '0x3F531c038A0D2d9c7D19FC3554cd0439791526c4',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x94c97dd3Bde5bC1406BCe82E7941A6365968521D',
+        decimals: 18,
       },
     },
   },
@@ -2205,6 +2250,10 @@ export const MAINNET_TOKENS: TokensConfig = {
       osmosis: {
         address:
           'ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E',
+        decimals: 5,
+      },
+      fantom: {
+        address: '0x3fEcdF1248fe7642d29f879a75CFC0339659ab93',
         decimals: 5,
       },
     },

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -80,6 +80,21 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xb47bC3ed6D70F04fe759b2529c9bc7377889678f',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole18csycs4vm6varkp00apuqlsm7v4twg8jsljk8wfdd7cghr7g4rtslwqndm',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/62F82550D0B96522361C89B0DA1119DE262FBDFB25E5502BC5101B5C0D0DBAAC',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/4442A8E0D487A49E76EA6606F5DADCF8D0DBDD8499112340C964970DB745EDA2',
+        decimals: 8,
+      },
     },
   },
   USDCeth: {
@@ -145,6 +160,21 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       optimism: {
         address: '0x711e53D031ea9B0bb0C24dD506df11b41AEA419e',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1utjx3594tlvfw4375esgu72wa4sdgf0q7x4ye27husf5kvuzp5rsr72gdq',
+        decimals: 6,
+      },
+      evmos: {
+        address:
+          'ibc/0C19171CDC59451F91D2749CDEA63355532DCD5D8904CCBAC4953290E16AB8FD',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/6B99DB46AA9FF47162148C1726866919E44A6A5E0274B90912FD17E19A337695',
         decimals: 6,
       },
     },
@@ -214,6 +244,21 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xB214C19d81c99E75e84706a3aa0A757319023e26',
         decimals: 8,
       },
+      wormchain: {
+        address:
+          'wormhole1nz0r0au8aj6dc00wmm3ufy4g4k86rjzlr8wkf92cktdlps5lgfcqxnx9yk',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/46C5DA1CB61C5BAA8730ABA467ADD58DE0333B075CACE28BC87E64AE8C9CA051',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/E4CD61E1FA3EB04EF1BF924D676AB9FD55E84A0DCF4E78C11CCA0E14E5B42672',
+        decimals: 8,
+      },
     },
   },
   USDT: {
@@ -275,6 +320,25 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       arbitrum: {
         address: '0xE4728F3E48E94C6DA2B53610E677cc241DAFB134',
+        decimals: 6,
+      },
+      optimism: {
+        address: '0xf6B4185FCf8aF291c0E3927fbEab7046b4f6A8CA',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1w27ekqvvtzfanfxnkw4jx2f8gdfeqwd3drkee3e64xat6phwjg0savgmhw',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C',
+        decimals: 6,
+      },
+      evmos: {
+        address:
+          'ibc/C9072A294F5649D64E87A6998DD750576881E454CACCDAF7376EFC0FA243808D',
         decimals: 6,
       },
     },
@@ -340,6 +404,21 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x098EA47D630b46df1E08e389e5e4466119c7dd30',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1chejx4qqtvwxy6684yrsmf6pylancxqhk3vsmtleg5ta3zrffljqfscg87',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/898ACF6F5DEBF535103BBD52E3E5B70A311AD097B198A152483F69290B4210C0',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/3CE8A3DE4AE5AE2B4B8C03B2B227CC284732EDC849E506615FF2AA3D8EB1BAFC',
+        decimals: 8,
+      },
     },
   },
   BUSD: {
@@ -381,6 +460,11 @@ export const MAINNET_TOKENS: TokensConfig = {
       aptos: {
         address:
           '0x77400d2f56a01bad2d7c8c6fa282f62647ce3c03f43f2a8742e47ea01a91e24a::coin::T',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole1msyushf6d76u9wupuvm6jdvc0x4trmv5w5kxr0hyt7n9npp233usg7pkhm',
         decimals: 8,
       },
     },
@@ -460,6 +544,20 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x3ab0E28C3F56616aD7061b4db38aE337E3809AEA',
         decimals: 18,
       },
+      optimism: {
+        address: '0x8f02B6a32cebcAe44D2Fd17d87966f5B5dD14c6d',
+        decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1xmpenz0ykxfy8rxr3yc3d4dtqq4dpas4zz3xl6sh873us3vajlpszn4ph7',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/03B6D1925A09B3033AA6FA8772202719ABDC51F8CC2A5C26D0A9B19832F2C023',
+        decimals: 8,
+      },
     },
   },
   USDCpolygon: {
@@ -521,6 +619,21 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       optimism: {
         address: '0x8ab72605E48C1f70A20BdD2B3A217FEc24d777f9',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole19wut8ssulwasjquxpspfeq097kwj2n86fk3vq0g9c8eml2rqtprq97zy3e',
+        decimals: 6,
+      },
+      evmos: {
+        address:
+          'ibc/CA80A29F0D7C5CDCFE97607594E5F8B37AEF5CFB75E260CD321A0A8370C15378',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/B8381EAF6D22EB6FDA639A94CF67DAF25159D5B96AAAABE8AF7EA3E18A0533E3',
         decimals: 6,
       },
     },
@@ -600,6 +713,20 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x7AF00405916D823eDb1121546EfA6F4972B51b84',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole169nr66h9gcsfljvsnxnqfjakskcjt6ac8f58wqjuagu79m540teqfvaal4',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/5394BB30B3C9BD1EE84C9531E5094DDE2490964F518CBE8A4C91F748CE559AF5',
+        decimals: 8,
+      },
+      optimism: {
+        address: '0x6A09fE65ACa27C12573F04aAFa290bD75497E1BC',
+        decimals: 18,
+      },
     },
   },
   USDCbnb: {
@@ -667,6 +794,21 @@ export const MAINNET_TOKENS: TokensConfig = {
       optimism: {
         address: '0x1C15057d1F3794C934a6cBC1f7EceE934050F219',
         decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1g3acw7aumaj3r348cqn4kazrehlmn822w9p46sqwztnke27h3lysxj4ddr',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/8E08C01546EF346F7E9A3600DDBC88943ADF3B20A67F1F2DD7B83D85613BCCAB',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/B28ACEF11D063FA8B1DA73C2F7DA3A1CFCCBC13E96B671698D4860E9367B55BB',
+        decimals: 8,
       },
     },
   },
@@ -749,6 +891,26 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x8418C1d909842f458c9394886b83F19d62bF1A0D',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1ml922hnp59jtq9a87arekvx60ezehwlg2v3j5pduplwkenfa68ksgmzxwr',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/28E7241F6508EB4692C721E91201377323796EF2758CCD83D220A40EAD32601E',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/2EA2FE172078576E62DA20F14EEED12B26611D93150FE1D68E1AAE00479AC335',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/22B44C7369EED16089B9840ADE399B80D9483B4E459E67643C96C681D7C463D0',
+        decimals: 8,
+      },
     },
   },
   USDCavax: {
@@ -810,6 +972,26 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       optimism: {
         address: '0x355f0a8a7ecAeD971b8Fbd50994558291ff2413a',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1gwm6mrnse9atzf4mer4dnrz64mp6pa75wpsxywu8gymt9fwsk46sfr372u',
+        decimals: 6,
+      },
+      kujira: {
+        address:
+          'ibc/F9F41DB8DA49EA6AB9EB4B2C9E0ECDC2502ABDA2FE728B85994BF31240CBC163',
+        decimals: 6,
+      },
+      evmos: {
+        address:
+          'ibc/39913E647C3549D663B1ED7F0745E1779515170C5215B98B2C8410B4C073AD30',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/0B3C3D06228578334B66B57FBFBA4033216CEB8119B27ACDEE18D92DA5B28D43',
         decimals: 6,
       },
     },
@@ -893,6 +1075,21 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x0b0ecbe5C3995541876d27633B63296570FB34Af',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1e0cwfmla7exa578xddl87paxexw9ymwrzysfjms8c2mstxjkldlqn45jqa',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/9EFE5F5D75A87197DD257BA7A96A3BCCEC9DB59D257C742FB5AA9D3DF612D476',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/397DFE63D87F6940ECA583DFF5461E48BF0BA6554CBBE70278E307DDFDC8E9D5',
+        decimals: 8,
+      },
     },
   },
   CELO: {
@@ -960,6 +1157,21 @@ export const MAINNET_TOKENS: TokensConfig = {
       optimism: {
         address: '0x9b88D293b7a791E40d36A39765FFd5A1B9b5c349',
         decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1kqey3a6k26kyensq7elcpx229tlj4d3qlshwhjq5xjm8dcdvu60qtef8k9',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/83300733052AB5F6E0F0C221E24189B6DF26CC94C73D2F44627627F9DEF4A9C8',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/4ACD155D71182398277CBD2C630A7C8C5F0F16FFF77965FDE4C845A4CDE2D60C',
+        decimals: 8,
       },
     },
   },
@@ -1041,6 +1253,21 @@ export const MAINNET_TOKENS: TokensConfig = {
       optimism: {
         address: '0xbffD46DFDb8d3a02b8D2E0F864a2cD712090a4D3',
         decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1gzuv84xrwwhxhf0f62av279vfyrfrm7x58fcnadlr5m90gnx223ses2st0',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/0F2941B0168D8DB77DA1B6A2D3A95EC04026D3C97FA3BFE8FD1D5D3F983AA518',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/3D337ECC89A8421DD6F33C4B7DDE9D4A18D728A4A688BA30E41F466EC8DD3869',
+        decimals: 8,
       },
     },
   },
@@ -1125,6 +1352,26 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xba1Cf949c382A32a09A17B2AdF3587fc7fA664f1',
         decimals: 9,
       },
+      wormchain: {
+        address:
+          'wormhole1wn625s4jcmvk0szpl85rj5azkfc6suyvf75q6vrddscjdphtve8sca0pvl',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/E5CA126979E2FFB4C70C072F8094D07ECF27773B37623AD2BF7582AD0726F0F3',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/1E43D59E565D41FB4E54CA639B838FFD5BCFC20003D330A56CB1396231AA1CBA',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/4443218F584A7AB2DFBCF93872D6E5B6967A11C53515DDF45A2CF387C54BD73A',
+        decimals: 8,
+      },
     },
   },
   USDCsol: {
@@ -1186,6 +1433,20 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       optimism: {
         address: '0x6F974A6dfD5B166731704Be226795901c45Bb815',
+        decimals: 6,
+      },
+      base: {
+        address: '0xe8CE40EBBB844142400D21558a2F1c9683d69139',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole17fr8awnysyv3nt5je4strczdupssl8u9jqam890jfv72sh32yyqqhtg3ry',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45',
         decimals: 6,
       },
     },
@@ -1256,6 +1517,21 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0x27A533e438892DA192725b4C9AcA51447F457212',
         decimals: 9,
       },
+      wormchain: {
+        address:
+          'wormhole19hlynxzedrlqv99v6qscww7d3crhl86qtd0vprpltg5g9xx6jk9q6ya33y',
+        decimals: 8,
+      },
+      kujira: {
+        address:
+          'ibc/EBA52E7239CC1BC7F8ECF4F41523B6DD477FF067FD953315704A9A4FD2131B48',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/B1C287C2701774522570010EEBCD864BCB7AB714711B3AA218699FDD75E832F5',
+        decimals: 8,
+      },
     },
   },
   APT: {
@@ -1321,6 +1597,16 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       optimism: {
         address: '0xC5B3AC2DF8D8D7AC851F763a5b3Ff23B4A696d59',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole1f9sxjn0qu8xylcpzlvnhrefnatndqxnrajfrnr5h97hegnmsdqhsh6juc0',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/A4D176906C1646949574B48C1928D475F2DF56DE0AC04E1C99B08F90BC21ABDE',
         decimals: 8,
       },
     },
@@ -1401,6 +1687,20 @@ export const MAINNET_TOKENS: TokensConfig = {
       optimism: {
         address: '0x825206E1D29456337769e6f1384101E997C6A732',
         decimals: 18,
+      },
+      moonbeam: {
+        address: '0x18872b45c603eD2EbC508b9C5514a85c2e2791FB',
+        decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole18nlwscr7290j463vcptqlgqudycry2rdnw2ysltpc2nqefk3353s808rl9',
+        decimals: 8,
+      },
+      evmos: {
+        address:
+          'ibc/9E2E7B4A53409267CD686F4EB67969C2602A0F5FF9BDB1082B00E71CC4815DDE',
+        decimals: 8,
       },
     },
   },
@@ -1516,6 +1816,31 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xB1fC645a86fB5085e12D8BDDb77702F728D2A26F',
         decimals: 18,
       },
+      avalanche: {
+        address: '0xDf11535274c0FD2Fe41A88bd1bBF802D72296037',
+        decimals: 18,
+      },
+      bsc: {
+        address: '0x94AEc09B5e2CE591e39DC6aa58A3A6E85Ed45265',
+        decimals: 18,
+      },
+      ethereum: {
+        address: '0x8B5653Ae095529155462eDa8CF664eD96773F557',
+        decimals: 18,
+      },
+      polygon: {
+        address: '0x8182De59485Bb646542Db8C7E5958148Dc699319',
+        decimals: 18,
+      },
+      base: {
+        address: '0xCb725aC8d9985D3bE306Dd9e1517d3702929176c',
+        decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1ev8rhdflmlq6de5g7ttj585fhuv3jfhnuhfzyh7qrswhzaq2tkqswxz6y3',
+        decimals: 8,
+      },
     },
   },
   USDCoptimism: {
@@ -1547,6 +1872,20 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       base: {
         address: '0xc6bfBeb3002aD563D2d1f72614C61C83Bf147Acd',
+        decimals: 6,
+      },
+      arbitrum: {
+        address: '0x3A5C2Da9E30741cb59a5e9446A23A86886fC9DC2',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1snw0qugpjcxwtxzzkqt5guwavq85eumxzeagql2u2m662xrtnjuqyj3pkj',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0x4f6ecb05a797902d472abc2f5804bde93a53d8b75f14f767824cdb1623a4ee83::coin::T',
         decimals: 6,
       },
     },
@@ -1664,6 +2003,34 @@ export const MAINNET_TOKENS: TokensConfig = {
     decimals: {
       default: 6,
     },
+    foreignAssets: {
+      solana: {
+        address: 'EfqRM8ZGWhDTKJ7BHmFvNagKVu3AxQRDQs8WMMaoBCu6',
+        decimals: 6,
+      },
+      moonbeam: {
+        address: '0xE6d02a875CcC153c076fe418f33De3A5C420f505',
+        decimals: 6,
+      },
+      celo: {
+        address: '0x2e2acb1782Aad0490f8446b6fD4626C467987bD6',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1edkult6zudk6ld23fesjfrehux35q86engsq5jlycl0e4upkz8mqkgcprf',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/8AC0F990290BBEF3AEBFCBF70F902AD954781BB40D07EB76341272800D48D05F',
+        decimals: 6,
+      },
+      bsc: {
+        address: '0x55CaD531c8E303Cab8B3BE4bB4744Db4f896ac81',
+        decimals: 6,
+      },
+    },
   },
   OSMO: {
     key: 'OSMO',
@@ -1729,6 +2096,16 @@ export const MAINNET_TOKENS: TokensConfig = {
         address: '0xeC0a755664271b87002dDa33CA2484B24aF68912',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1nu9wf9dw384attnpu0pwfet5fajn05w2ex4r07mghvk3xcwrt2yq5uutp5',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/6207D35D2C08F2162575C3C4BFD524226E50639121A273045F1B393AF67DCEB3',
+        decimals: 8,
+      },
     },
   },
   wstETH: {
@@ -1753,6 +2130,24 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       solana: {
         address: 'ZScHuTtqZukUrtZS43teTKGs2VqkKL8k4QCouR2n6Uo',
+        decimals: 8,
+      },
+      arbitrum: {
+        address: '0xf2717122Dfdbe988ae811E7eFB157aAa07Ff9D0F',
+        decimals: 18,
+      },
+      optimism: {
+        address: '0x855CFcEEe998c8ca34F9c914F584AbF72dC88B87',
+        decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1gg6f95cymcfrfzhpek7cf5wl53t5kng52cd2m0krgdlu8k58vd8qezy8pt',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/BF75AE1500CB7EC458E91A11731F1B6AC1F1FE1FA937A88564955ED6A83CA2FB',
         decimals: 8,
       },
     },
@@ -1800,6 +2195,16 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
       arbitrum: {
         address: '0x09199d9A5F4448D0848e4395D065e1ad9c4a1F74',
+        decimals: 5,
+      },
+      wormchain: {
+        address:
+          'wormhole10qt8wg0n7z740ssvf3urmvgtjhxpyp74hxqvqt7z226gykuus7eq9mpu8u',
+        decimals: 5,
+      },
+      osmosis: {
+        address:
+          'ibc/CA3733CB0071F480FAE8EF0D9C3D47A49C6589144620A642BBE0D59A293D110E',
         decimals: 5,
       },
     },

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -1666,6 +1666,31 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       default: 6,
     },
+    foreignAssets: {
+      moonbasealpha: {
+        address: '0x7480641F5B00b4Fc39d6AaeC4Cd851EdEA7f31CF',
+        decimals: 6,
+      },
+      goerli: {
+        address: '0x5aA392243437dDC8b4d86bfC90DF296908740A41',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1ja4txt6m0jjq0gmjtmv442f8wk0r5f5apaya0z55wwlrpg3p5xaq3qxw7h',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/8560BA5F45C95AE716C05978E364F50C98347ACBEC745840C30F91611FA36698',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/2E4F8BC7F7AF33752CF7E290CAD4417EE67CD18FFC0D099E6519A440E588E0CE',
+        decimals: 6,
+      },
+    },
   },
   OSMO: {
     key: 'OSMO',

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -85,6 +85,11 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0x33Db338718aC89Cd8DB13B56af05be3a3029BBE5',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1vguuxez2h5ekltfj9gjd62fs5k4rl2zy5hfrncasykzw08rezpfs63pmq2',
+        decimals: 8,
+      },
     },
   },
   USDCeth: {
@@ -147,6 +152,11 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0x0382F518AcE1a86224c78B7CDfa67B9774055A1b',
         decimals: 6,
       },
+      wormchain: {
+        address:
+          'wormhole1rl8su3hadqqq2v86lscpuklsh2mh84cxqvjdew4jt9yd07dzekyqkmcy3p',
+        decimals: 6,
+      },
     },
   },
   WBTC: {
@@ -193,6 +203,20 @@ export const TESTNET_TOKENS: TokensConfig = {
       },
       arbitrumgoerli: {
         address: '0x2B732F5ad6117818Ad3b7aC73C16033F6ECD78E5',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x32eF19C4b3DF65a24972A489e70AdDef5E54262C',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1v2efcqkp2qtev06t0ksjnx6trxdd0f7fxg2zdrtzr8cr9wdpjkyqkv9ch6',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/755FBC53FFB46FB505B5269F9BEDF47041F2A0EF2FF8D0520315403E5925C80A',
         decimals: 6,
       },
     },
@@ -244,6 +268,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       basegoerli: {
         address: '0x31B2BAEE47Dc5Fc06baEC1BF73C124031b44fB97',
         decimals: 18,
+      },
+      sui: {
+        address:
+          '0xe6fc78aa2b52b785bdcb67901cd85793a0b593248f315cb755974d23d0fcb837::coin::COIN',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole1uuwad4khwek2h05gmkktzmh8l4t0ep54yydlsqg0l4y2uh3tqfyq3an9k6',
+        decimals: 8,
       },
     },
   },
@@ -331,6 +365,16 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0x427B5a0b0384D7FD3AF81805A166a2d9C1116D7d',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1vhjnzk9ly03dugffvzfcwgry4dgc8x0sv0nqqtfxj3ajn7rn5ghq6whn2p',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/37FB599287C6963C413E915FDE83EFA69A3CE8147675DD5A7F974B45F39C8A31',
+        decimals: 8,
+      },
     },
   },
   USDCpolygon: {
@@ -380,6 +424,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       sei: {
         address:
           'sei1vccw9g60mphsaj9t96vru53mjje3vmxcl49lg8lfqdh0zgmq6zsqf03y9n',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1qmk0v725sdg5ecu6xfh5pt0fv0nfzrstarue2maum3snzk2zrt5qcm4w3g',
         decimals: 6,
       },
     },
@@ -464,6 +513,16 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0xB039aC4Fa8Ed99d30C2f7D791294A9d5FAd698eF',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1335rlmhujm0gj5e9gh7at9jpqvqckz0mpe4v284ar4lw5mlkryzsnetfsj',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/5B0D5974A56332468DD4B2D07C96A7386FCF8FE7303FF41234F90E410EF51937',
+        decimals: 8,
+      },
     },
   },
   AVAX: {
@@ -546,6 +605,21 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0x92b0C4D27a05921Ded4BB117755990F567aEe049',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole1tqwwyth34550lg2437m05mjnjp8w7h5ka7m70jtzpxn4uh2ktsmq8dv649',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/BAEAC83736444C09656FBE666FB625974FCCDEE566EB700EBFD2642C5F6CF13A',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/99EAD53D49EC7CC4E2E2EB26C22CF81C16727DF0C4BF7F7ACBF0D22D910DB5DE',
+        decimals: 8,
+      },
     },
   },
   USDCavax: {
@@ -612,6 +686,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       },
       arbitrumgoerli: {
         address: '0xb39697B8BA5df91A169690DfEf88B911436619F2',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv2exs9',
         decimals: 6,
       },
     },
@@ -691,6 +770,26 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0xa507f7566B8aDE000E886166B95964677ef3b3Ef',
         decimals: 18,
       },
+      aptos: {
+        address:
+          '0x533c6ade00d15d1e014c41e29e34853e87df92c4e01a6a3f41318dbd098048d6::coin::T',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole1808lz8dp2c39vhm9gnemt7zzj95nvrmjepxp7v3w4skzrlyzcmnsxkduxf',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/145C6B688F70B0C2F6D87546A5974A75CE75B3A2940275B750E65797B2996157',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/919D8F138B7E71BB067C7301AB5C2D48415E8C3A2D9187861245CEC668F88E3C',
+        decimals: 8,
+      },
     },
   },
   CELO: {
@@ -759,6 +858,21 @@ export const TESTNET_TOKENS: TokensConfig = {
       arbitrumgoerli: {
         address: '0x9592eE6eD1D9E611b7aa6F20CCbD7Ba571Be8bdd',
         decimals: 18,
+      },
+      wormchain: {
+        address:
+          'wormhole1e8z2wjelypwxw5sey62jvwjyup88w55q3h6m0x8jtwjf6sx5c7ys4mzydk',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/3A4EA3F8096856C0802F86B218DD74213B4C10224AA44BBD54AEAAA2ABF078BA',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/009206915358A002C852A2A2CBEDB8446D2D02E519C815087A01F8BDB4DF77BA',
+        decimals: 8,
       },
     },
   },
@@ -836,6 +950,21 @@ export const TESTNET_TOKENS: TokensConfig = {
       optimismgoerli: {
         address: '0x99436d62259532E0407A7aE78A3b48D119B13903',
         decimals: 18,
+      },
+      aptos: {
+        address:
+          '0x338373b6694f71dbeac5ca4a30503bf5f083888d71678aed31255de416be37c0::coin::T',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole10sfpr8ykh9xn93u8xec4ed3990nmvh86e0vaegkauqhlkxspysyqwavrxx',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/1EEDF447A6B046B20C00B1497BED5947219AEEBE0D9A85235C85133A554DF7A4',
+        decimals: 8,
       },
     },
   },
@@ -921,6 +1050,16 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0x06EcAF6638070Ccf3b3dEA421b3becAA57f3e559',
         decimals: 9,
       },
+      wormchain: {
+        address:
+          'wormhole1gryz69gzl6mz2m66a4twg922jtlc47nlx73sxv88lvq86du5zvyqz3mt23',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/D3EA463A51E31B2B30BED1978575CAC145DBAB354B8A0EA5D4CFB12D737AF790',
+        decimals: 8,
+      },
     },
   },
   USDCsol: {
@@ -940,6 +1079,11 @@ export const TESTNET_TOKENS: TokensConfig = {
     foreignAssets: {
       bsc: {
         address: '0x51a3cc54eA30Da607974C5D07B8502599801AC08',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1ced9v4plkf25q8c6k9gz0guq6l4xyjujpjlvxfg8lpaqywkmamashswq7p',
         decimals: 6,
       },
     },
@@ -1007,6 +1151,20 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0xe64e2139fdf6Ee7e3795FE51955e21bA3d9eB9F7',
         decimals: 9,
       },
+      moonbasealpha: {
+        address: '0x2ed4B5B1071A3C676664E9085C0e3826542C1b27',
+        decimals: 9,
+      },
+      wormchain: {
+        address:
+          'wormhole1yf4p93xu68j5fseupm4laj4k6f60gy7ynx6r5vvyr9c0hl3uy8vqpqd6h0',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/129EC6B8A41BE07F94DD267F552F4AE1D5EAEBB51634A1468556AF06C10C2692',
+        decimals: 8,
+      },
     },
   },
   APT: {
@@ -1070,6 +1228,21 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0xa81C3BEf2d6f10213b860458DC119666C0ba13bf',
         decimals: 8,
       },
+      wormchain: {
+        address:
+          'wormhole1u8rft0gee23fa6a0t4t88ualrza5lj8ses4aur0l66c7efpvjezqchv34j',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/0CCA5EB15BC2FE474E71DBC9698302CDE260B6F6548F91C30002F7CBF228197B',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/7C495BD95757ED662A897C139F1C9F18275A86EE7203A0B073E2DB12B1E19D63',
+        decimals: 8,
+      },
     },
   },
   ETHarbitrum: {
@@ -1128,6 +1301,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'sei1pf5j3dgngm8yj2xkwmvmvt87g4vyc0szpjz92q8ly9erh23ytn4s983htv',
         decimals: 8,
       },
+      wormchain: {
+        address:
+          'wormhole186k0cp83c3wyvapgh8fxf66ededemzrfujvjfsx0xw3vr0u9g8sq2y30vx',
+        decimals: 8,
+      },
     },
   },
   USDCarbitrum: {
@@ -1151,6 +1329,21 @@ export const TESTNET_TOKENS: TokensConfig = {
       },
       alfajores: {
         address: '0x0C4AbF95Ff3d82d1F02f55e65050eA5bA062606E',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1s3pk90ccfl6ueehnj8s9pdgyjjlspmr3m5rv46arjh5v4g08dd0qrchjrk',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/6D1B6A7A9EF692A279A6B5994C98C0D598D003D9203BE8309F14B6E57A58506E',
+        decimals: 6,
+      },
+      aptos: {
+        address:
+          '0x3f0fdd44d96dae888d6c576218cf655458316a27c7bdc46537f61e531b10d3df::coin::T',
         decimals: 6,
       },
     },
@@ -1206,6 +1399,16 @@ export const TESTNET_TOKENS: TokensConfig = {
         address: '0xFd903eA23Bf65f26FdAf2eeb589cf007b108882E',
         decimals: 18,
       },
+      wormchain: {
+        address:
+          'wormhole12eu6c7f67l8gdl2lt0hz0dgdh24dhune6wjgy5t0es3tpfzhc3yspwnpfy',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/A0298483510D803A045AA7F49CCBD0F9D01010FE0B1A346EBDFFF4BA820C3D21',
+        decimals: 8,
+      },
     },
   },
   USDCoptimism: {
@@ -1221,6 +1424,21 @@ export const TESTNET_TOKENS: TokensConfig = {
     color: '#2774CA',
     decimals: {
       default: 6,
+    },
+    foreignAssets: {
+      moonbasealpha: {
+        address: '0xf98E630a3DD4F21Cab7a37Bb01209cb62959169D',
+        decimals: 6,
+      },
+      fantom: {
+        address: '0x685B29e17440c42758Ab3F80FD3603EF01bebe9A',
+        decimals: 6,
+      },
+      wormchain: {
+        address:
+          'wormhole1u5z7097gm57zvun9wqsx6jxej2gpdjhg9l9xfe58rhpm29rtjmfqfnl4yv',
+        decimals: 6,
+      },
     },
   },
   ETHbase: {
@@ -1290,6 +1508,21 @@ export const TESTNET_TOKENS: TokensConfig = {
       sei: {
         address:
           'sei1kdqylzcv86t7slg8m30mlfgna9xsrusghdgnavvurkv0rku7jvqqta7lka',
+        decimals: 8,
+      },
+      sui: {
+        address:
+          '0x7b442b988864149dedfb9b6a75a88c7c33b9ddd3d15a87bf25104e1fcdd680ab::coin::COIN',
+        decimals: 8,
+      },
+      wormchain: {
+        address:
+          'wormhole10p89p4zh00dwdg8h52sysrqm0l2j47jj3kmg93pnz2a039ucw7esgl5vl9',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/97035986A4BD0AF555713355A02EA31A4526616B6543E019E0D750007FABE06C',
         decimals: 8,
       },
     },
@@ -1406,6 +1639,13 @@ export const TESTNET_TOKENS: TokensConfig = {
     decimals: {
       default: 8,
       Ethereum: 18,
+    },
+    foreignAssets: {
+      wormchain: {
+        address:
+          'wormhole1u2zdjcczjrenwmf57fmrpensk4the84azdm05m3unm387rm8asdsxqwfeu',
+        decimals: 8,
+      },
     },
   },
   SEI: {

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -90,6 +90,16 @@ export const TESTNET_TOKENS: TokensConfig = {
           'wormhole1vguuxez2h5ekltfj9gjd62fs5k4rl2zy5hfrncasykzw08rezpfs63pmq2',
         decimals: 8,
       },
+      osmosis: {
+        address:
+          'ibc/A4A8B6AE885DACD75B228031C0D18AD7EE1B914CED30C9F6F4230DDBD4A1CF2B',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/77FE9153FA76C3107CB9F6633AC33509A58529E9622327F216BA8107C79C2DE3',
+        decimals: 8,
+      },
     },
   },
   USDCeth: {
@@ -157,6 +167,16 @@ export const TESTNET_TOKENS: TokensConfig = {
           'wormhole1rl8su3hadqqq2v86lscpuklsh2mh84cxqvjdew4jt9yd07dzekyqkmcy3p',
         decimals: 6,
       },
+      cosmoshub: {
+        address:
+          'ibc/D0EC31D1176BB69EA1A7CF7172CA0380B7AF488AFC6D55B101B8363C2141CD4F',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/3BB8C4BD1C90599B2FA5B5839DD0813EF7B94B0BD0904C4C5A61498AE81E0EE9',
+        decimals: 6,
+      },
     },
   },
   WBTC: {
@@ -219,6 +239,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'ibc/755FBC53FFB46FB505B5269F9BEDF47041F2A0EF2FF8D0520315403E5925C80A',
         decimals: 6,
       },
+      osmosis: {
+        address:
+          'ibc/1941ED1147121BA7DF35559597B6EB3251844DBBBE4557337D957CB95E0978C2',
+        decimals: 6,
+      },
     },
   },
   DAI: {
@@ -277,6 +302,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1uuwad4khwek2h05gmkktzmh8l4t0ep54yydlsqg0l4y2uh3tqfyq3an9k6',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/5F21E975410DA22AF565B1772DC45AD0BD5F6DA004981EBE291763F3D2C72A96',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/2864B3418775DDB90EE1410EFF822FDA94E9F0FF77FC8771644761C79EDFE7A3',
         decimals: 8,
       },
     },
@@ -375,6 +410,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'ibc/37FB599287C6963C413E915FDE83EFA69A3CE8147675DD5A7F974B45F39C8A31',
         decimals: 8,
       },
+      osmosis: {
+        address:
+          'ibc/43F15553F8598186394E81E18604B8B4532B2D7E855D9FFE68A2EF6802C18BE4',
+        decimals: 8,
+      },
     },
   },
   USDCpolygon: {
@@ -429,6 +469,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1qmk0v725sdg5ecu6xfh5pt0fv0nfzrstarue2maum3snzk2zrt5qcm4w3g',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/ED0651B0141CA50326B1FFA2E9207F42BE616DE2712356CF8DA4B8CAC4A6A5B6',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/FDEEB950A2538F30EBA949B9F8D0D28DAC9D26D0B138445BF0DF9FC4B800E1F9',
         decimals: 6,
       },
     },
@@ -521,6 +571,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       cosmoshub: {
         address:
           'ibc/5B0D5974A56332468DD4B2D07C96A7386FCF8FE7303FF41234F90E410EF51937',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/65A67BA10DE2378B32AC5A822321E370966D3D4E180DEFB4C3C5245B21088DDF',
         decimals: 8,
       },
     },
@@ -691,6 +746,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1qum2tr7hh4y7ruzew68c64myjec0dq2s2njf6waja5t0w879lutqv2exs9',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/F09E98FA8682FF39130F171E9D89A948B0C3A452F2A31F22B6CC54A3AAE1CD4A',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/EC9FA5074F34F0644A025BB0263FDAE8F364C5E08523F6464465EF1010FF5A3A',
         decimals: 6,
       },
     },
@@ -966,6 +1031,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'ibc/1EEDF447A6B046B20C00B1497BED5947219AEEBE0D9A85235C85133A554DF7A4',
         decimals: 8,
       },
+      osmosis: {
+        address:
+          'ibc/7DB06BB67428510AFC3967DC90F5632C679D55D8C487A951A0EEC3160AF492A6',
+        decimals: 8,
+      },
     },
   },
   SOL: {
@@ -1060,6 +1130,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'ibc/D3EA463A51E31B2B30BED1978575CAC145DBAB354B8A0EA5D4CFB12D737AF790',
         decimals: 8,
       },
+      osmosis: {
+        address:
+          'ibc/B5D53105A7AA2BEC4DA4B3304228F3856219AE7CF84A9023043C481629E3E319',
+        decimals: 8,
+      },
     },
   },
   USDCsol: {
@@ -1084,6 +1159,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1ced9v4plkf25q8c6k9gz0guq6l4xyjujpjlvxfg8lpaqywkmamashswq7p',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/26D8D6C63C8D37A5127591DDA905E04CC69CBD3A64F9DA3B1DA3FB0B6A7D9FA5',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/35A0467DE5744662078DE8B36CBBE0CF0EAA022565A3E6630CB375DDEBB96E05',
         decimals: 6,
       },
     },
@@ -1163,6 +1248,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       cosmoshub: {
         address:
           'ibc/129EC6B8A41BE07F94DD267F552F4AE1D5EAEBB51634A1468556AF06C10C2692',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/30778BA41ADF2D8A70B90DB53C2E0251731A40276EF6737215BB1A6ED9E90078',
         decimals: 8,
       },
     },
@@ -1306,6 +1396,16 @@ export const TESTNET_TOKENS: TokensConfig = {
           'wormhole186k0cp83c3wyvapgh8fxf66ededemzrfujvjfsx0xw3vr0u9g8sq2y30vx',
         decimals: 8,
       },
+      cosmoshub: {
+        address:
+          'ibc/AB4046AF5B6F146C006DE4DECAD929D24F762A701E09EC8B29000EC63A6E649B',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/221A4AADF7972F3BB8F48A6CA984FF0AE65B5D973FF1A695B9642AD702F51789',
+        decimals: 8,
+      },
     },
   },
   USDCarbitrum: {
@@ -1344,6 +1444,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       aptos: {
         address:
           '0x3f0fdd44d96dae888d6c576218cf655458316a27c7bdc46537f61e531b10d3df::coin::T',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/06ED2700071B5A9C582F51A556537DA94E69EF547E7E6CCD8BFA3D95C818A525',
         decimals: 6,
       },
     },
@@ -1409,6 +1514,11 @@ export const TESTNET_TOKENS: TokensConfig = {
           'ibc/A0298483510D803A045AA7F49CCBD0F9D01010FE0B1A346EBDFFF4BA820C3D21',
         decimals: 8,
       },
+      osmosis: {
+        address:
+          'ibc/80B3FECB24A4CE94537444E5BF937AC4C08A39BF90D59620D278FA185BD2B148',
+        decimals: 8,
+      },
     },
   },
   USDCoptimism: {
@@ -1437,6 +1547,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1u5z7097gm57zvun9wqsx6jxej2gpdjhg9l9xfe58rhpm29rtjmfqfnl4yv',
+        decimals: 6,
+      },
+      cosmoshub: {
+        address:
+          'ibc/CE3F2FE630DA6A1187F085CDC8D59BA8B20DA48F4866F2D71C5AB7A1D5859933',
+        decimals: 6,
+      },
+      osmosis: {
+        address:
+          'ibc/0A98A3947189D7C368170C76C3EF49486DDBE095F34B72A3C7F92AEBE1013A1D',
         decimals: 6,
       },
     },
@@ -1523,6 +1643,11 @@ export const TESTNET_TOKENS: TokensConfig = {
       cosmoshub: {
         address:
           'ibc/97035986A4BD0AF555713355A02EA31A4526616B6543E019E0D750007FABE06C',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/A45069EA82C933945973E66E4222EEE4624498D4483508FE9BEBF9D519F2132F',
         decimals: 8,
       },
     },
@@ -1644,6 +1769,16 @@ export const TESTNET_TOKENS: TokensConfig = {
       wormchain: {
         address:
           'wormhole1u2zdjcczjrenwmf57fmrpensk4the84azdm05m3unm387rm8asdsxqwfeu',
+        decimals: 8,
+      },
+      cosmoshub: {
+        address:
+          'ibc/5BB02667F9F0C8284FCF7716065C2779039817FBCB91E937F5149FE89FD8F202',
+        decimals: 8,
+      },
+      osmosis: {
+        address:
+          'ibc/C66B7DB3ED665D2F5FE8ED15E88B5913A37D80601E161C5E53A743DE12C0FB85',
         decimals: 8,
       },
     },


### PR DESCRIPTION
 * Update foreign asset caches for some tokens
 * Add some checks to the `checkForeignAssetsConfig` script to skip errors when querying gateway chains