### PR TITLE
Vite environment variables support

### DIFF
--- a/wormhole-connect/src/config/devnet/rpcs.ts
+++ b/wormhole-connect/src/config/devnet/rpcs.ts
@@ -5,7 +5,8 @@ const {
   REACT_APP_WORMCHAIN_DEVNET_RPC,
   REACT_APP_TERRA2_DEVNET_RPC,
   REACT_APP_SEI_REST,
-} = process.env;
+  REACT_APP_APTOS_DEVNET_REST,
+} = import.meta.env;
 
 export const DEVNET_RPC_MAPPING = {
   ...populateRpcField('ethereum', REACT_APP_ETHEREUM_DEVNET_RPC),
@@ -19,5 +20,5 @@ export const DEVNET_REST_MAPPING = {
 };
 
 export const DEVNET_GRAPHQL_MAPPING = {
-  ...populateRpcField('aptos', process.env.REACT_APP_APTOS_DEVNET_REST),
+  ...populateRpcField('aptos', REACT_APP_APTOS_DEVNET_REST),
 };

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -23,7 +23,7 @@ const configJson = el.getAttribute('config');
 export const config: WormholeConnectConfig = JSON.parse(configJson!) || {};
 
 const getEnv = () => {
-  const processEnv = process.env.REACT_APP_CONNECT_ENV?.toLowerCase();
+  const processEnv = import.meta.env.REACT_APP_CONNECT_ENV?.toLowerCase();
   if (config.env === 'mainnet' || processEnv === 'mainnet') return 'MAINNET';
   if (config.env === 'devnet' || processEnv === 'devnet') return 'DEVNET';
   return 'TESTNET';
@@ -141,7 +141,7 @@ export const BRIDGE_DEFAULTS =
 export const WALLET_CONNECT_PROJECT_ID =
   config && config.walletConnectProjectId
     ? config.walletConnectProjectId
-    : process.env.REACT_APP_WALLET_CONNECT_PROJECT_ID;
+    : import.meta.env.REACT_APP_WALLET_CONNECT_PROJECT_ID;
 
 export const TESTNET_TO_MAINNET_CHAIN_NAMES: {
   [k in TestnetChainName]: MainnetChainName;

--- a/wormhole-connect/src/config/mainnet/rpcs.ts
+++ b/wormhole-connect/src/config/mainnet/rpcs.ts
@@ -18,7 +18,10 @@ const {
   REACT_APP_KUJIRA_RPC,
   REACT_APP_SEI_REST,
   REACT_APP_EVMOS_REST,
-} = process.env;
+  REACT_APP_ARBITRUM_RPC,
+  REACT_APP_OPTIMISM_RPC,
+  REACT_APP_APTOS_GRAPHQL,
+} = import.meta.env;
 
 export const MAINNET_RPC_MAPPING = {
   ...populateRpcField('ethereum', REACT_APP_ETHEREUM_RPC),
@@ -35,8 +38,8 @@ export const MAINNET_RPC_MAPPING = {
   ...populateRpcField('base', REACT_APP_BASE_RPC),
   ...populateRpcField('osmosis', REACT_APP_OSMOSIS_RPC),
   ...populateRpcField('wormchain', REACT_APP_WORMCHAIN_RPC),
-  ...populateRpcField('arbitrum', process.env.REACT_APP_ARBITRUM_RPC),
-  ...populateRpcField('optimism', process.env.REACT_APP_OPTIMISM_RPC),
+  ...populateRpcField('arbitrum', REACT_APP_ARBITRUM_RPC),
+  ...populateRpcField('optimism', REACT_APP_OPTIMISM_RPC),
   ...populateRpcField('evmos', REACT_APP_EVMOS_RPC),
   ...populateRpcField('kujira', REACT_APP_KUJIRA_RPC),
 };
@@ -47,5 +50,5 @@ export const MAINNET_REST_MAPPING = {
 };
 
 export const MAINNET_GRAPHQL_MAPPING = {
-  ...populateRpcField('aptos', process.env.REACT_APP_APTOS_GRAPHQL),
+  ...populateRpcField('aptos', REACT_APP_APTOS_GRAPHQL),
 };

--- a/wormhole-connect/src/config/testnet/rpcs.ts
+++ b/wormhole-connect/src/config/testnet/rpcs.ts
@@ -19,7 +19,10 @@ const {
   REACT_APP_KUJIRA_TESTNET_RPC,
   REACT_APP_SEI_REST,
   REACT_APP_EVMOS_REST,
-} = process.env;
+  REACT_APP_ARBITRUM_GOERLI_RPC,
+  REACT_APP_OPTIMISM_GOERLI_RPC,
+  REACT_APP_APTOS_TESTNET_GRAPHQL,
+} = import.meta.env;
 
 export const TESTNET_RPC_MAPPING = {
   ...populateRpcField('goerli', REACT_APP_GOERLI_RPC),
@@ -36,14 +39,8 @@ export const TESTNET_RPC_MAPPING = {
   ...populateRpcField('basegoerli', REACT_APP_BASE_GOERLI_RPC),
   ...populateRpcField('osmosis', REACT_APP_OSMOSIS_TESTNET_RPC),
   ...populateRpcField('wormchain', REACT_APP_WORMCHAIN_TESTNET_RPC),
-  ...populateRpcField(
-    'arbitrumgoerli',
-    process.env.REACT_APP_ARBITRUM_GOERLI_RPC,
-  ),
-  ...populateRpcField(
-    'optimismgoerli',
-    process.env.REACT_APP_OPTIMISM_GOERLI_RPC,
-  ),
+  ...populateRpcField('arbitrumgoerli', REACT_APP_ARBITRUM_GOERLI_RPC),
+  ...populateRpcField('optimismgoerli', REACT_APP_OPTIMISM_GOERLI_RPC),
   ...populateRpcField('cosmoshub', REACT_APP_COSMOSHUB_TESTNET_RPC),
   ...populateRpcField('evmos', REACT_APP_EVMOS_TESTNET_RPC),
   ...populateRpcField('kujira', REACT_APP_KUJIRA_TESTNET_RPC),
@@ -55,5 +52,5 @@ export const TESTNET_REST_MAPPING = {
 };
 
 export const TESTNET_GRAPHQL_MAPPING = {
-  ...populateRpcField('aptos', process.env.REACT_APP_APTOS_TESTNET_GRAPHQL),
+  ...populateRpcField('aptos', REACT_APP_APTOS_TESTNET_GRAPHQL),
 };

--- a/wormhole-connect/src/env.d.ts
+++ b/wormhole-connect/src/env.d.ts
@@ -1,0 +1,65 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // env
+  REACT_APP_CONNECT_ENV: string;
+
+  // wallet connect
+  REACT_APP_WALLET_CONNECT_PROJECT_ID: string;
+
+  // mainnet
+  REACT_APP_ETHEREUM_RPC: string;
+  REACT_APP_SOLANA_RPC: string;
+  REACT_APP_POLYGON_RPC: string;
+  REACT_APP_BSC_RPC: string;
+  REACT_APP_AVALANCHE_RPC: string;
+  REACT_APP_FANTOM_RPC: string;
+  REACT_APP_CELO_RPC: string;
+  REACT_APP_MOONBEAM_RPC: string;
+  REACT_APP_SUI_RPC: string;
+  REACT_APP_APTOS_RPC: string;
+  REACT_APP_SEI_RPC: string;
+  REACT_APP_BASE_RPC: string;
+  REACT_APP_OSMOSIS_RPC: string;
+  REACT_APP_WORMCHAIN_RPC: string;
+  REACT_APP_EVMOS_RPC: string;
+  REACT_APP_KUJIRA_RPC: string;
+  REACT_APP_SEI_REST: string;
+  REACT_APP_EVMOS_REST: string;
+  REACT_APP_ARBITRUM_RPC: string;
+  REACT_APP_OPTIMISM_RPC: string;
+  REACT_APP_APTOS_GRAPHQL: string;
+
+  // testnet
+  REACT_APP_GOERLI_RPC: string;
+  REACT_APP_MUMBAI_RPC: string;
+  REACT_APP_BSC_TESTNET_RPC: string;
+  REACT_APP_FUJI_RPC: string;
+  REACT_APP_FANTOM_TESTNET_RPC: string;
+  REACT_APP_ALFAJORES_RPC: string;
+  REACT_APP_SOLANA_DEVNET_RPC: string;
+  REACT_APP_MOONBASE_RPC: string;
+  REACT_APP_SUI_TESTNET_RPC: string;
+  REACT_APP_APTOS_TESTNET_RPC: string;
+  REACT_APP_SEI_TESTNET_RPC: string;
+  REACT_APP_BASE_GOERLI_RPC: string;
+  REACT_APP_OSMOSIS_TESTNET_RPC: string;
+  REACT_APP_WORMCHAIN_TESTNET_RPC: string;
+  REACT_APP_EVMOS_TESTNET_RPC: string;
+  REACT_APP_COSMOSHUB_TESTNET_RPC: string;
+  REACT_APP_KUJIRA_TESTNET_RPC: string;
+  REACT_APP_ARBITRUM_GOERLI_RPC: string;
+  REACT_APP_OPTIMISM_GOERLI_RPC: string;
+  REACT_APP_APTOS_TESTNET_GRAPHQL: string;
+
+  // devnet
+  REACT_APP_ETHEREUM_DEVNET_RPC: string;
+  REACT_APP_OSMOSIS_DEVNET_RPC: string;
+  REACT_APP_WORMCHAIN_DEVNET_RPC: string;
+  REACT_APP_TERRA2_DEVNET_RPC: string;
+  REACT_APP_APTOS_DEVNET_REST: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/wormhole-connect/tsconfig.json
+++ b/wormhole-connect/tsconfig.json
@@ -13,7 +13,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "lib": ["es2021", "dom"],
-    "module": "commonjs",
+    "module": "ES2022",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noFallthroughCasesInSwitch": true,

--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -6,6 +6,8 @@ import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // TODO: consider using the "VITE_APP_" prefix which is the default for Vite
+  envPrefix: 'REACT_APP_',
   resolve: {
     alias: {
       utils: path.resolve(__dirname, './src/utils'),


### PR DESCRIPTION
We can't access environment variables on the client from `process.env` in a Vite build. Changed the default env var prefix to be `REACT_APP_` to maintain backwards compatibility for now. See more here: https://vitejs.dev/guide/env-and-mode