### PR TITLE
[#1212] Fix solana parsed message recipient for gateway transfers

### DIFF
--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -72,7 +72,7 @@ export async function getUnsignedMessageFromCosmos(
     block: tx.height,
     sender: data.sender,
     gasFee: BigNumber.from(tx.gasUsed.toString()),
-    payloadID: 3, // should not be required for this case
+    payloadID: 1, // no vaa, but wormchain will eventually emit a normal transfer
     tokenChain,
     tokenAddress,
     tokenId: {


### PR DESCRIPTION
The recipient address for transfers from solana would not be correctly decoded to the owner account when transferring from Gateway chains. The issue would be that the token owner retrieval was performed only for payload1 type transfers, when outbound gateway transfers would be marked as payload3 when they should've been marked as payload1.

Fixes #1212