### PR TITLE
fix: bridge not show after router change in SPA

### DIFF
--- a/wormhole-connect-loader/src/index.tsx
+++ b/wormhole-connect-loader/src/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { WormholeConnectConfig } from "./types";
 
 const PACKAGE_NAME = "@wormhole-foundation/wormhole-connect";
@@ -12,30 +12,41 @@ function WormholeBridge({
   config?: WormholeConnectConfig;
   versionOrTag?: string;
 }) {
+  const ref = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
-    const script = document.createElement("script");
-    script.src = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.js`;
-    script.type = "module";
-    script.async = true;
+    let connectElement = document.getElementById("wormhole-connect");
+    if (!connectElement) {
+      connectElement = document.createElement("div");
+      connectElement.id = "wormhole-connect";
+    }
+    connectElement.setAttribute("config", config ? JSON.stringify(config) : "");
+    if (ref.current) {
+      connectElement.style.display = "block";
+      ref.current.appendChild(connectElement);
+    }
+    if (!document.getElementById("wormhole-connect-script")) {
+      const script = document.createElement("script");
+      script.src = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.js`;
+      script.type = "module";
+      script.async = true;
+      script.id = "wormhole-connect-script";
+      document.body.appendChild(script);
+    }
+    if (!document.getElementById("wormhole-connect-style")) {
+      const link = document.createElement("link");
+      link.href = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.css`;
+      link.id = "wormhole-connect-style";
+      document.body.appendChild(link);
+    }
 
-    const link = document.createElement("link");
-    link.href = `https://www.unpkg.com/${PACKAGE_NAME}@${versionOrTag}/dist/main.css`;
-
-    document.body.appendChild(script);
-    document.body.appendChild(link);
     return () => {
-      script.remove();
-      link.remove();
+      connectElement!.style.display = "none";
+      document.body.appendChild(connectElement!);
     };
-  }, [versionOrTag]);
+  }, [versionOrTag, config]);
 
-  return (
-    <div
-      id="wormhole-connect"
-      //@ts-ignore
-      config={config ? JSON.stringify(config) : null}
-    ></div>
-  );
+  return <div ref={ref}></div>;
 }
 
 export * from "./theme";


### PR DESCRIPTION
Modules loaded with the script tag will only be executed once.
When the Bridge component is unmount from the page and remount, it will not be render again.