### PR TITLE
Fix wormholescan explorer link not showing for gateway chains

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -108,8 +108,8 @@ export interface ParsedMessage {
   tokenAddress: string;
   tokenChain: ChainName;
   tokenId: TokenId;
-  sequence: BigNumber;
-  emitterAddress: string;
+  sequence?: BigNumber;
+  emitterAddress?: string;
   block: number;
   gasFee?: BigNumber;
   payload?: string;

--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -98,8 +98,6 @@ export async function getUnsignedMessageFromCosmos(
       address: tokenAddress,
       chain: tokenChain,
     },
-    emitterAddress: '',
-    sequence: BigNumber.from(0),
   });
 
   return {

--- a/wormhole-connect/src/routes/utils.ts
+++ b/wormhole-connect/src/routes/utils.ts
@@ -35,7 +35,7 @@ export const adaptParsedMessage = async (
     tokenKey: token?.key || '',
     tokenDecimals: decimals,
     receivedTokenKey: token?.key || '',
-    sequence: parsed.sequence.toString(),
+    sequence: parsed.sequence?.toString(),
     gasFee: parsed.gasFee ? parsed.gasFee.toString() : undefined,
   };
   // get wallet address of associated token account for Solana


### PR DESCRIPTION
The transfer information first built from gateway source chains might not have the sequence/emitter address since that information is only available on wormchain. Since these few pieces of data were missing, the wormholescan link could not be built. The solution was to use the data present in the `signedMessage` which is built using the wormchain information.

Initially mentioned here: https://github.com/XLabs/portal-bridge-ui/pull/509#issuecomment-1814423393