### PR TITLE
#1581 - include the hashed css file

### DIFF
--- a/wormhole-connect-loader/package.json
+++ b/wormhole-connect-loader/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "lint:ci": "prettier -c ./src && eslint --max-warnings=0 ./src",
-    "build:deps": "rm -rf dist && mkdir dist && cp -r ../wormhole-connect/build/* dist/ && mv dist/main-*.css dist/main.css",
+    "build:deps": "rm -rf dist && mkdir dist && cp -r ../wormhole-connect/build/* dist/ && cp dist/main-*.css dist/main.css",
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
     "build": "npm run build:deps && rm -rf lib && npm run build:cjs && npm run build:esm && node scripts/replaceEnvWithCurrentVersion"


### PR DESCRIPTION
Include hashed css file to avoid issue with Wallet Connect since Vite loader complain on pre load phase, and dynamic import does not work for @walletconnect/modal library


https://github.com/wormhole-foundation/wormhole-connect/assets/1277510/d29bdd79-e838-425a-b037-aaa73cc416d9


