### PR TITLE
[#1286] Support for polygon manual CCTP route

### DIFF
--- a/sdk/src/config/TESTNET.ts
+++ b/sdk/src/config/TESTNET.ts
@@ -80,9 +80,14 @@ const TESTNET: { [chain in TestnetChainName]: ChainConfig } = {
       ...CONTRACTS.TESTNET.polygon,
       relayer: '0x9563a59c15842a6f322b10f69d1dd88b41f2e97b',
       tbtcGateway: '0x91fe7128f74dbd4f031ea3d90fc5ea4dcfd81818',
+      cctpContracts: {
+        cctpTokenMessenger: '0x9f3B8679c73C2Fef8b59B4f3444d4e156fb70AA5',
+        cctpMessageTransmitter: '0xe09A679F56207EF33F5b9d8fb4499Ec00792eA73',
+      },
     },
     finalityThreshold: 64,
     nativeTokenDecimals: 18,
+    cctpDomain: 7,
   },
   bsc: {
     key: 'bsc',

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -424,64 +424,14 @@ export const TESTNET_TOKENS: TokensConfig = {
     icon: Icon.USDC,
     tokenId: {
       chain: 'mumbai',
-      address: '0x0FA8781a83E46826621b3BC094Ea2A0212e71B23',
+      address: '0x9999f7fea5938fd3b1e26a12c3f2fb024e194f97',
     },
     coinGeckoId: 'usd-coin',
     color: '#2774CA',
     decimals: {
       default: 6,
     },
-    foreignAssets: {
-      goerli: {
-        address: '0xB3658B4C6704356F155c369F4583aF68424128e9',
-        decimals: 6,
-      },
-      bsc: {
-        address: '0x88B8b85ED6d39E613d2d1449e1c1B808d505D561',
-        decimals: 6,
-      },
-      fuji: {
-        address: '0xFB2C24197A92598C633Ed8eE60ee90b104d7B145',
-        decimals: 6,
-      },
-      fantom: {
-        address: '0x450dC724a1793b0E2182d09Eb883ad76f7F4C0Aa',
-        decimals: 6,
-      },
-      alfajores: {
-        address: '0x4364bb251a0F33914AAb2088ed435122694Ce2BD',
-        decimals: 6,
-      },
-      moonbasealpha: {
-        address: '0x5366c7204A49D6CdD6A99e647aE695Cb0866FD5e',
-        decimals: 6,
-      },
-      sui: {
-        address:
-          '0xe1deb395283034cbfc81c5acb4c89d3223e5165b5384282c73963aa5262a4993::coin::COIN',
-        decimals: 6,
-      },
-      sei: {
-        address:
-          'sei1vccw9g60mphsaj9t96vru53mjje3vmxcl49lg8lfqdh0zgmq6zsqf03y9n',
-        decimals: 6,
-      },
-      wormchain: {
-        address:
-          'wormhole1qmk0v725sdg5ecu6xfh5pt0fv0nfzrstarue2maum3snzk2zrt5qcm4w3g',
-        decimals: 6,
-      },
-      cosmoshub: {
-        address:
-          'ibc/ED0651B0141CA50326B1FFA2E9207F42BE616DE2712356CF8DA4B8CAC4A6A5B6',
-        decimals: 6,
-      },
-      osmosis: {
-        address:
-          'ibc/FDEEB950A2538F30EBA949B9F8D0D28DAC9D26D0B138445BF0DF9FC4B800E1F9',
-        decimals: 6,
-      },
-    },
+    foreignAssets: {},
   },
   BNB: {
     key: 'BNB',

--- a/wormhole-connect/src/routes/cctpManual/utils/chains.ts
+++ b/wormhole-connect/src/routes/cctpManual/utils/chains.ts
@@ -12,6 +12,7 @@ export const CCTPManual_CHAINS: ChainName[] = [
   'optimismgoerli',
   'arbitrumgoerli',
   'basegoerli',
+  'mumbai',
 ];
 
 export function getChainNameCCTP(domain: number): ChainName {
@@ -26,6 +27,8 @@ export function getChainNameCCTP(domain: number): ChainName {
       return isMainnet ? 'arbitrum' : 'arbitrumgoerli';
     case 6:
       return isMainnet ? 'base' : 'basegoerli';
+    case 7:
+      return isMainnet ? 'polygon' : 'mumbai';
   }
   throw new Error('Invalid CCTP domain');
 }

--- a/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
+++ b/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
@@ -183,6 +183,11 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
 
     if (!chainsAreValid) return false;
 
+    const bothHaveRelayer =
+      CHAINS[sourceChainName]?.contracts.cctpContracts?.wormholeCircleRelayer &&
+      CHAINS[destChainName]?.contracts.cctpContracts?.wormholeCircleRelayer;
+    if (!bothHaveRelayer) return false;
+
     let relayerFee;
     try {
       relayerFee = await this.getRelayerFee(


### PR DESCRIPTION
 * Add polygon to cctp chains (domain 7)
 * Update testnet USDC contract address for polygon

Addresses information from here: https://developers.circle.com/stablecoins/docs/evm-smart-contracts

Should close #1286 