### PR TITLE
Fix isTransferComplete check for cosmos to cosmos gateway transfers

### DIFF
--- a/wormhole-connect/src/routes/cosmosGateway/types.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/types.ts
@@ -18,7 +18,7 @@ export interface IBCTransferInfo {
   timeout: string;
   srcChannel: string;
   dstChannel: string;
-  data: string;
+  data: string | null;
 }
 
 export interface IBCTransferData {

--- a/wormhole-connect/src/routes/cosmosGateway/utils/events.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/events.ts
@@ -49,6 +49,9 @@ export async function fetchRedeemedEventNonCosmosSource(
   return destTx.hash;
 }
 
+/**
+ * Find the redeem/receive funds transaction on the destination chain
+ */
 export async function fetchRedeemedEventCosmosSource(
   message: SignedTokenTransferMessage | SignedRelayTransferMessage,
 ): Promise<string | null> {
@@ -56,21 +59,51 @@ export async function fetchRedeemedEventCosmosSource(
     return (await new BridgeRoute().tryFetchRedeemTx(message)) || null;
   }
 
+  /**
+   * When sending an IBC transfer from a chain A to B, the following happens:
+   *  i. A transaction is executed on blockchain A which emmits a send_packet and an ibc_transfer event,
+   * the former contains the ibc packet information, while the later holds the denom/amount to transfer
+   *  ii. The relayer picks up the packet and delivers it to B through a transaction, which emmits 3 events:
+   * recv_packet, fungible_token_packet, and write_acknowledgement. The ACK event means that the packet was
+   * processed succesfully, which in this case means the funds arrived to the address on B
+   *  iii. The relayer then sends a transaction on A to acknowledge the packet, which emmits an
+   * acknowledge_packet event which has the same data as the original send_packet event
+   *
+   * For cosmos to cosmos transfers, the chain is A->Wormchain->B, each of these interactions follows the
+   * procedure described above. However, Wormchain acts a "packet forwarder", so instead of writing the ACK
+   * to A as soon as it receives the first transfer, it will hold that ACK until it's received the ACK of the
+   * transfer to B. This means that the tx on wormchain which receives the packet from A won't emit the ACK event;
+   * this will be done at a later transaction when the relayer has confirmed that the tx from wormchain to B has
+   * processed succesfully, emitting two events: a write_acknowledgement for the Wormchain->B transfer, followed by
+   * a write_acknowledgement for the A->Wormchain transfer. It is after this second tx on wormchain that the relayer
+   * delivers the ack back to A.
+   *
+   * So, the process to get the transaction on B which receives the funds will be the following:
+   *  i. Extract the first ibc transfer packet information from the tx on A by scanning the send_packet event
+   *  ii. Look for the write_acknowledgement transaction on wormchain
+   *  iii. From that same transaction, extract the Wormchain->B ibc packet information present in the acknowledge_packet
+   * event.
+   *  iv. Now that we have the ibc packet info for Wormchain->B, search for the write_acknowledgement on the destination chain
+   */
+
   // find tx in the source chain and extract the ibc transfer to wormchain
   const sourceClient = await getCosmWasmClient(message.fromChain);
   const tx = await sourceClient.getTx(message.sendTx);
   if (!tx) return null;
   const sourceIbcInfo = getTransactionIBCTransferInfo(tx, 'send_packet');
 
-  // find tx in the ibc receive in wormchain and extract the ibc transfer to the dest tx
+  // find the tx on wormchain that writes the acknowledgement back to source chain
   const wormchainTx = await findDestinationIBCTransferTx(
     CHAIN_ID_WORMCHAIN,
     sourceIbcInfo,
   );
   if (!wormchainTx) return null;
+
+  // extract the ibc packet info for Wormchain->dest chain from
+  // the event that receives the ACK for that transfer
   const wormchainToDestIbcInfo = getTransactionIBCTransferInfo(
     wormchainTx,
-    'send_packet',
+    'acknowledge_packet',
   );
 
   // find the tx that deposits the funds in the final recipient

--- a/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/getMessage.ts
@@ -61,6 +61,7 @@ export async function getUnsignedMessageFromCosmos(
   const ibcPacketInfo = getTransactionIBCTransferInfo(tx, 'send_packet');
 
   // extract the IBC transfer data payload from the packet
+  if (!ibcPacketInfo.data) throw new Error('Missing packet data');
   const data: IBCTransferData = JSON.parse(ibcPacketInfo.data);
   const payload: FromCosmosPayload = JSON.parse(data.memo);
 

--- a/wormhole-connect/src/routes/cosmosGateway/utils/transaction.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/utils/transaction.ts
@@ -7,17 +7,25 @@ import {
 import { getCosmWasmClient } from '../utils';
 import { IBCTransferInfo } from '../types';
 
+/**
+ * Search the ibc transfer info (sequence, timeout, src channel, dst channel, data) from an event
+ * emitted by a transaction
+ */
 export function getTransactionIBCTransferInfo(
   tx: IndexedTx,
-  event: 'send_packet' | 'write_acknowledgement',
+  event: 'send_packet' | 'write_acknowledgement' | 'acknowledge_packet',
 ): IBCTransferInfo {
   const logs = cosmosLogs.parseRawLog(tx.rawLog);
   return getIBCTransferInfoFromLogs(logs, event);
 }
 
+/**
+ * Search the ibc transfer info (sequence, timeout, src channel, dst channel, data) from an event
+ * in the transaction logs
+ */
 export function getIBCTransferInfoFromLogs(
   logs: readonly cosmosLogs.Log[],
-  event: 'send_packet' | 'write_acknowledgement',
+  event: 'send_packet' | 'write_acknowledgement' | 'acknowledge_packet',
 ): IBCTransferInfo {
   const packetSeq = searchCosmosLogs(`${event}.packet_sequence`, logs);
   const packetTimeout = searchCosmosLogs(
@@ -33,13 +41,7 @@ export function getIBCTransferInfoFromLogs(
     logs,
   );
   const packetData = searchCosmosLogs(`${event}.packet_data`, logs);
-  if (
-    !packetSeq ||
-    !packetTimeout ||
-    !packetSrcChannel ||
-    !packetDstChannel ||
-    !packetData
-  ) {
+  if (!packetSeq || !packetTimeout || !packetSrcChannel || !packetDstChannel) {
     throw new Error('Missing packet information in transaction logs');
   }
   return {


### PR DESCRIPTION
Introduced by #1490 when the destination transaction search started looking for `write_acknowledgement` events instead of `recv_packet` events. This caused an issue with cosmos to cosmos transfers due to the forwarding behaviour from wormchain for this cases. More information on the code and comments.

It should address the case Kujira->Evmos case mentioned here