### PR TITLE
style: text aligment in Preview, Route, and Send from card

### DIFF
--- a/wormhole-connect/src/components/RenderRows.tsx
+++ b/wormhole-connect/src/components/RenderRows.tsx
@@ -10,11 +10,30 @@ const useStyles = makeStyles()((theme) => ({
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    margin: '4px 0',
+    margin: '4px 0 8px',
+    gap: '10px',
+  },
+  rowTitleContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    [theme.breakpoints.down('sm')]: {
+      flex: 1,
+    },
   },
   rowTitle: {
     fontSize: '14px',
     opacity: '70%',
+  },
+  rowTitleMinContent: {
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 'min-content',
+    },
+  },
+  rowText: {
+    [theme.breakpoints.down('sm')]: {
+      textAlign: 'right',
+      flex: 1,
+    },
   },
   arrow: {
     height: '24px',
@@ -50,8 +69,14 @@ export function RenderRows(props: RenderRowsProps) {
             style={{ cursor: row.rows ? 'pointer' : 'default' }}
             onClick={() => row.rows && toggleCollapsed()}
           >
-            <div className={classes.row}>
-              <span className={classes.rowTitle}>{row.title}</span>
+            <div className={classes.rowTitleContainer}>
+              <span
+                className={`${classes.rowTitle} ${
+                  row.rows ? classes.rowTitleMinContent : ''
+                }`}
+              >
+                {row.title}
+              </span>
               {row.rows && (
                 <Down
                   className={joinClass([
@@ -61,7 +86,11 @@ export function RenderRows(props: RenderRowsProps) {
                 />
               )}
             </div>
-            <div className={`${props.small && classes.subrowText}`}>
+            <div
+              className={`${classes.rowText} ${
+                props.small ? classes.subrowText : ''
+              }`}
+            >
               {row.value}
             </div>
           </div>

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -81,6 +81,7 @@ const useStyles = makeStyles()((theme: any) => ({
     alignItems: 'flex-end',
     padding: '4px 0',
     height: '100%',
+    textAlign: 'right',
   },
   routeAmt: {
     opacity: '0.6',

--- a/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
+++ b/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
@@ -10,6 +10,12 @@ const useStyles = makeStyles()((theme) => ({
     ...LINK(theme),
     transform: 'translateX(10px)',
   },
+  linkText: {
+    [theme.breakpoints.down('sm')]: {
+      wordBreak: 'break-word',
+      textAlign: 'right',
+    },
+  },
 }));
 
 type ExplorerLinkProps = {
@@ -75,7 +81,7 @@ function ExplorerLink(props: ExplorerLinkProps) {
       target="_blank"
       rel="noreferrer"
     >
-      <div>{chainConfig.explorerName}</div>
+      <div className={classes.linkText}>{chainConfig.explorerName}</div>
       <LaunchIcon />
     </a>
   );


### PR DESCRIPTION
## What fix you did

This PR fixes the issue of text alignment on smaller screens for Preview, Route, and Send from the card. #1283

## End result

<img width="1370" alt="Screenshot 2023-12-06 at 1 24 50 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/56081584/9153dcbe-7bfb-4e90-babf-9597260f5ec2">
<img width="1374" alt="Screenshot 2023-12-06 at 1 25 09 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/56081584/a6869351-d74c-49b3-843f-06424f10f0bb">
<img width="1365" alt="Screenshot 2023-12-06 at 1 25 24 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/56081584/f4de306e-68e8-46c1-b0c9-101a6c67d87d">

<img width="1371" alt="Screenshot 2023-12-06 at 1 26 00 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/56081584/be76d304-30fd-4236-a584-915d34557742">
<img width="1357" alt="Screenshot 2023-12-06 at 1 25 42 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/56081584/193d232d-c464-4590-adf9-08732dd0802f">
