### PR TITLE
fix: solana testnet rpc endpoint

### DIFF
--- a/sdk/src/config/TESTNET.ts
+++ b/sdk/src/config/TESTNET.ts
@@ -303,7 +303,7 @@ const TESTNET_CONFIG: WormholeConfig = {
     fuji: 'https://api.avax-test.network/ext/bc/C/rpc',
     fantom: 'https://rpc.ankr.com/fantom_testnet',
     alfajores: 'https://alfajores-forno.celo-testnet.org',
-    solana: 'https://api.devnet.solana.com',
+    solana: 'https://api.testnet.solana.com',
     moonbasealpha: 'https://rpc.api.moonbase.moonbeam.network',
     sui: 'https://fullnode.testnet.sui.io',
     aptos: 'https://fullnode.testnet.aptoslabs.com/v1',


### PR DESCRIPTION
This PR fixes issue #1289 
The issue was happening because of the incorrect Solana testnet RPC endpoint.