### PR TITLE
global-tx txHash double 0x prefix fix

### DIFF
--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -12,7 +12,6 @@ import {
   isEvmChain,
   wh,
 } from './sdk';
-import { hexlify } from 'ethers/lib/utils';
 
 export type ParsedVaa = {
   bytes: string;
@@ -252,7 +251,7 @@ export const fetchGlobalTx = async (
     .then(function (response: any) {
       const data = response.data;
       if (!data || !data.destinationTx?.txHash) return undefined;
-      return hexlify(data.destinationTx.txHash);
+      return data.destinationTx.txHash;
     })
     .catch(function (error) {
       throw error;

--- a/wormhole-connect/src/utils/vaa.ts
+++ b/wormhole-connect/src/utils/vaa.ts
@@ -12,6 +12,7 @@ import {
   isEvmChain,
   wh,
 } from './sdk';
+import { hexlify } from 'ethers/lib/utils';
 
 export type ParsedVaa = {
   bytes: string;
@@ -251,7 +252,7 @@ export const fetchGlobalTx = async (
     .then(function (response: any) {
       const data = response.data;
       if (!data || !data.destinationTx?.txHash) return undefined;
-      return `0x${data.destinationTx.txHash}`;
+      return hexlify(data.destinationTx.txHash);
     })
     .catch(function (error) {
       throw error;


### PR DESCRIPTION
The txHash from the response already starts with 0x. We shouldn't be pre-fxing with 0x in the first place since this would result in an invalid solana signature for example.