### PR TITLE
[Enhancemenet] Show automatic redemption route even if insufficient funds are available

### DIFF
--- a/wormhole-connect/src/routes/abstracts/routeAbstract.ts
+++ b/wormhole-connect/src/routes/abstracts/routeAbstract.ts
@@ -20,8 +20,8 @@ export abstract class RouteAbstract {
   // protected abstract sendGasFallback: { [key: ChainName]: TokenConfig };
   // protected abstract claimGasFallback: { [key: ChainName]: TokenConfig };
 
-  // Is this route available for the given chain, token and amount specifications?
-  public abstract isRouteAvailable(
+  // Is this route supported for the given chain, token and amount specifications?
+  public abstract isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,
@@ -29,8 +29,8 @@ export abstract class RouteAbstract {
     destChain: ChainName | ChainId,
   ): Promise<boolean>;
 
-  // Is this route supported for the given chain, fee and amount specifications?
-  public abstract isRouteSupported(
+  // Is this route available for the given chain, fee and amount specifications?
+  public abstract isRouteAvailable(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/abstracts/routeAbstract.ts
+++ b/wormhole-connect/src/routes/abstracts/routeAbstract.ts
@@ -29,6 +29,15 @@ export abstract class RouteAbstract {
     destChain: ChainName | ChainId,
   ): Promise<boolean>;
 
+  // Is this route supported for the given chain, fee and amount specifications?
+  public abstract isRouteSupported(
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean>;
+
   public abstract isSupportedChain(chain: ChainName): boolean;
 
   public abstract isSupportedSourceToken(

--- a/wormhole-connect/src/routes/bridge/baseRoute.ts
+++ b/wormhole-connect/src/routes/bridge/baseRoute.ts
@@ -86,7 +86,7 @@ export abstract class BaseRoute extends RouteAbstract {
     });
   }
 
-  async isRouteSupported(
+  async isRouteAvailable(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/bridge/baseRoute.ts
+++ b/wormhole-connect/src/routes/bridge/baseRoute.ts
@@ -86,6 +86,16 @@ export abstract class BaseRoute extends RouteAbstract {
     });
   }
 
+  async isRouteSupported(
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
+    return true;
+  }
+
   async getPreview(
     token: TokenConfig,
     destToken: TokenConfig,

--- a/wormhole-connect/src/routes/bridge/bridge.ts
+++ b/wormhole-connect/src/routes/bridge/bridge.ts
@@ -28,7 +28,7 @@ export class BridgeRoute extends BaseRoute {
   readonly NATIVE_GAS_DROPOFF_SUPPORTED: boolean = false;
   readonly AUTOMATIC_DEPOSIT: boolean = false;
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/cctpManual/cctpManual.ts
+++ b/wormhole-connect/src/routes/cctpManual/cctpManual.ts
@@ -143,7 +143,7 @@ export class CCTPManualRoute extends BaseRoute {
     });
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
+++ b/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
@@ -188,6 +188,16 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
       CHAINS[destChainName]?.contracts.cctpContracts?.wormholeCircleRelayer;
     if (!bothHaveRelayer) return false;
 
+    return true;
+  }
+
+  async isRouteSupported(
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
     let relayerFee;
     try {
       relayerFee = await this.getRelayerFee(

--- a/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
+++ b/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
@@ -150,7 +150,7 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
     });
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,
@@ -186,12 +186,11 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
     const bothHaveRelayer =
       CHAINS[sourceChainName]?.contracts.cctpContracts?.wormholeCircleRelayer &&
       CHAINS[destChainName]?.contracts.cctpContracts?.wormholeCircleRelayer;
-    if (!bothHaveRelayer) return false;
 
-    return true;
+    return !!bothHaveRelayer;
   }
 
-  async isRouteSupported(
+  async isRouteAvailable(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/cosmosGateway/cosmosGateway.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/cosmosGateway.ts
@@ -57,7 +57,7 @@ export class CosmosGatewayRoute extends BaseRoute {
     return isGatewayChain(chain);
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/hashflow/hashflow.ts
+++ b/wormhole-connect/src/routes/hashflow/hashflow.ts
@@ -35,6 +35,16 @@ export class HashflowRoute extends RouteAbstract {
 
     throw new Error('Method not implemented.');
   }
+
+  public isRouteSupported(
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
+    throw new Error('Method not implemented.');
+  }
   isSupportedSourceToken(
     token: TokenConfig | undefined,
     destToken: TokenConfig | undefined,

--- a/wormhole-connect/src/routes/hashflow/hashflow.ts
+++ b/wormhole-connect/src/routes/hashflow/hashflow.ts
@@ -22,7 +22,7 @@ export class HashflowRoute extends RouteAbstract {
     return false;
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,
@@ -36,7 +36,7 @@ export class HashflowRoute extends RouteAbstract {
     throw new Error('Method not implemented.');
   }
 
-  public isRouteSupported(
+  public isRouteAvailable(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -113,27 +113,6 @@ export class Operator {
       : Route.Bridge;
   }
 
-  async isRouteAvailable(
-    route: Route,
-    sourceToken: string,
-    destToken: string,
-    amount: string,
-    sourceChain: ChainName | ChainId,
-    destChain: ChainName | ChainId,
-  ): Promise<boolean> {
-    if (!ROUTES.includes(route)) {
-      return false;
-    }
-
-    const r = this.getRoute(route);
-    return await r.isRouteAvailable(
-      sourceToken,
-      destToken,
-      amount,
-      sourceChain,
-      destChain,
-    );
-  }
   async isRouteSupported(
     route: Route,
     sourceToken: string,
@@ -148,6 +127,27 @@ export class Operator {
 
     const r = this.getRoute(route);
     return await r.isRouteSupported(
+      sourceToken,
+      destToken,
+      amount,
+      sourceChain,
+      destChain,
+    );
+  }
+  async isRouteAvailable(
+    route: Route,
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
+    if (!ROUTES.includes(route)) {
+      return false;
+    }
+
+    const r = this.getRoute(route);
+    return await r.isRouteAvailable(
       sourceToken,
       destToken,
       amount,

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -134,7 +134,27 @@ export class Operator {
       destChain,
     );
   }
+  async isRouteSupported(
+    route: Route,
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
+    if (!ROUTES.includes(route)) {
+      return false;
+    }
 
+    const r = this.getRoute(route);
+    return await r.isRouteSupported(
+      sourceToken,
+      destToken,
+      amount,
+      sourceChain,
+      destChain,
+    );
+  }
   allSupportedChains(): ChainName[] {
     const supported = new Set<ChainName>();
     for (const key in CHAINS) {

--- a/wormhole-connect/src/routes/relay/relay.ts
+++ b/wormhole-connect/src/routes/relay/relay.ts
@@ -88,7 +88,18 @@ export class RelayRoute extends BridgeRoute implements RelayAbstract {
     const accepted = await isAcceptedToken(tokenId);
 
     if (!accepted) return false;
+    return true;
+  }
 
+  async isRouteSupported(
+    sourceToken: string,
+    destToken: string,
+    amount: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+  ): Promise<boolean> {
+    const tokenConfig = TOKENS[sourceToken]!;
+    const tokenId = getWrappedTokenId(tokenConfig);
     let relayerFee;
     try {
       relayerFee = await this.getRelayerFee(

--- a/wormhole-connect/src/routes/relay/relay.ts
+++ b/wormhole-connect/src/routes/relay/relay.ts
@@ -59,7 +59,7 @@ export class RelayRoute extends BridgeRoute implements RelayAbstract {
     return !!sdkConfig.chains[chain]?.contracts.relayer;
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,
@@ -70,7 +70,7 @@ export class RelayRoute extends BridgeRoute implements RelayAbstract {
       return false;
     }
 
-    const isBridgeRouteAvailable = await super.isRouteAvailable(
+    const isBridgeRouteAvailable = await super.isRouteSupported(
       sourceToken,
       destToken,
       amount,
@@ -85,13 +85,10 @@ export class RelayRoute extends BridgeRoute implements RelayAbstract {
     }
     const tokenConfig = TOKENS[sourceToken]!;
     const tokenId = getWrappedTokenId(tokenConfig);
-    const accepted = await isAcceptedToken(tokenId);
-
-    if (!accepted) return false;
-    return true;
+    return isAcceptedToken(tokenId);
   }
 
-  async isRouteSupported(
+  async isRouteAvailable(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/routes/tbtc/tbtc.ts
+++ b/wormhole-connect/src/routes/tbtc/tbtc.ts
@@ -85,7 +85,7 @@ export class TBTCRoute extends BaseRoute {
     return wh.toChainId(token.nativeChain) === CHAIN_ID_ETH;
   }
 
-  async isRouteAvailable(
+  async isRouteSupported(
     sourceToken: string,
     destToken: string,
     amount: string,

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -224,7 +224,6 @@ const establishRoute = (state: TransferInputState) => {
   for (const r of routeOrderOfPreference) {
     const routeState = routeStates.find((rs) => rs.name === r);
     if (routeState && routeState.available) {
-      console.log('routeState', routeState, r);
       state.route = r;
       return;
     }

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -223,7 +223,7 @@ const establishRoute = (state: TransferInputState) => {
   ];
   for (const r of routeOrderOfPreference) {
     const routeState = routeStates.find((rs) => rs.name === r);
-    if (routeState && routeState.supported) {
+    if (routeState && routeState.supported && routeState.available) {
       state.route = r;
       return;
     }

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -223,7 +223,7 @@ const establishRoute = (state: TransferInputState) => {
   ];
   for (const r of routeOrderOfPreference) {
     const routeState = routeStates.find((rs) => rs.name === r);
-    if (routeState && routeState.available) {
+    if (routeState && routeState.supported) {
       state.route = r;
       return;
     }
@@ -352,7 +352,7 @@ export const transferInputSlice = createSlice({
       }
       if (
         state.routeStates &&
-        state.routeStates.some((rs) => rs.name === payload && rs.available)
+        state.routeStates.some((rs) => rs.name === payload && rs.supported)
       ) {
         state.route = payload;
       } else {

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -203,7 +203,7 @@ export const validateAll = async (
     foreignAsset,
     route,
     supportedDestTokens,
-    availableRoutes,
+    routeStates,
   } = transferData;
   const { maxSwapAmt, toNativeToken } = relayData;
   const { sending, receiving } = walletData;
@@ -215,7 +215,9 @@ export const validateAll = async (
     fromChain,
     token,
   );
-
+  const availableRoutes = routeStates
+    ?.filter((rs) => rs.available)
+    .map((val) => val.name);
   const baseValidations = {
     sendingWallet: await validateWallet(sending, fromChain),
     receivingWallet: await validateWallet(receiving, toChain),
@@ -269,7 +271,7 @@ export const validate = async (
     transferInput.destToken &&
     transferInput.amount &&
     Number.parseFloat(transferInput.amount) >= 0 &&
-    transferInput.availableRoutes !== undefined
+    transferInput.routeStates?.filter((rs) => rs.available) !== undefined
       ? true
       : false;
   dispatch(setValidations({ validations, showValidationState }));

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -216,7 +216,7 @@ export const validateAll = async (
     token,
   );
   const availableRoutes = routeStates
-    ?.filter((rs) => rs.available)
+    ?.filter((rs) => rs.supported)
     .map((val) => val.name);
   const baseValidations = {
     sendingWallet: await validateWallet(sending, fromChain),
@@ -271,7 +271,7 @@ export const validate = async (
     transferInput.destToken &&
     transferInput.amount &&
     Number.parseFloat(transferInput.amount) >= 0 &&
-    transferInput.routeStates?.filter((rs) => rs.available) !== undefined
+    transferInput.routeStates?.filter((rs) => rs.supported) !== undefined
       ? true
       : false;
   dispatch(setValidations({ validations, showValidationState }));

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -271,7 +271,7 @@ export const validate = async (
     transferInput.destToken &&
     transferInput.amount &&
     Number.parseFloat(transferInput.amount) >= 0 &&
-    transferInput.routeStates?.filter((rs) => rs.supported) !== undefined
+    transferInput.routeStates?.some((rs) => rs.supported) !== undefined
       ? true
       : false;
   dispatch(setValidations({ validations, showValidationState }));

--- a/wormhole-connect/src/views/Bridge/Collapse.tsx
+++ b/wormhole-connect/src/views/Bridge/Collapse.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import Collapse from '@mui/material/Collapse';
 import Down from 'icons/Down';
@@ -119,8 +119,8 @@ type Props = {
 
 function BridgeCollapse(props: Props) {
   const { classes } = useStyles();
-  const { onCollapseChange, disabled } = props;
-  const [collapsed, setCollapsed] = React.useState(props.startClosed || false);
+  const { onCollapseChange, disabled, startClosed } = props;
+  const [collapsed, setCollapsed] = React.useState(startClosed || false);
 
   const toggleCollapsed = useCallback(() => {
     if (disabled) return;
@@ -131,6 +131,10 @@ function BridgeCollapse(props: Props) {
       return !prev;
     });
   }, [disabled, onCollapseChange]);
+
+  useEffect(() => {
+    setCollapsed(startClosed || false);
+  }, [startClosed]);
 
   const controlStyle = props.controlStyle || CollapseControlStyle.Arrow;
   const collapsedState = props.controlled ? props.value || false : collapsed;

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -322,11 +322,7 @@ function RouteOptions() {
   const allRoutes = useMemo(() => {
     if (!routeStates) return [];
     const available = routeStates.filter((rs) => rs.available);
-    const unavailable = routeStates.filter(
-      (rs) => rs.available && !rs.supported,
-    );
-    console.log('allRoutes', available.concat(unavailable));
-    return available.concat(unavailable);
+    return available;
   }, [routeStates]);
 
   return allRoutes ? (

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -263,6 +263,7 @@ function RouteOption(props: { route: RouteData; disabled: boolean }) {
 function RouteOptions() {
   const dispatch = useDispatch();
   const [collapsed, setCollapsed] = useState(true);
+  const [unsupportedRoute, setUnsupportedRoute] = useState(false);
   const {
     isTransactionInProgress,
     route,
@@ -322,8 +323,13 @@ function RouteOptions() {
   const allRoutes = useMemo(() => {
     if (!routeStates) return [];
     const available = routeStates.filter((rs) => rs.available);
+    setUnsupportedRoute(available.some((rs) => !rs.supported));
     return available;
   }, [routeStates]);
+
+  useEffect(() => {
+    setCollapsed(!unsupportedRoute);
+  }, [unsupportedRoute]);
 
   return allRoutes ? (
     <BridgeCollapse
@@ -331,7 +337,7 @@ function RouteOptions() {
       disabled={isTransactionInProgress}
       banner={<Banner />}
       disableCollapse
-      startClosed
+      startClosed={!unsupportedRoute}
       onCollapseChange={onCollapseChange}
       controlStyle={
         allRoutes.length > 1

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -263,7 +263,7 @@ function RouteOption(props: { route: RouteData; disabled: boolean }) {
 function RouteOptions() {
   const dispatch = useDispatch();
   const [collapsed, setCollapsed] = useState(true);
-  const [unsupportedRoute, setUnsupportedRoute] = useState(false);
+  const [unavailableRoute, setUnavailableRoute] = useState(false);
   const {
     isTransactionInProgress,
     route,
@@ -278,7 +278,7 @@ function RouteOptions() {
     (value: Route) => {
       if (routeStates && routeStates.some((rs) => rs.name === value)) {
         const route = routeStates.find((rs) => rs.name === value);
-        if (route?.supported) dispatch(setTransferRoute(value));
+        if (route?.available) dispatch(setTransferRoute(value));
       }
     },
     [routeStates, dispatch],
@@ -322,14 +322,14 @@ function RouteOptions() {
 
   const allRoutes = useMemo(() => {
     if (!routeStates) return [];
-    const available = routeStates.filter((rs) => rs.available);
-    setUnsupportedRoute(available.some((rs) => !rs.supported));
-    return available;
+    const routes = routeStates.filter((rs) => rs.supported);
+    setUnavailableRoute(routes.some((rs) => !rs.available));
+    return routes;
   }, [routeStates]);
 
   useEffect(() => {
-    setCollapsed(!unsupportedRoute);
-  }, [unsupportedRoute]);
+    setCollapsed(!unavailableRoute);
+  }, [unavailableRoute]);
 
   return allRoutes ? (
     <BridgeCollapse
@@ -337,7 +337,7 @@ function RouteOptions() {
       disabled={isTransactionInProgress}
       banner={<Banner />}
       disableCollapse
-      startClosed={!unsupportedRoute}
+      startClosed={!unavailableRoute}
       onCollapseChange={onCollapseChange}
       controlStyle={
         allRoutes.length > 1
@@ -351,12 +351,12 @@ function RouteOptions() {
         collapsable
         collapsed={collapsed}
       >
-        {allRoutes.map(({ name, supported }) => {
+        {allRoutes.map(({ name, available }) => {
           return {
             key: name,
             child: (
               <RouteOption
-                disabled={!supported}
+                disabled={!available}
                 route={RoutesConfig[name as Route]}
               />
             ),

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -331,7 +331,7 @@ function RouteOptions() {
     setCollapsed(!unavailableRoute);
   }, [unavailableRoute]);
 
-  return allRoutes ? (
+  return allRoutes && allRoutes.length > 0 ? (
     <BridgeCollapse
       title="Route"
       disabled={isTransactionInProgress}


### PR DESCRIPTION
Issue: https://github.com/wormhole-foundation/wormhole-connect/issues/1299

Now we take into account a new field, that the route is supported, in that context it means that the amount is sufficient to cover the fee, even though the route is enabled.

Result:
![image](https://github.com/wormhole-foundation/wormhole-connect/assets/35125931/f0e09b29-f8d5-440c-8e8b-f590d1b2c187)


[testt2.webm](https://github.com/wormhole-foundation/wormhole-connect/assets/35125931/b1ef64c3-bf47-4250-91fa-250344849c94)
