### PR TITLE
Updated guardian RPCs and added round-robin support for fetching VAAs.

### DIFF
--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -69,15 +69,16 @@ export const USDC_BRIDGE_URL = config.cctpWarning?.href || '';
 export const WORMHOLE_RPC_HOSTS =
   ENV === 'MAINNET'
     ? [
-        'https://wormhole-v2-mainnet-api.certus.one',
-        'https://wormhole.inotel.ro',
         'https://wormhole-v2-mainnet-api.mcf.rocks',
         'https://wormhole-v2-mainnet-api.chainlayer.network',
         'https://wormhole-v2-mainnet-api.staking.fund',
-        'https://wormhole-v2-mainnet.01node.com',
       ]
     : ENV === 'TESTNET'
-    ? ['https://wormhole-v2-testnet-api.certus.one']
+    ? [
+        'https://guardian.testnet.xlabs.xyz',
+        'https://guardian-01.testnet.xlabs.xyz',
+        'https://guardian-02.testnet.xlabs.xyz',
+      ]
     : ['http://localhost:7071'];
 
 export const NETWORK_DATA =

--- a/wormhole-connect/src/hooks/useIsTransferLimited.ts
+++ b/wormhole-connect/src/hooks/useIsTransferLimited.ts
@@ -7,7 +7,7 @@ import { useSelector } from 'react-redux';
 import { formatAssetAddress, wh } from 'utils/sdk';
 import { RootState } from 'store';
 import { getWrappedTokenId } from 'utils';
-import { WORMHOLE_RPC_HOSTS } from 'utils/vaa';
+import { WORMHOLE_RPC_HOSTS } from 'config';
 
 const REMAINING_NOTIONAL_TOLERANCE = 0.98;
 interface TokenListEntry {


### PR DESCRIPTION
Previously we would just fetch the VAA from the first guardian in the list. I didn't include wormholescan in the updated list of RPCs since there's a separate function for making calls to wormholescan: https://github.com/wormhole-foundation/wormhole-connect/blob/444c43176c3ae886b2febca4695ada0f8c8aedf8/wormhole-connect/src/utils/vaa.ts#L94