### PR TITLE
[bugfix] Address failure to fetch balances when the config sets a custom tokens array

### DIFF
--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -6,7 +6,7 @@ import {
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { BigNumber } from 'ethers';
 
-import { CHAINS, ROUTES, TOKENS } from 'config';
+import { CHAINS, ROUTES, TOKENS, TOKENS_ARR } from 'config';
 import { TokenConfig, Route } from 'config/types';
 import {
   ParsedMessage,
@@ -147,7 +147,8 @@ export class Operator {
   ): Promise<TokenConfig[]> {
     const supported: { [key: string]: TokenConfig } = {};
     for (const route of ROUTES) {
-      for (const key in TOKENS) {
+      for (const token of TOKENS_ARR) {
+        const { key } = token;
         const alreadySupported = supported[key];
         if (!alreadySupported) {
           const isSupported = await this.isSupportedSourceToken(
@@ -173,7 +174,8 @@ export class Operator {
   ): Promise<TokenConfig[]> {
     const supported: { [key: string]: TokenConfig } = {};
     for (const route of ROUTES) {
-      for (const key in TOKENS) {
+      for (const token of TOKENS_ARR) {
+        const { key } = token;
         const alreadySupported = supported[key];
         if (!alreadySupported) {
           const isSupported = await this.isSupportedDestToken(


### PR DESCRIPTION
Use the TOKENS_ARR to compute available tokens so that the resulting array is filtered for the specific configured tokens.

Setting a custom config with a tokens array (e.g: `{ "tokens": [ "WETH", "WETHoptimism", "WETHarbitrum", "USDCarbitrum", "AVAX", "WAVAX" ] }` would cause issues with fetching balances since the behaviour was to fetch for all tokens and not only those configured. Since part of the fetching process would involve looking up the `TOKENS_ARR` (done [here](https://github.com/wormhole-foundation/wormhole-connect/blob/21ba498910922b4468f155d3668a530ce525f89f/wormhole-connect/src/utils/index.ts#L91)), it would fail due to not finding the token config for it.