### PR TITLE
Cache gateway ibc connections in order to avoid redundant calls

### DIFF
--- a/sdk/src/contexts/cosmos/types.ts
+++ b/sdk/src/contexts/cosmos/types.ts
@@ -10,3 +10,8 @@ export interface CosmosTransaction {
 export interface WrappedRegistryResponse {
   address: string;
 }
+
+export interface IBCConnection {
+  srcChannel: string;
+  destChannel: string;
+}

--- a/sdk/src/utils.ts
+++ b/sdk/src/utils.ts
@@ -66,3 +66,16 @@ export const waitFor = (
     }, ms);
   });
 };
+
+export class Lock {
+  private locked: boolean = false;
+
+  async acquire() {
+    await waitFor(() => Promise.resolve(!this.locked));
+    this.locked = true;
+  }
+
+  release() {
+    this.locked = false;
+  }
+}


### PR DESCRIPTION
The process to get the foreign address on a gateway enabled cosmos chain requires fetching the IBC connection information that connects wormchain to the destination chain. This is done by querying the gateway contract and then making another call to the node api. However, this is performed for each asset we look the foreign address for, when it could be done once and cache the result for future requests.

The changes in this PR introduces a cache as a static field con the `CosmosContext` class, as well as a flag for cases where multiple promises are triggered (e.g. [when fetching the balances for multiple tokens](https://github.com/wormhole-foundation/wormhole-connect/blob/1e0426d49b32c8c28d9e97c7506efb745418ca8a/sdk/src/contexts/cosmos/context.ts#L347)). These should help reduce the amount of calls performed to the rpcs.