### PR TITLE
Update avalanche explorer links to avascan

### DIFF
--- a/wormhole-connect/src/config/mainnet/chains.ts
+++ b/wormhole-connect/src/config/mainnet/chains.ts
@@ -40,8 +40,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
   avalanche: {
     ...chains.avalanche!,
     displayName: 'Avalanche',
-    explorerUrl: 'https://snowtrace.io/',
-    explorerName: 'Snowtrace',
+    explorerUrl: 'https://avascan.info/blockchain/c/',
+    explorerName: 'Avascan',
     gasToken: 'AVAX',
     chainId: 43114,
     icon: Icon.AVAX,

--- a/wormhole-connect/src/config/testnet/chains.ts
+++ b/wormhole-connect/src/config/testnet/chains.ts
@@ -40,8 +40,8 @@ export const TESTNET_CHAINS: ChainsConfig = {
   fuji: {
     ...chains.fuji!,
     displayName: 'Fuji',
-    explorerUrl: 'https://testnet.snowtrace.io/',
-    explorerName: 'Snowtrace',
+    explorerUrl: 'https://testnet.avascan.info/blockchain/c/',
+    explorerName: 'Avascan',
     gasToken: 'AVAX',
     chainId: 43113,
     icon: Icon.AVAX,


### PR DESCRIPTION
https://snowtrace.io/ is being discontinued by the end of November. Update to use https://avascan.info/