### PR TITLE
Update README instructions so Vite build works for HTML integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Include the wormhole connect
 
 ```html
 <!-- include in <head> -->
-<script src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.js" defer></script>
-<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.css" />
+<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js" defer></script>
+<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css" />
 
 <!-- include in <body> -->
 <div id="wormhole-connect"></div>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Include the wormhole connect
 
 ```html
 <!-- include in <head> -->
-<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js" defer></script>
-<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css" />
+<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.js" defer></script>
+<link rel="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.css" />
 
 <!-- include in <body> -->
 <div id="wormhole-connect"></div>

--- a/wormhole-connect-loader/README.md
+++ b/wormhole-connect-loader/README.md
@@ -144,9 +144,9 @@ If you created a config from step 1, [stringify](https://developer.mozilla.org/e
 
 ```html
 <!-- paste below into index.html body -->
-<script src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.js"></script>
+<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js"></script>
 <link
-  href="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.css"
+  href="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css"
 />
 ```
 
@@ -156,12 +156,13 @@ Note that the `wormhole-connect` div with your config has to be present _before_
 function mount() {
   const script = document.createElement("script");
   script.src =
-    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.js";
+    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js";
   script.async = true;
+  script.type = "module";
 
   const link = document.createElement("link");
   link.href =
-    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.0.12/dist/main.css";
+    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css";
 
   document.body.appendChild(script);
   document.body.appendChild(link);

--- a/wormhole-connect-loader/README.md
+++ b/wormhole-connect-loader/README.md
@@ -144,9 +144,9 @@ If you created a config from step 1, [stringify](https://developer.mozilla.org/e
 
 ```html
 <!-- paste below into index.html body -->
-<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js"></script>
+<script type="module" src="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.js"></script>
 <link
-  href="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css"
+  href="https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.css"
 />
 ```
 
@@ -156,13 +156,13 @@ Note that the `wormhole-connect` div with your config has to be present _before_
 function mount() {
   const script = document.createElement("script");
   script.src =
-    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.js";
+    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.js";
   script.async = true;
   script.type = "module";
 
   const link = document.createElement("link");
   link.href =
-    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.1.8/dist/main.css";
+    "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.2.0/dist/main.css";
 
   document.body.appendChild(script);
   document.body.appendChild(link);


### PR DESCRIPTION
The Vite build creates a more modern build that leverages JavaScript modules. This is [fully supported on all major browsers](https://caniuse.com/?search=type%20module), but it requires a `type="module"` attribute set on the `script` tag. I had addressed it in the loader [here](https://github.com/wormhole-foundation/wormhole-connect/pull/1335/files#diff-50a8ddca1567eec9e96e3d26bf25654bb5ea7f3baaa21760dffd15a4c85e472bR18), but forgot to update the README for the copy pasters out there.

People using the JSX loader over NPM won't be affected. But we will need to make sure people integrating with the dummy HTML copy-pasta method from the README update their code to have that `type="module"` attribute. 0.18 won't work with the code for 0.17.