### PR TITLE
[#1213] Avoid decoding the transfer payload for non gateway chains

### DIFF
--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -152,7 +152,7 @@ export async function getUnsignedMessageFromNonCosmos(
   hash: string,
   chain: ChainName,
 ): Promise<UnsignedMessage> {
-  const message = await wh.getMessage(hash, chain);
+  const message = await wh.getMessage(hash, chain, false);
   if (!message.payload)
     throw new Error(`Missing payload from message ${hash} on chain ${chain}`);
   const decoded: GatewayTransferMsg = JSON.parse(


### PR DESCRIPTION
Transfers for cosmos gateway use a payload 3 type, so when trying to recover the transfer information chains with relayers (EVM, Solana, Sui) would try to decode it as if it was a normal relayer payload, which would incur into errors for some chains (Sui and Solana).

The solution here was to set the `parseRelayerPayload` flag to false when retrieving the info for the gateway route.

Fixes #1213 