### PR TITLE
connect/gateway: fix message/vaa decoding when there are multiple ibc transfers

### DIFF
--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -9,17 +9,21 @@ import {
   parseVaa,
 } from '@certusone/wormhole-sdk';
 import { CosmWasmClient } from '@cosmjs/cosmwasm-stargate';
-import { EncodeObject, decodeTxRaw } from '@cosmjs/proto-signing';
+import { EncodeObject } from '@cosmjs/proto-signing';
 import {
   BankExtension,
   Coin,
   IbcExtension,
   QueryClient,
   calculateFee,
-  logs as cosmosLogs,
   setupBankExtension,
   setupIbcExtension,
 } from '@cosmjs/stargate';
+import {
+  Tendermint34Client,
+  Tendermint37Client,
+  TendermintClient,
+} from '@cosmjs/tendermint-rpc';
 import { MsgExecuteContract } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
 import { BigNumber, utils } from 'ethers';
 import {
@@ -27,7 +31,6 @@ import {
   base58,
   base64,
   hexStripZeros,
-  hexlify,
   keccak256,
   zeroPad,
 } from 'ethers/lib/utils';
@@ -41,18 +44,13 @@ import {
   ParsedRelayerPayload,
   TokenId,
 } from '../../types';
+import { ForeignAssetCache, waitFor } from '../../utils';
 import { WormholeContext } from '../../wormhole';
 import { TokenBridgeAbstract } from '../abstracts/tokenBridge';
 import { CosmosContracts } from './contracts';
-import { isGatewayChain, searchCosmosLogs } from './utils';
-import { ForeignAssetCache, waitFor } from '../../utils';
-import {
-  Tendermint34Client,
-  Tendermint37Client,
-  TendermintClient,
-} from '@cosmjs/tendermint-rpc';
 import { getNativeDenom, getPrefix, isNativeDenom } from './denom';
 import { CosmosTransaction, WrappedRegistryResponse } from './types';
+import { isGatewayChain } from './utils';
 
 const MSG_EXECUTE_CONTRACT_TYPE_URL = '/cosmwasm.wasm.v1.MsgExecuteContract';
 const buildExecuteMsg = (
@@ -473,64 +471,10 @@ export class CosmosContext<
     id: string,
     chain: ChainName | ChainId,
   ): Promise<ParsedMessage | ParsedRelayerMessage> {
-    const client = await this.getCosmWasmClient(chain);
-    const tx = await client.getTx(id);
-    if (!tx) throw new Error('tx not found');
-
-    // parse logs emitted for the tx execution
-    const logs = cosmosLogs.parseRawLog(tx.rawLog);
-
-    // extract information wormhole contract logs
-    // - wasm.message.message: the vaa payload (i.e. the transfer information)
-    // - wasm.message.sequence: the vaa's sequence number
-    // - wasm.message.sender: the vaa's emitter address
-    const tokenTransferPayload = searchCosmosLogs('wasm.message.message', logs);
-    if (!tokenTransferPayload)
-      throw new Error('message/transfer payload not found');
-    const sequence = searchCosmosLogs('wasm.message.sequence', logs);
-    if (!sequence) throw new Error('sequence not found');
-    const emitterAddress = searchCosmosLogs('wasm.message.sender', logs);
-    if (!emitterAddress) throw new Error('emitter not found');
-
-    const parsed = parseTokenTransferPayload(
-      Buffer.from(tokenTransferPayload, 'hex'),
-    );
-
-    const decoded = decodeTxRaw(tx.tx);
-    const { sender } = MsgExecuteContract.decode(
-      decoded.body.messages[0].value,
-    );
-
-    const destContext = this.context.getContext(parsed.toChain as ChainId);
-    const tokenContext = this.context.getContext(parsed.tokenChain as ChainId);
-
-    const tokenAddress = await tokenContext.parseAssetAddress(
-      hexlify(parsed.tokenAddress),
-    );
-    const tokenChain = this.context.toChainName(parsed.tokenChain);
-
-    return {
-      sendTx: tx.hash,
-      sender,
-      amount: BigNumber.from(parsed.amount),
-      payloadID: parsed.payloadType,
-      recipient: destContext.parseAddress(hexlify(parsed.to)),
-      toChain: this.context.toChainName(parsed.toChain),
-      fromChain: this.context.toChainName(chain),
-      tokenAddress,
-      tokenChain,
-      tokenId: {
-        address: tokenAddress,
-        chain: tokenChain,
-      },
-      sequence: BigNumber.from(sequence),
-      emitterAddress,
-      block: tx.height,
-      gasFee: BigNumber.from(tx.gasUsed),
-      payload: parsed.tokenTransferPayload.length
-        ? hexlify(parsed.tokenTransferPayload)
-        : undefined,
-    };
+    // see the gateway route for the implementation
+    // we might not have all information available in the parameters
+    // to do it here
+    throw new Error('Not implemented');
   }
 
   parseRelayerPayload(payload: Buffer): ParsedRelayerPayload {

--- a/sdk/src/contexts/cosmos/context.ts
+++ b/sdk/src/contexts/cosmos/context.ts
@@ -474,7 +474,9 @@ export class CosmosContext<
     // see the gateway route for the implementation
     // we might not have all information available in the parameters
     // to do it here
-    throw new Error('Not implemented');
+    throw new Error(
+      'Not implemented. Something went wrong, this method implementation should never be called',
+    );
   }
 
   parseRelayerPayload(payload: Buffer): ParsedRelayerPayload {

--- a/wormhole-connect/src/routes/cosmosGateway/utils/events.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/events.ts
@@ -8,7 +8,7 @@ import { getCosmWasmClient } from './client';
 import { getTranslatorAddress } from './contracts';
 import {
   findDestinationIBCTransferTx,
-  getIBCTransferInfoFromLogs,
+  getTransactionIBCTransferInfo,
 } from './transaction';
 import { BridgeRoute } from '../../bridge';
 import { isGatewayChain } from '../../../utils/cosmos';
@@ -39,7 +39,7 @@ export async function fetchRedeemedEventNonCosmosSource(
   }
 
   // extract the ibc transfer info from the transaction logs
-  const ibcInfo = getIBCTransferInfoFromLogs(txs[0], 'send_packet');
+  const ibcInfo = getTransactionIBCTransferInfo(txs[0], 'send_packet');
 
   // find the transaction on the target chain based on the ibc transfer info
   const destTx = await findDestinationIBCTransferTx(message.toChain, ibcInfo);
@@ -60,7 +60,7 @@ export async function fetchRedeemedEventCosmosSource(
   const sourceClient = await getCosmWasmClient(message.fromChain);
   const tx = await sourceClient.getTx(message.sendTx);
   if (!tx) return null;
-  const sourceIbcInfo = getIBCTransferInfoFromLogs(tx, 'send_packet');
+  const sourceIbcInfo = getTransactionIBCTransferInfo(tx, 'send_packet');
 
   // find tx in the ibc receive in wormchain and extract the ibc transfer to the dest tx
   const wormchainTx = await findDestinationIBCTransferTx(
@@ -68,7 +68,7 @@ export async function fetchRedeemedEventCosmosSource(
     sourceIbcInfo,
   );
   if (!wormchainTx) return null;
-  const wormchainToDestIbcInfo = getIBCTransferInfoFromLogs(
+  const wormchainToDestIbcInfo = getTransactionIBCTransferInfo(
     wormchainTx,
     'send_packet',
   );

--- a/wormhole-connect/src/routes/cosmosGateway/utils/transaction.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/transaction.ts
@@ -7,11 +7,18 @@ import {
 import { getCosmWasmClient } from '../utils';
 import { IBCTransferInfo } from '../types';
 
-export function getIBCTransferInfoFromLogs(
+export function getTransactionIBCTransferInfo(
   tx: IndexedTx,
   event: 'send_packet' | 'recv_packet',
 ): IBCTransferInfo {
   const logs = cosmosLogs.parseRawLog(tx.rawLog);
+  return getIBCTransferInfoFromLogs(logs, event);
+}
+
+export function getIBCTransferInfoFromLogs(
+  logs: readonly cosmosLogs.Log[],
+  event: 'send_packet' | 'recv_packet',
+): IBCTransferInfo {
   const packetSeq = searchCosmosLogs(`${event}.packet_sequence`, logs);
   const packetTimeout = searchCosmosLogs(
     `${event}.packet_timeout_timestamp`,


### PR DESCRIPTION
It turns out that sometimes IBC transfers can get queued up on the source chain and, when the relayer eventually picks them up, they all get delivered on a single transaction on wormchain. So for `n` transactions on the source chain, there will be only one transaction on wormchain, which emits the `n` observations, each as a msg in the transaction.

The current implementation assumed there was only one transaction per IBC transfer, so it would extract the first vaa present in the logs, yielding an incorrect VAA. The changes in this PR involve using the IBC transfer information (src and dst channel, packet sequence) to find the exact entry in the wormchain transaction's logs for that specific IBC transfer.

Should address #1231 