### PR TITLE
Allow resuming a transaction without having an ATA created

### DIFF
--- a/wormhole-connect/src/routes/utils.ts
+++ b/wormhole-connect/src/routes/utils.ts
@@ -45,10 +45,19 @@ export const adaptParsedMessage = async (
     toChainId === MAINNET_CHAINS.solana &&
     parsed.payloadID === PayloadType.Manual
   ) {
-    const accountOwner = await solanaContext().getTokenAccountOwner(
-      parsed.recipient,
-    );
-    base.recipient = accountOwner;
+    try {
+      const accountOwner = await solanaContext().getTokenAccountOwner(
+        parsed.recipient,
+      );
+      base.recipient = accountOwner;
+    } catch (e: any) {
+      if (e.name === 'TokenAccountNotFoundError') {
+        // we'll promp them to create it before claiming it
+        base.recipient = '';
+      } else {
+        throw e;
+      }
+    }
   }
   return base;
 };

--- a/wormhole-connect/src/views/Bridge/Inputs/TokenWarnings.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/TokenWarnings.tsx
@@ -53,7 +53,7 @@ const useStyles = makeStyles()((theme: any) => ({
 type Props = {
   createAssociatedTokenAccount: any;
 };
-function AssociatedTokenWarning(props: Props) {
+export function AssociatedTokenWarning(props: Props) {
   const { classes } = useStyles();
   const [inProgress, setInProgress] = useState(false);
   const [error, setError] = useState('');


### PR DESCRIPTION
Before this change, the application would show a generic error when trying to resume the tx (see attached picture). Now prompt the user to create the ATA before redeeming (see attached video).

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/11276821/ca591cd0-1b62-4a16-83a8-0d6a0b373d11)

https://github.com/wormhole-foundation/wormhole-connect/assets/11276821/87937f01-796e-4d31-a32e-1a03512c9498

