### PR TITLE
Add BSKT to wormhole connect token selection. 

### DIFF
--- a/builder/src/consts.ts
+++ b/builder/src/consts.ts
@@ -179,6 +179,7 @@ export const MAINNET_TOKEN_KEYS: string[] = [
   "EVMOS",
   "KUJI",
   "PYTH",
+  "BSKT",
   "WETHpolygon",
   "WETHbsc",
   "wstETHarbitrum",

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -2664,4 +2664,73 @@ export const MAINNET_TOKENS: TokensConfig = {
       },
     },
   },
+  BSKT: {
+    key: 'BSKT',
+    symbol: 'BSKT',
+    nativeChain: 'solana',
+    tokenId: {
+      chain: 'solana',
+      address: '6gnCPhXtLnUD76HjQuSYPENLSZdG8RvDB1pTLM5aLSJA',
+    },
+    icon: Icon.BSKT,
+    coinGeckoId: 'basket',
+    color: '#2894EE',
+    decimals: {
+      default: 5,
+    },
+    foreignAssets: {
+      ethereum: {
+        address: '0xbC0899E527007f1B8Ced694508FCb7a2b9a46F53',
+        decimals: 5,
+      },
+      bsc: {
+        address: '0xaF42A5df3C1C1427DA8FC0326bD7b030A9367e78',
+        decimals: 5,
+      },
+      polygon: {
+        address: '0x9a6a40CdF21a0AF417F1b815223FD92c85636c58',
+        decimals: 5,
+      },
+      avalanche: {
+        address: '0x6Ac048ae05E7E015accA2aA7Abd0Ec013e8E3a59',
+        decimals: 5,
+      },
+      sui: {
+        address:
+          '0xd4d52a6bf452401c0c70a1d19ff6cec2933f22a548eae552f3e514f64f61703a::coin::COIN',
+        decimals: 5,
+      },
+      aptos: {
+        address:
+          '',
+        decimals: 5,
+      },
+      arbitrum: {
+        address: '0xa3210cd727fE6DAf8386af5623ba51A367E46263',
+        decimals: 5,
+      },
+      wormchain: {
+        address:
+          '',
+        decimals: 5,
+      },
+      osmosis: {
+        address:
+          '',
+        decimals: 5,
+      },
+      fantom: {
+        address: '',
+        decimals: 5,
+      },
+      base: {
+        address: '0x7CCDbA6198db389cF37b714FD6573b73F3670236',
+        decimals: 5,
+      },
+      celo: {
+        address: '0x3fc50bc066aE2ee280876EeefADfdAbF6cA02894',
+        decimals: 5,
+      },
+    },
+  },
 };

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -37,6 +37,7 @@ export enum Icon {
   'EVMOS',
   'KUJI',
   'PYTH',
+  'BSKT',
 }
 
 export enum Route {

--- a/wormhole-connect/src/icons/TokenIcons.tsx
+++ b/wormhole-connect/src/icons/TokenIcons.tsx
@@ -32,6 +32,7 @@ import EVMOS from './Tokens/EVMOS';
 import ATOM from './Tokens/ATOM';
 import KUJI from './Tokens/KUJI';
 import PYTH from './Tokens/PYTH';
+import BSKT from './Tokens/BSKT';
 
 const useStyles = makeStyles<{ size: number }>()((theme, { size }) => ({
   container: {
@@ -130,6 +131,9 @@ export const getIcon = (icon: Icon) => {
     }
     case Icon.PYTH: {
       return PYTH;
+    }
+    case Icon.BSKT: {
+      return BSKT;
     }
     default: {
       return noIcon;

--- a/wormhole-connect/src/icons/Tokens/BSKT.tsx
+++ b/wormhole-connect/src/icons/Tokens/BSKT.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+function BSKT() {
+  return (
+    <img
+      style={{ maxHeight: '100%', maxWidth: '100%', borderRadius: '100%' }}
+      alt="BSKT"
+      src="https://gateway.irys.xyz/69o2b3_ekRo4nosnyyXc9piS7d7-8u-h7MNviNzXFYA"
+    />
+  );
+}
+
+export default BSKT;


### PR DESCRIPTION
BSKT is looking to use wormhole connect for an easy to use interface to travese cross chain. 

PR submitted for details to get added. 

PR also submitted to SDK repo to add details there also.

Please let us know if more submissions are needed.