### PR TITLE
Add warning for transfer larger than CCTP max transfer limit (1M) 

### DIFF
--- a/wormhole-connect/src/consts/index.ts
+++ b/wormhole-connect/src/consts/index.ts
@@ -1,2 +1,4 @@
 export const GOVERNOR_WHITEPAPER_URL =
   'https://github.com/wormhole-foundation/wormhole/blob/main/whitepapers/0007_governor.md';
+
+export const CCTP_MAX_TRANSFER_LIMIT = 1000000;

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -112,7 +112,9 @@ export const validateAmount = (
     if (numAmount > b) return 'Amount cannot exceed balance';
   }
   if (isCctp && numAmount >= CCTP_MAX_TRANSFER_LIMIT)
-    return 'Your transaction exceeds the maximum transfer limit of 1,000,000 USDC. Please use a different amount.';
+    return `Your transaction exceeds the maximum transfer limit of ${Intl.NumberFormat(
+      'en-EN',
+    ).format(CCTP_MAX_TRANSFER_LIMIT)} USDC. Please use a different amount.`;
   if (numAmount > maxAmount) {
     return `At the moment, amount cannot exceed ${maxAmount}`;
   }

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -112,7 +112,7 @@ export const validateAmount = (
     if (numAmount > b) return 'Amount cannot exceed balance';
   }
   if (isCctp && numAmount >= CCTP_MAX_TRANSFER_LIMIT)
-    return 'Burn amount exceeds per transaction limit';
+    return 'Your transaction exceeds the maximum transfer limit of 1,000,000 USDC. Please use a different amount.';
   if (numAmount > maxAmount) {
     return `At the moment, amount cannot exceed ${maxAmount}`;
   }


### PR DESCRIPTION
Issue: https://github.com/wormhole-foundation/wormhole-connect/issues/1504

I decided to keep a const value because query in [TokenMinter contracts](https://developers.circle.com/stablecoins/docs/evm-smart-contracts#tokenminter-mainnet) the result in burnLimitsPerMessage method with the USDC token is the following:

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/35125931/ac05b08d-1206-4a7d-8fa8-9c87d1425d4e)
The result with decimals is: 1,000,000.00

Result:
![image](https://github.com/wormhole-foundation/wormhole-connect/assets/35125931/81497877-160e-4001-9622-528aade08eec)

