### PR TITLE
add integrity check for js/css assets

### DIFF
--- a/wormhole-connect-loader/src/index.tsx
+++ b/wormhole-connect-loader/src/index.tsx
@@ -16,10 +16,14 @@ function WormholeBridge({
     const script = document.createElement("script");
     script.src = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.js`;
     script.async = true;
-
+    if (process.env.REACT_APP_JS_INTEGRITY_SHA_384) {
+      script.integrity = process.env.REACT_APP_JS_INTEGRITY_SHA_384;
+    }
     const link = document.createElement("link");
     link.href = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.css`;
-
+    if (process.env.REACT_APP_CSS_INTEGRITY_SHA_384) {
+      link.integrity = process.env.REACT_APP_CSS_INTEGRITY_SHA_384;
+    }
     document.body.appendChild(script);
     document.body.appendChild(link);
     return () => {


### PR DESCRIPTION
simplest PoC to add integrity checks to Wormhole Connect Loader to avoid poisoned asset to be loaded

check: 
- https://www.w3schools.com/tags/att_script_integrity.asp
- https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity#tools_for_generating_sri_hashes