### PR TITLE
Address edge case where an ibc transfer might be delivered twice

### DIFF
--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -321,11 +321,14 @@ function getIbcTransferLog(
   for (const log of logs) {
     for (const ev of log.events) {
       // find an ibc received packet event
-      if (ev.type !== 'recv_packet') continue;
+      if (ev.type !== 'write_acknowledgement') continue;
 
       // check that this packet is the one that matches the source ibc transfer
       // if not, skip this msg log entirely and proceed to the next one
-      const logIbcInfo = getIBCTransferInfoFromLogs([log], 'recv_packet');
+      const logIbcInfo = getIBCTransferInfoFromLogs(
+        [log],
+        'write_acknowledgement',
+      );
 
       if (
         logIbcInfo.sequence !== ibcTransfer.sequence ||


### PR DESCRIPTION
Sometimes a relayer might redeliver an ibc package which already has been processed. This would cause tx queries by the `recv_packet` event to yield two transaction, which was unexpected at the time of implementation. By searching for `write_acknowledgement` we ensure that only that transaction which actually processed the package is selected.