### PR TITLE
add configuration option to provide a link to a wormhole explorer

### DIFF
--- a/wormhole-connect-loader/README.md
+++ b/wormhole-connect-loader/README.md
@@ -374,3 +374,14 @@ Show a special entry on the select tokens modal which redirects the user to a di
 |`moreTokens.label`| Display text | mandatory|
 |`moreTokens.href`| URL to redirect to. If present, the values `{:sourceChain}` and `{:targetChain}` are replaced with the selected currently selected chains before redirecting | mandatory|
 |`moreTokens.target`| href target | optional, defaults to `_self`
+
+
+### Explorer 
+
+Enable explorer button to allow users to search for his transactions on a given explorer filtering by his wallet address
+
+|Property|description||
+|:--|:--|:--:|
+|`explorer.label`| Display text | optional, defaults to `Transactions`|
+|`explorer.href`| URL of the explorer, for instance https://wormholescan.com/. If present, the values `{:address}` is replaced with the connected wallet address| mandatory|
+|`explorer.target`| href target | optional, defaults to `_blank`

--- a/wormhole-connect-loader/src/types.ts
+++ b/wormhole-connect-loader/src/types.ts
@@ -72,6 +72,11 @@ export interface WormholeConnectConfig {
     text: string;
     link: string;
   };
+  explorer?: {
+    label: string;
+    href: string;
+    target: "_blank" | "_self";
+  };
   menu?: MenuEntry[];
   bridgeDefaults?: BridgeDefaults;
   routes?: string[];

--- a/wormhole-connect-loader/src/types.ts
+++ b/wormhole-connect-loader/src/types.ts
@@ -72,11 +72,7 @@ export interface WormholeConnectConfig {
     text: string;
     link: string;
   };
-  explorer?: {
-    label: string;
-    href: string;
-    target: "_blank" | "_self";
-  };
+  explorer?: ExplorerConfig;
   menu?: MenuEntry[];
   bridgeDefaults?: BridgeDefaults;
   routes?: string[];
@@ -91,6 +87,12 @@ export interface WormholeConnectConfig {
   partnerLogo?: string;
   walletConnectProjectId?: string;
 }
+
+export type ExplorerConfig = {
+  href: string;
+  label?: string;
+  target?: "_blank" | "_self";
+};
 
 export type SearchTxConfig = {
   txHash?: string;

--- a/wormhole-connect/src/components/ConnectWallet.tsx
+++ b/wormhole-connect/src/components/ConnectWallet.tsx
@@ -15,6 +15,7 @@ import WalletIcon from 'icons/Wallet';
 import WalletIcons from 'icons/WalletIcons';
 import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
 import Popover from '@mui/material/Popover';
+import { EXPLORER } from 'config';
 
 const useStyles = makeStyles()((theme: any) => ({
   connectWallet: {
@@ -121,6 +122,19 @@ function ConnectWallet(props: Props) {
                   >
                     Copy address
                   </div>
+                  {EXPLORER ? (
+                    <div
+                      className={classes.dropdownItem}
+                      onClick={() =>
+                        window.open(
+                          EXPLORER?.href.replace('{:address}', wallet.address),
+                          EXPLORER?.target || '_blank',
+                        )
+                      }
+                    >
+                      {EXPLORER?.label || 'Transactions'}
+                    </div>
+                  ) : null}
                   <div
                     className={classes.dropdownItem}
                     onClick={() => connect(popupState)}

--- a/wormhole-connect/src/components/ConnectWallet.tsx
+++ b/wormhole-connect/src/components/ConnectWallet.tsx
@@ -16,6 +16,7 @@ import WalletIcons from 'icons/WalletIcons';
 import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
 import Popover from '@mui/material/Popover';
 import { EXPLORER } from 'config';
+import { ExplorerConfig } from 'config/types';
 
 const useStyles = makeStyles()((theme: any) => ({
   connectWallet: {
@@ -57,6 +58,26 @@ type Props = {
   type: TransferWallet;
   disabled?: boolean;
 };
+
+type ExplorerLinkProps = {
+  address: string;
+} & ExplorerConfig;
+
+function ExplorerLink({
+  address,
+  href,
+  target = '_blank',
+  label = 'Transactions',
+}: ExplorerLinkProps) {
+  const { classes } = useStyles();
+  const handleOpenExplorer = () =>
+    window.open(href.replace('{:address}', address), target);
+  return (
+    <div className={classes.dropdownItem} onClick={handleOpenExplorer}>
+      {label}
+    </div>
+  );
+}
 
 function ConnectWallet(props: Props) {
   const { disabled = false, type } = props;
@@ -123,17 +144,12 @@ function ConnectWallet(props: Props) {
                     Copy address
                   </div>
                   {EXPLORER ? (
-                    <div
-                      className={classes.dropdownItem}
-                      onClick={() =>
-                        window.open(
-                          EXPLORER?.href.replace('{:address}', wallet.address),
-                          EXPLORER?.target || '_blank',
-                        )
-                      }
-                    >
-                      {EXPLORER?.label || 'Transactions'}
-                    </div>
+                    <ExplorerLink
+                      address={wallet.address}
+                      href={EXPLORER.href}
+                      target={EXPLORER.target}
+                      label={EXPLORER.label}
+                    />
                   ) : null}
                   <div
                     className={classes.dropdownItem}

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -57,6 +57,8 @@ export const WORMHOLE_API =
     ? ''
     : 'https://api.testnet.wormholescan.io/';
 
+export const EXPLORER = config.explorer;
+
 export const ATTEST_URL =
   ENV === 'MAINNET'
     ? 'https://www.portalbridge.com/#/register'

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -75,11 +75,7 @@ export interface WormholeConnectConfig {
     text: string;
     link: string;
   };
-  explorer?: {
-    label: string;
-    href: string;
-    target: '_blank' | '_self';
-  };
+  explorer?: ExplorerConfig;
   bridgeDefaults?: BridgeDefaults;
   routes?: string[];
   cctpWarning?: {
@@ -94,6 +90,12 @@ export interface WormholeConnectConfig {
   partnerLogo?: string;
   walletConnectProjectId?: string;
 }
+
+export type ExplorerConfig = {
+  href: string;
+  label?: string;
+  target?: '_blank' | '_self';
+};
 
 export type PageHeader = {
   text: string;

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -75,6 +75,11 @@ export interface WormholeConnectConfig {
     text: string;
     link: string;
   };
+  explorer?: {
+    label: string;
+    href: string;
+    target: '_blank' | '_self';
+  };
   bridgeDefaults?: BridgeDefaults;
   routes?: string[];
   cctpWarning?: {


### PR DESCRIPTION


https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/7010420a-f1b5-48b7-ac25-77a215690728

<img width="1071" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/14309091-9624-47c6-bec8-2ab7194274a6">

## Sample Settings

```json
{
  "explorer": {
   "href": "https://wormholescan.io/#/txs?address={:address}&network=testnet",
   "label": "View on Wormholescan",
  }
}
```

<img width="737" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/c247585c-4bd2-4059-a1f8-778b1af467bb">
