### PR TITLE
#1221 - adjust size for bottom menu

### DIFF
--- a/wormhole-connect/src/components/FooterNavBar.tsx
+++ b/wormhole-connect/src/components/FooterNavBar.tsx
@@ -16,11 +16,12 @@ const useStyles = makeStyles()((theme) => ({
     flexDirection: 'row',
     gap: '8px',
     padding: '8px',
-    width: '85%',
+    width: '97%',
   },
   menuItem: {
     padding: '16px 0',
     textAlign: 'center',
+    fontSize: '14px',
     flex: 1,
     cursor: 'pointer',
     '&:hover': {

--- a/wormhole-connect/src/components/FooterNavBar.tsx
+++ b/wormhole-connect/src/components/FooterNavBar.tsx
@@ -16,13 +16,13 @@ const useStyles = makeStyles()((theme) => ({
     flexDirection: 'row',
     gap: '8px',
     padding: '8px',
-    width: '97%',
+    width: '100%',
   },
   menuItem: {
     padding: '16px 0',
     textAlign: 'center',
     fontSize: '14px',
-    flex: 1,
+    margin: 'auto',
     cursor: 'pointer',
     '&:hover': {
       textDecoration: 'underline',


### PR DESCRIPTION
Adjust bottom nav bar size

<img width="750" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/70642163-aced-4867-884d-4631499f4700">
