### PR TITLE
[#1276] Upgrade to use Wallet Connect V2

### DIFF
--- a/wormhole-connect-loader/README.md
+++ b/wormhole-connect-loader/README.md
@@ -292,12 +292,15 @@ function App() {
 
 ## Configuration Options
 
+### Wallet Connect Project ID
 
-## Toggle Hamburguer Menu
+Required in order to display Wallet Connect as a wallet option. You can get a project ID on https://cloud.walletconnect.com/. Refer to the wallet connect [documentation](https://docs.walletconnect.com/advanced/migration-from-v1.x/overview) for more information on v2.
+
+### Toggle Hamburguer Menu
 
 By setting the `showHamburgerMenu` option to **false**, you can deactivate the hamburger menu, causing the links to be positioned at the bottom.
 
-### Add extra menu entry
+#### Add extra menu entry
 
 By setting the `showHamburgerMenu` option to **false**, you can use the `menu` array to add extra links.
 
@@ -308,7 +311,7 @@ By setting the `showHamburgerMenu` option to **false**, you can use the `menu` a
 |`menu[].target`|anchor standard target, by default `_blank`|
 |`menu[].order`|order where the new item should be injected|
 
-### Sample configuration
+#### Sample configuration
 
 ```json
 {

--- a/wormhole-connect-loader/src/types.ts
+++ b/wormhole-connect-loader/src/types.ts
@@ -84,6 +84,7 @@ export interface WormholeConnectConfig {
   moreTokens?: MoreTokenConfig;
   moreNetworks?: MoreChainConfig;
   partnerLogo?: string;
+  walletConnectProjectId?: string;
 }
 
 export type SearchTxConfig = {

--- a/wormhole-connect/src/components/Modal.tsx
+++ b/wormhole-connect/src/components/Modal.tsx
@@ -8,6 +8,9 @@ import CloseIcon from 'icons/Close';
 // type StyleProps = { align: Alignment };
 // const useStyles = makeStyles<StyleProps>()((theme, { align }) => ({
 const useStyles = makeStyles<{ width: number }>()((theme: any, { width }) => ({
+  dialog: {
+    zIndex: 10,
+  },
   container: {
     position: 'relative',
     width: '100%',
@@ -61,7 +64,13 @@ function Modal({ open, width, closable, children, onClose }: Props) {
   }, []);
 
   return (
-    <Dialog open={open} sx={{ borderRadius: 8 }} fullWidth fullScreen>
+    <Dialog
+      open={open}
+      sx={{ borderRadius: 8 }}
+      className={classes.dialog}
+      fullWidth
+      fullScreen
+    >
       <ScopedCssBaseline enableColorScheme>
         <div className={classes.container} onClick={onClose}>
           {closable && (

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -132,6 +132,11 @@ export const CTA = config && config.cta;
 export const BRIDGE_DEFAULTS =
   config && validateDefaults(config.bridgeDefaults);
 
+export const WALLET_CONNECT_PROJECT_ID =
+  config && config.walletConnectProjectId
+    ? config.walletConnectProjectId
+    : process.env.REACT_APP_WALLET_CONNECT_PROJECT_ID;
+
 export const TESTNET_TO_MAINNET_CHAIN_NAMES: {
   [k in TestnetChainName]: MainnetChainName;
 } = {

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -87,6 +87,7 @@ export interface WormholeConnectConfig {
   moreTokens?: MoreTokenConfig;
   moreNetworks?: MoreChainConfig;
   partnerLogo?: string;
+  walletConnectProjectId?: string;
 }
 
 export type PageHeader = {

--- a/wormhole-connect/src/utils/wallet.ts
+++ b/wormhole-connect/src/utils/wallet.ts
@@ -13,7 +13,7 @@ import { NotSupported, Wallet } from '@xlabs-libs/wallet-aggregator-core';
 import {
   EVMWallet,
   MetamaskWallet,
-  WalletConnectLegacyWallet,
+  WalletConnectWallet,
 } from '@xlabs-libs/wallet-aggregator-evm';
 import {
   CosmosTransaction,
@@ -60,7 +60,15 @@ import { AptosWallet } from '@xlabs-libs/wallet-aggregator-aptos';
 import { Types } from 'aptos';
 
 import { wh } from './sdk';
-import { CHAINS, CHAINS_ARR, ENV, REST, RPCS, isMainnet } from 'config';
+import {
+  CHAINS,
+  CHAINS_ARR,
+  ENV,
+  REST,
+  RPCS,
+  WALLET_CONNECT_PROJECT_ID,
+  isMainnet,
+} from 'config';
 import { getChainByChainId } from 'utils';
 
 export enum TransferWallet {
@@ -109,7 +117,15 @@ const buildCosmosWallets = (evm?: boolean) => {
 export const wallets = {
   evm: {
     metamask: new MetamaskWallet(),
-    walletConnect: new WalletConnectLegacyWallet(),
+    ...(WALLET_CONNECT_PROJECT_ID
+      ? {
+          walletConnect: new WalletConnectWallet({
+            connectorOptions: {
+              projectId: WALLET_CONNECT_PROJECT_ID,
+            },
+          }),
+        }
+      : {}),
   },
   solana: {
     phantom: new SolanaWallet(new PhantomWalletAdapter(), connection),


### PR DESCRIPTION
In order for the wallet connect v2 to be available, a project id must be configured either through the config or by an env variable at build time.

Adjusted the wallet modals z-index so it doesn't cover the WC QR modal.

Should fix #1276 