### PR TITLE
Make sure receiving wallet is connected before calling `nativeTokenAmount`

### DIFF
--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -296,7 +296,13 @@ function GasSlider(props: { disabled: boolean }) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      if (!receivingToken || !sendingToken || !route) return;
+      if (
+        !receivingToken ||
+        !sendingToken ||
+        !route ||
+        !receivingWallet.address
+      )
+        return;
       dispatch(setToNativeToken(debouncedSwapAmt));
       const tokenId = receivingToken.tokenId!;
       const tokenToChainDecimals = getTokenDecimals(


### PR DESCRIPTION
Previously if the receiving wallet was not connected then the function would throw an exception when Sui or Solana is the target chain.