### PR TITLE
Fix glitchy error message, remove collapsing from route options

### DIFF
--- a/wormhole-connect/src/components/Options.tsx
+++ b/wormhole-connect/src/components/Options.tsx
@@ -23,6 +23,8 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   optionContent: {
     padding: '16px',
+  },
+  optionContentEnabled: {
     '&:hover': {
       backgroundColor: theme.palette.options.hover,
     },
@@ -45,6 +47,7 @@ const useStyles = makeStyles()((theme: any) => ({
 export type Option = {
   key: any;
   child: any;
+  disabled?: boolean;
 };
 type Props = {
   children: Option[];
@@ -75,7 +78,10 @@ function Options(props: Props) {
             unmountOnExit
           >
             <div
-              className={classes.optionContent}
+              className={joinClass([
+                classes.optionContent,
+                !option.disabled && classes.optionContentEnabled,
+              ])}
               onClick={() => props.onSelect(option.key)}
               style={{
                 cursor: props.children.length > 0 ? 'pointer' : 'default',

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -97,6 +97,7 @@ export const validateAmount = (
   balance: string | null,
   minAmt: number | undefined,
 ): ValidationErr => {
+  if (amount === '') return '';
   const numAmount = Number.parseFloat(amount);
   if (!numAmount) return 'Enter an amount';
   if (numAmount <= 0) return 'Amount must be greater than 0';

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -95,17 +95,15 @@ export const validateDestToken = (
 export const validateAmount = (
   amount: string,
   balance: string | null,
-  minAmt: number | undefined,
 ): ValidationErr => {
   if (amount === '') return '';
+
   const numAmount = Number.parseFloat(amount);
   if (numAmount <= 0) return 'Amount must be greater than 0';
   if (balance) {
     const b = Number.parseFloat(balance);
     if (numAmount > b) return 'Amount cannot exceed balance';
   }
-  if (!minAmt) return '';
-  if (numAmount < minAmt) return `Minimum amount is ${minAmt}`;
   return '';
 };
 
@@ -208,7 +206,6 @@ export const validateAll = async (
   const { maxSwapAmt, toNativeToken } = relayData;
   const { sending, receiving } = walletData;
   const isAutomatic = getIsAutomatic(route);
-  const minAmt = getMinAmt(route, relayData);
   const sendingTokenBalance = accessBalance(
     balances,
     sending.address,
@@ -225,8 +222,8 @@ export const validateAll = async (
     toChain: validateToChain(toChain, fromChain),
     token: validateToken(token, fromChain),
     destToken: validateDestToken(destToken, toChain, supportedDestTokens),
+    amount: validateAmount(amount, sendingTokenBalance),
     route: validateRoute(route, availableRoutes),
-    amount: '',
     toNativeToken: '',
     foreignAsset: validateForeignAsset(foreignAsset),
   };
@@ -237,10 +234,7 @@ export const validateAll = async (
       toNativeToken: validateToNativeAmt(toNativeToken, maxSwapAmt),
     };
   } else {
-    return {
-      ...baseValidations,
-      amount: validateAmount(amount, sendingTokenBalance, minAmt),
-    };
+    return baseValidations;
   }
 };
 

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -99,7 +99,6 @@ export const validateAmount = (
 ): ValidationErr => {
   if (amount === '') return '';
   const numAmount = Number.parseFloat(amount);
-  if (!numAmount) return 'Enter an amount';
   if (numAmount <= 0) return 'Amount must be greater than 0';
   if (balance) {
     const b = Number.parseFloat(balance);

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -97,8 +97,8 @@ export const validateAmount = (
   balance: string | null,
 ): ValidationErr => {
   if (amount === '') return '';
-
   const numAmount = Number.parseFloat(amount);
+  if (isNaN(numAmount)) return 'Amount must be a number';
   if (numAmount <= 0) return 'Amount must be greater than 0';
   if (balance) {
     const b = Number.parseFloat(balance);

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -226,17 +226,23 @@ export const validateAll = async (
     toChain: validateToChain(toChain, fromChain),
     token: validateToken(token, fromChain),
     destToken: validateDestToken(destToken, toChain, supportedDestTokens),
-    amount: validateAmount(amount, sendingTokenBalance, minAmt),
     route: validateRoute(route, availableRoutes),
+    amount: '',
     toNativeToken: '',
     foreignAsset: validateForeignAsset(foreignAsset),
   };
-  if (!isAutomatic) return baseValidations;
-  return {
-    ...baseValidations,
-    amount: validateAmount(amount, sendingTokenBalance, minAmt),
-    toNativeToken: validateToNativeAmt(toNativeToken, maxSwapAmt),
-  };
+
+  if (isAutomatic) {
+    return {
+      ...baseValidations,
+      toNativeToken: validateToNativeAmt(toNativeToken, maxSwapAmt),
+    };
+  } else {
+    return {
+      ...baseValidations,
+      amount: validateAmount(amount, sendingTokenBalance, minAmt),
+    };
+  }
 };
 
 export const isTransferValid = (validations: TransferValidations) => {

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -289,8 +289,6 @@ function RouteOption(props: { route: RouteData; disabled: boolean }) {
 
 function RouteOptions() {
   const dispatch = useDispatch();
-  const [collapsed, setCollapsed] = useState(true);
-  const [unavailableRoute, setUnavailableRoute] = useState(false);
   const {
     isTransactionInProgress,
     route,
@@ -343,20 +341,11 @@ function RouteOptions() {
     getAvailable();
   }, [dispatch, token, destToken, debouncedAmount, fromChain, toChain]);
 
-  const onCollapseChange = (collapsed: boolean) => {
-    setCollapsed(collapsed);
-  };
-
   const allRoutes = useMemo(() => {
     if (!routeStates) return [];
     const routes = routeStates.filter((rs) => rs.supported);
-    setUnavailableRoute(routes.some((rs) => !rs.available));
     return routes;
   }, [routeStates]);
-
-  useEffect(() => {
-    setCollapsed(!unavailableRoute);
-  }, [unavailableRoute]);
 
   return allRoutes && allRoutes.length > 0 ? (
     <BridgeCollapse
@@ -364,20 +353,11 @@ function RouteOptions() {
       disabled={isTransactionInProgress}
       banner={<Banner />}
       disableCollapse
-      startClosed={!unavailableRoute}
-      onCollapseChange={onCollapseChange}
-      controlStyle={
-        allRoutes.length > 1
-          ? CollapseControlStyle.Arrow
-          : CollapseControlStyle.None
-      }
+      startClosed={false}
+      onCollapseChange={() => {}}
+      controlStyle={CollapseControlStyle.None}
     >
-      <Options
-        active={route}
-        onSelect={onSelect}
-        collapsable
-        collapsed={collapsed}
-      >
+      <Options active={route} onSelect={onSelect} collapsable collapsed={false}>
         {allRoutes.map(({ name, available }) => {
           return {
             key: name,

--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -243,7 +243,7 @@ function RouteOption(props: { route: RouteData; disabled: boolean }) {
                 />
               ) : (
                 <Chip
-                  label="Approve a txn from your destination chain wallet"
+                  label="Approve transfer with destination wallet"
                   color="warning"
                   variant="outlined"
                   size="small"
@@ -270,7 +270,7 @@ function RouteOption(props: { route: RouteData; disabled: boolean }) {
           <div className={classes.routeRight}>
             {props.disabled ? (
               <>
-                <div>Not available</div>
+                <div>Transfer amount too low</div>
               </>
             ) : (
               <>
@@ -361,6 +361,7 @@ function RouteOptions() {
         {allRoutes.map(({ name, available }) => {
           return {
             key: name,
+            disabled: !available,
             child: (
               <RouteOption
                 disabled={!available}

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -220,7 +220,7 @@ function Send(props: { valid: boolean }) {
       {!!props.valid && (
         <AlertBanner
           show={showValidationState && !!props.valid && showWarning}
-          content="This transfer will require two transactions - one on the source chain and one on the destination chain."
+          content="This transfer requires two transactions: one on the source chain and one on the destination chain. You will need gas on the destination chain."
           warning
           margin="0 0 16px 0"
         />

--- a/wormhole-connect/src/views/Bridge/ValidationError.tsx
+++ b/wormhole-connect/src/views/Bridge/ValidationError.tsx
@@ -1,29 +1,9 @@
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { makeStyles } from 'tss-react/mui';
+import { useSelector } from 'react-redux';
 
 import { RootState } from 'store';
-import { ValidationErr, setTransferRoute } from 'store/transferInput';
-import { Route } from 'config/types';
-import RouteOperator from 'routes/operator';
+import { ValidationErr } from 'store/transferInput';
 import AlertBanner from 'components/AlertBanner';
-
-const useStyles = makeStyles()((theme) => ({
-  minAmtError: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'start',
-  },
-  link: {
-    textDecoration: 'underline',
-    opacity: '0.8',
-    padding: '4px 0',
-    cursor: 'pointer',
-    '&:hover': {
-      opacity: '1',
-    },
-  },
-}));
 
 type Props = {
   validations: ValidationErr[];
@@ -32,46 +12,12 @@ type Props = {
 };
 
 function ValidationError(props: Props) {
-  const { classes } = useStyles();
-  const dispatch = useDispatch();
   const showErrors = useSelector(
     (state: RootState) => state.transferInput.showValidationState,
-  );
-  const { route } = useSelector((state: RootState) => state.transferInput);
-  const { toNativeToken, relayerFee } = useSelector(
-    (state: RootState) => state.relay,
   );
   const validationErrors = props.validations.filter((v) => !!v) as string[];
   const showError = validationErrors.length > 0;
   let content: React.ReactNode = validationErrors[0];
-
-  const selectManual = () => {
-    // TODO: Only change the enum
-    if (route === Route.CCTPRelay || route === Route.CCTPManual) {
-      dispatch(setTransferRoute(Route.CCTPManual));
-    } else {
-      dispatch(setTransferRoute(Route.Bridge));
-    }
-  };
-
-  if (
-    route &&
-    validationErrors[0] &&
-    validationErrors[0].includes('Minimum amount is')
-  ) {
-    const r = RouteOperator.getRoute(route);
-    const min = r.getMinSendAmount({ toNativeToken, relayerFee });
-    content = (
-      <div className={classes.minAmtError}>
-        <div>
-          Minimum amount is {min} for single transaction automatic transfers
-        </div>
-        <div className={classes.link} onClick={selectManual}>
-          Switch to a manual claim transfer?
-        </div>
-      </div>
-    );
-  }
 
   const show = (props.forceShow || showErrors) && showError;
 


### PR DESCRIPTION
*Fix to #952*

I can't reproduce "Scenario 1", perhaps that was already fixed.

For "Scenario 2" I removed the minimum amount validation. It appears that Connect always disables routes where the minimum is higher than the inputted amount. So there's no case where this error message is needed.

The only reason this bug happened is because the `amount` changes before the `route`, for a split second, because the `setRoutes` runs on a debounced `amount` value. Then `route` catches up when Connect forcibly changes it for the user in `setRoutes`. In that split second in between, we show an incorrect error message.

IMO it would be better to do all validation in the redux stores, and not in component effects. All of the debounces and deferred execution makes this kind of messy. But that's a larger refactor.

*I need someone more familiar with Connect to verify this is correct and my solution is valid.*

*Fix to #1394*

- Minor style and copy changes as per https://github.com/wormhole-foundation/wormhole-connect/issues/1394#issuecomment-1877707804

*Fix to #1422*

- Don't actually let the `Collapse` element collapse for the route options. It's a bit weird to continue using it at all, but it has styles consistent with the following sections. A larger refactor could allow us to get off the `Collapse` element here altogether but I'm trying to fight off scope creep here.