### PR TITLE
Confirm before closing tab if transaction is in progress

### DIFF
--- a/wormhole-connect/src/utils/confirmBeforeLeaving.ts
+++ b/wormhole-connect/src/utils/confirmBeforeLeaving.ts
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 
-const useConfirmBeforeLeaving = (shouldConfirm: boolean) => {
-  let unloadHandler = (e: Event) => {
-    e = e ?? window.event;
-    if (e) e.returnValue = true;
-    return true;
-  };
+const unloadHandler = (e: Event) => {
+  e = e ?? window.event;
+  if (e) e.returnValue = true;
+  return true;
+};
 
+const useConfirmBeforeLeaving = (shouldConfirm: boolean) => {
   useEffect(() => {
     let cancel = () => {
       window.removeEventListener('beforeunload', unloadHandler);

--- a/wormhole-connect/src/utils/confirmBeforeLeaving.ts
+++ b/wormhole-connect/src/utils/confirmBeforeLeaving.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+const useConfirmBeforeLeaving = (shouldConfirm: boolean) => {
+  let unloadHandler = (e: Event) => {
+    e = e ?? window.event;
+    if (e) e.returnValue = true;
+    return true;
+  };
+
+  useEffect(() => {
+    let cancel = () => {
+      window.removeEventListener('beforeunload', unloadHandler);
+    };
+
+    if (shouldConfirm) {
+      window.addEventListener('beforeunload', unloadHandler);
+      return cancel;
+    } else {
+      cancel();
+    }
+  }, [shouldConfirm]);
+};
+
+export default useConfirmBeforeLeaving;

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -24,6 +24,7 @@ import { wh, toChainId } from 'utils/sdk';
 import { joinClass } from 'utils/style';
 import { toDecimals } from 'utils/balance';
 import { isTransferValid, useValidate } from 'utils/transferValidation';
+import useConfirmBeforeLeaving from 'utils/confirmBeforeLeaving';
 import RouteOperator from 'routes/operator';
 
 import GasSlider from './NativeGasSlider';
@@ -104,6 +105,9 @@ function Bridge() {
   );
   const portico = useSelector((state: RootState) => state.porticoBridge);
   const { receiving } = useSelector((state: RootState) => state.wallet);
+
+  // Warn user before closing tab if transaction has begun
+  useConfirmBeforeLeaving(isTransactionInProgress);
 
   // check destination native balance
   useEffect(() => {

--- a/wormhole-connect/src/views/Redeem/Redeem.tsx
+++ b/wormhole-connect/src/views/Redeem/Redeem.tsx
@@ -21,6 +21,8 @@ import Stepper from './Stepper';
 import GovernorEnqueuedWarning from './GovernorEnqueuedWarning';
 import { showHamburgerMenu } from 'config';
 
+import useConfirmBeforeLeaving from 'utils/confirmBeforeLeaving';
+
 function Redeem({
   setSignedMessage,
   setIsVaaEnqueued,
@@ -40,6 +42,9 @@ function Redeem({
   route: Route | undefined;
   signedMessage: SignedMessage | undefined;
 }) {
+  // Warn user before closing tab if transaction is unredeemed
+  useConfirmBeforeLeaving(!transferComplete);
+
   // check if VAA is enqueued
   useEffect(() => {
     if (


### PR DESCRIPTION
Addresses https://github.com/wormhole-foundation/wormhole-connect/issues/1500

This maintains a `beforeunload` event handler in two scenarios:

1. in the Bridge view, if the user has started a transaction (basically when the Submit button has a "loading" spinner)
2. in the Redeem view, if the transaction isn't complete yet

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/897596/b492b959-70fb-4ea0-90ef-40705f62cc2a)

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/897596/3df5e4aa-9662-422a-96d1-0ddfd0189abc)

This will trigger when a user tries to reload the page, close a tab, or close the browser window containing the tab.