### PR TITLE
#1221 - add options to extend menu links

### DIFF
--- a/wormhole-connect-loader/src/types.ts
+++ b/wormhole-connect-loader/src/types.ts
@@ -70,6 +70,7 @@ export interface WormholeConnectConfig {
     text: string;
     link: string;
   };
+  menu?: MenuEntry[];
   bridgeDefaults?: BridgeDefaults;
   routes?: string[];
   pageHeader?: string;
@@ -81,3 +82,10 @@ export type SearchTxConfig = {
   txHash?: string;
   chainName?: ChainName;
 };
+
+export interface MenuEntry {
+  label: string;
+  href: string;
+  target?: string;
+  order?: number;
+}

--- a/wormhole-connect/README.md
+++ b/wormhole-connect/README.md
@@ -85,13 +85,11 @@ class WormholeConnect extends React.Component {
 
 ## Togle Hamburguer Menu
 
-by setting `showHamburgerMenu` to **false**, you can toggle hamburguer menu off
-and that makes the links to be placed at bottom
+By setting the `showHamburgerMenu` option to false, you can deactivate the hamburger menu, causing the links to be positioned at the bottom.
 
 ### Add extra menu entry
 
-by setting `showHumburgerMenu` to **false**, you can use `menu` array to add
-extra links
+By setting the `showHumburgerMenu` option to false, you can use the menu array to add extra links.
 
 |property|description|
 |--|--|

--- a/wormhole-connect/README.md
+++ b/wormhole-connect/README.md
@@ -83,13 +83,13 @@ class WormholeConnect extends React.Component {
 }
 ```
 
-## Togle Hamburguer Menu
+## Toggle Hamburguer Menu
 
-By setting the `showHamburgerMenu` option to false, you can deactivate the hamburger menu, causing the links to be positioned at the bottom.
+By setting the `showHamburgerMenu` option to **false**, you can deactivate the hamburger menu, causing the links to be positioned at the bottom.
 
 ### Add extra menu entry
 
-By setting the `showHumburgerMenu` option to false, you can use the menu array to add extra links.
+By setting the `showHamburgerMenu` option to **false**, you can use the `menu` array to add extra links.
 
 |property|description|
 |--|--|

--- a/wormhole-connect/README.md
+++ b/wormhole-connect/README.md
@@ -82,3 +82,36 @@ class WormholeConnect extends React.Component {
   }
 }
 ```
+
+## Togle Hamburguer Menu
+
+by setting `showHamburgerMenu` to **false**, you can toggle hamburguer menu off
+and that makes the links to be placed at bottom
+
+### Add extra menu entry
+
+by setting `showHumburgerMenu` to **false**, you can use `menu` array to add
+extra links
+
+|property|description|
+|--|--|
+|`menu[].label`|link name to show up|
+|`menu[].href`|target url or urn|
+|`menu[].target`|anchor standard target, by default `_blank`|
+|`menu[].order`|order where the new item should be injected|
+
+### Sample configuration
+
+```json
+{
+  "showHamburgerMenu": false,
+  "menu": [
+    {
+      "label": "Advance Tools",
+      "href": "https://portalbridge.com",
+      "target": "_self",
+      "order": 1
+    }
+  ]
+}
+```

--- a/wormhole-connect/src/components/FooterNavBar.tsx
+++ b/wormhole-connect/src/components/FooterNavBar.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { ICON } from 'utils/style';
 import { Route, setRoute } from 'store/router';
+import { MENU_ENTRIES } from 'config';
+import { MenuEntry } from 'config/types';
 
-const useStyles = makeStyles()(() => ({
+const useStyles = makeStyles()((theme) => ({
   menuIcon: ICON,
   menu: {
     display: 'flex',
+    [theme.breakpoints.down('md')]: {
+      flexDirection: 'column',
+    },
     flexDirection: 'row',
     gap: '8px',
     padding: '8px',
@@ -24,25 +29,52 @@ const useStyles = makeStyles()(() => ({
   },
 }));
 
+type MenuItem = {
+  label: string;
+  handleClick: () => void;
+};
+
+function itemAppender(acc: MenuItem[], item: MenuEntry) {
+  const { order = acc.length, target = '_black', href, label } = item;
+  acc.splice(order, 0, { label, handleClick: () => window.open(href, target) });
+  return acc;
+}
+
+function defaultMenuItems(navigate: (name: Route) => void): MenuItem[] {
+  return [
+    { label: 'Resume Transaction', handleClick: () => navigate('search') },
+    { label: 'FAQs', handleClick: () => navigate('faq') },
+    { label: 'Terms of Use', handleClick: () => navigate('terms') },
+  ];
+}
+
 export default function FooterNavBar() {
   const { classes } = useStyles();
   const dispatch = useDispatch();
 
-  const navigate = (name: Route) => {
-    dispatch(setRoute(name));
-  };
+  const navigate = useCallback(
+    (name: Route) => {
+      dispatch(setRoute(name));
+    },
+    [dispatch],
+  );
+
+  const entries = useMemo(
+    () => MENU_ENTRIES.reduce(itemAppender, defaultMenuItems(navigate)),
+    [navigate],
+  );
 
   return (
     <div className={classes.menu}>
-      <div className={classes.menuItem} onClick={() => navigate('search')}>
-        Resume transaction
-      </div>
-      <div className={classes.menuItem} onClick={() => navigate('faq')}>
-        FAQs
-      </div>
-      <div className={classes.menuItem} onClick={() => navigate('terms')}>
-        Terms of Use
-      </div>
+      {entries.map(({ label, handleClick }: MenuItem, idx) => (
+        <div
+          className={classes.menuItem}
+          onClick={handleClick}
+          key={`${label.toLowerCase()}_${idx}`}
+        >
+          {label}
+        </div>
+      ))}
     </div>
   );
 }

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -19,7 +19,9 @@ const el = document.getElementById('wormhole-connect');
 if (!el)
   throw new Error('must specify an anchor element with id wormhole-connect');
 const configJson = el.getAttribute('config');
-export const config: WormholeConnectConfig = JSON.parse(configJson!) || {};
+export const config: WormholeConnectConfig = JSON.parse(configJson!) || {
+  showHamburgerMenu: false,
+};
 
 const getEnv = () => {
   const processEnv = process.env.REACT_APP_CONNECT_ENV?.toLowerCase();

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -84,6 +84,8 @@ export const TOKENS_ARR =
     ? Object.values(TOKENS).filter((c) => config.tokens!.includes(c.key))
     : (Object.values(TOKENS) as TokenConfig[]);
 
+export const MENU_ENTRIES = config.menu || [];
+
 export const ROUTES =
   config && config.routes ? config.routes : Object.values(Route);
 

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -19,9 +19,7 @@ const el = document.getElementById('wormhole-connect');
 if (!el)
   throw new Error('must specify an anchor element with id wormhole-connect');
 const configJson = el.getAttribute('config');
-export const config: WormholeConnectConfig = JSON.parse(configJson!) || {
-  showHamburgerMenu: false,
-};
+export const config: WormholeConnectConfig = JSON.parse(configJson!) || {};
 
 const getEnv = () => {
   const processEnv = process.env.REACT_APP_CONNECT_ENV?.toLowerCase();

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -77,6 +77,7 @@ export interface WormholeConnectConfig {
   pageHeader?: string;
   pageSubHeader?: string;
   searchTx?: SearchTxConfig;
+  menu?: MenuEntry[];
 }
 
 export type SearchTxConfig = {
@@ -148,3 +149,10 @@ export type NetworkData = {
   rest: RpcMapping;
   graphql: RpcMapping;
 };
+
+export interface MenuEntry {
+  label: string;
+  href: string;
+  target?: string;
+  order?: number;
+}


### PR DESCRIPTION
<img width="872" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/e49f30e8-6176-46f5-9d4e-378d6484d2d6">

<img width="447" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/32ffc0e3-2ce9-44b1-b82c-57dcee939167">

## Sample Config

```json
{
  "showHamburgerMenu": false,
  "menu": [
    {
      "label": "Advance Tools",
      "href": "https://portalbridge.com",
      "target": "_self",
      "order": 1
    }
  ]
}
```