### PR TITLE
Undo change to Vite config that shows lint warnings

### DIFF
--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -37,9 +37,7 @@ export default defineConfig({
   },
   plugins: [
     checker({
-      eslint: {
-        lintCommand: 'eslint "./src/**/*.{ts,tsx}"',
-      },
+      typescript: true,
     }),
     react(),
     nodePolyfills({


### PR DESCRIPTION
As per @yuli-ferna 