### PR TITLE
Control for race condition

### DIFF
--- a/wormhole-connect/src/views/Bridge/RouteOptions.tsx
+++ b/wormhole-connect/src/views/Bridge/RouteOptions.tsx
@@ -311,6 +311,8 @@ function RouteOptions() {
   const [debouncedAmount] = useDebounce(amount, 500);
 
   useEffect(() => {
+    let isActive = true;
+
     if (!fromChain || !toChain || !token || !destToken) return;
     const getAvailable = async () => {
       let routes: RouteState[] = [];
@@ -336,9 +338,15 @@ function RouteOptions() {
         routes.push({ name: r, supported, available });
       }
 
-      dispatch(setRoutes(routes));
+      if (isActive) {
+        dispatch(setRoutes(routes));
+      }
     };
     getAvailable();
+
+    return () => {
+      isActive = false;
+    };
   }, [dispatch, token, destToken, debouncedAmount, fromChain, toChain]);
 
   const allRoutes = useMemo(() => {


### PR DESCRIPTION
Fixes #952. When changing the "from" asset, this effect fires twice: once before the "to" asset is changed accordingly, and once after. This causes a race condition. If the first firing resolves second, the UI says there is no available route because the assets didn't match.