### PR TITLE
Avoid infinite loop in useEffect

### DIFF
--- a/wormhole-connect/src/views/Bridge/Preview.tsx
+++ b/wormhole-connect/src/views/Bridge/Preview.tsx
@@ -22,6 +22,8 @@ import {
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { isPorticoRoute } from 'routes/porticoBridge/utils';
 
+const defaultPrices = {};
+
 function Preview(props: { collapsed: boolean }) {
   const dispatch = useDispatch();
   const theme: any = useTheme();
@@ -43,7 +45,7 @@ function Preview(props: { collapsed: boolean }) {
   const {
     usdPrices: { data },
   } = useSelector((state: RootState) => state.tokenPrices);
-  const prices = data || {};
+  const prices = data || defaultPrices;
   useEffect(() => {
     const buildPreview = async () => {
       if (!fromChain || !route) return;


### PR DESCRIPTION
If the USD prices are not present, this code was creating a new empty object each time in `|| {}` which React was seeing unequal to the last value of `prices`, thus running the hook in an infinite loop.

> React will compare each dependency with its previous value using the [Object.is](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) comparison.

https://react.dev/reference/react/useEffect

```
Object.is({}, {})
-> false
```