### PR TITLE
Event hooks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ jobs:
       - run: |
           IFS='@' read -a strarr <<< $(git describe --tags)
           sed  -i "s/\"version\": .*/\"version\": \"${strarr[1]}$(echo $([ ${strarr[0]} == "production" ] && echo "" || echo "-${strarr[0]}"))\",/" wormhole-connect/package.json
+          export CONNECT_VERSION="${strarr[1]}"
           npm run build:lib
           npm run build:hosted
           cp README.md wormhole-connect/

--- a/package-lock.json
+++ b/package-lock.json
@@ -36665,7 +36665,7 @@
     },
     "wormhole-connect": {
       "name": "@wormhole-foundation/wormhole-connect",
-      "version": "0.0.1-beta.0",
+      "version": "0.3.4",
       "dependencies": {
         "@certusone/wormhole-sdk": "^0.10.10",
         "@coral-xyz/anchor": "^0.29.0",

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wormhole-foundation/wormhole-connect",
-  "version": "0.0.1-beta.0",
+  "version": "0.3.4",
   "repository": "github:wormhole-foundation/wormhole-connect",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -8,6 +8,7 @@ import { clearTransfer } from './store/transferInput';
 import { usePrevious } from './utils';
 import { WormholeConnectConfig } from './config/types';
 import { setConfig } from './config';
+import config from './config';
 
 import Bridge from './views/Bridge/Bridge';
 import FAQ from './views/FAQ';
@@ -43,7 +44,7 @@ interface Props {
 }
 
 // since this will be embedded, we'll have to use pseudo routes instead of relying on the url
-function AppRouter({ config }: Props) {
+function AppRouter(props: Props) {
   const { classes } = useStyles();
   const dispatch = useDispatch();
 
@@ -53,10 +54,14 @@ function AppRouter({ config }: Props) {
   // We don't allow config changes afterwards because they could lead to lots of
   // broken and undesired behavior.
   React.useEffect(() => {
-    if (config) {
-      setConfig(config);
+    if (props.config) {
+      setConfig(props.config);
       dispatch(clearTransfer());
     }
+
+    config.triggerEvent({
+      type: 'load',
+    });
   }, []);
 
   const showWalletModal = useSelector(
@@ -77,7 +82,7 @@ function AppRouter({ config }: Props) {
       internalConfig.wh.registerProviders(); // reset providers that may have been set during transfer
     }
     // reset transfer state on leave
-    if (prevRoute === bridgeRoute && route !== bridgeRoute) {
+    if (route === bridgeRoute && prevRoute !== bridgeRoute) {
       dispatch(clearTransfer());
       dispatch(clearPorticoBridge());
     }

--- a/wormhole-connect/src/config/constants.ts
+++ b/wormhole-connect/src/config/constants.ts
@@ -2,3 +2,6 @@ export const WORMSCAN = 'https://wormholescan.io/#/';
 
 export const AVAILABLE_MARKETS_URL =
   'https://portalbridge.com/docs/faqs/liquid-markets/';
+
+export const CONNECT_VERSION =
+  import.meta.env.REACT_APP_CONNECT_VERSION || 'unknown';

--- a/wormhole-connect/src/config/events.ts
+++ b/wormhole-connect/src/config/events.ts
@@ -1,0 +1,23 @@
+import { CONNECT_VERSION } from './constants';
+import {
+  WormholeConnectEvent,
+  WormholeConnectEventHandler,
+  WormholeConnectEventWithMeta,
+} from 'telemetry/types';
+
+export function wrapEventHandler(
+  integrationHandler?: WormholeConnectEventHandler,
+): WormholeConnectEventHandler {
+  return function (event: WormholeConnectEvent) {
+    const eventWithMeta: WormholeConnectEventWithMeta = {
+      meta: {
+        version: CONNECT_VERSION,
+        host: window?.location?.host,
+      },
+      ...event,
+    };
+
+    console.info('Wormhole Connect event:', eventWithMeta);
+    if (integrationHandler) integrationHandler(eventWithMeta);
+  };
+}

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -16,6 +16,7 @@ import {
   mergeNttGroups,
   validateDefaults,
 } from './utils';
+import { wrapEventHandler } from './events';
 
 export function buildConfig(
   customConfig?: WormholeConnectConfig,
@@ -92,6 +93,9 @@ export function buildConfig(
       devnet: ['http://localhost:7071'],
     }[network],
     coinGeckoApiKey: customConfig?.coinGeckoApiKey,
+
+    // Callbacks
+    triggerEvent: wrapEventHandler(customConfig?.eventHandler),
 
     // White lists
     chains: networkData.chains,

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -10,6 +10,7 @@ import {
 } from '@wormhole-foundation/wormhole-connect-sdk';
 import { Alignment } from 'components/Header';
 import { WormholeConnectPartialTheme } from 'theme';
+import { WormholeConnectEventHandler } from 'telemetry/types';
 
 export enum Icon {
   'AVAX' = 1,
@@ -98,6 +99,9 @@ export interface WormholeConnectConfig {
   customTheme?: WormholeConnectPartialTheme;
   mode?: 'dark' | 'light';
 
+  // Callbacks
+  eventHandler?: WormholeConnectEventHandler;
+
   // UI details
   cta?: {
     text: string;
@@ -153,6 +157,9 @@ export interface InternalConfig {
   tokensArr: TokenConfig[];
   gasEstimates: GasEstimates;
   routes: string[];
+
+  // Callbacks
+  triggerEvent: WormholeConnectEventHandler;
 
   // UI details
   cta?: {

--- a/wormhole-connect/src/main.tsx
+++ b/wormhole-connect/src/main.tsx
@@ -4,6 +4,7 @@ import WormholeConnect from './WormholeConnect';
 import ErrorBoundary from './components/ErrorBoundary';
 import { WormholeConnectConfig } from 'config/types';
 import { WormholeConnectPartialTheme } from './theme';
+import { WormholeConnectEvent } from 'telemetry/types';
 export * from './theme';
 
 // This is the entry point that runs when integrators add the Connect widget
@@ -25,7 +26,13 @@ if (!container) {
   );
 }
 
-let config: WormholeConnectConfig | undefined = undefined;
+let config: WormholeConnectConfig = {
+  eventHandler: (event: WormholeConnectEvent) => {
+    container.dispatchEvent(
+      new CustomEvent('wormholeConnectEvent', { detail: event }),
+    );
+  },
+};
 let theme: WormholeConnectPartialTheme | undefined = undefined;
 
 try {

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -299,10 +299,7 @@ export const transferInputSlice = createSlice({
         // @ts-ignore
         state.validations[key] = validations[key];
       });
-      // this one-time sets the errors to show, only after the form has been filled out (see `validate`)
-      if (!state.showValidationState && showValidationState) {
-        state.showValidationState = showValidationState;
-      }
+      state.showValidationState = showValidationState;
     },
     setRoutes: (
       state: TransferInputState,

--- a/wormhole-connect/src/telemetry/index.ts
+++ b/wormhole-connect/src/telemetry/index.ts
@@ -1,0 +1,13 @@
+import config from 'config';
+
+import { TokenDetails } from './types';
+
+export function getTokenDetails(token: string): TokenDetails {
+  const tokenConfig = config.tokens[token]!;
+  const { symbol, tokenId } = tokenConfig;
+
+  return {
+    symbol,
+    tokenId: tokenId ?? 'native',
+  };
+}

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -68,6 +68,7 @@ export type TransferErrorType =
   | typeof ERR_SOURCE_CONTRACT_PAUSED
   | typeof ERR_DESTINATION_CONTRACT_PAUSED
   | typeof ERR_UNSUPPORTED_ABI_VERSION
+  | typeof ERR_INSUFFICIENT_GAS
   | typeof ERR_USER_REJECTED
   | typeof ERR_TIMEOUT
   | typeof ERR_UNKNOWN;

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -1,0 +1,100 @@
+import { ChainId, ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import { Route } from 'config/types';
+import { TransferWallet } from 'utils/wallet';
+
+export interface LoadEvent {
+  type: 'load';
+}
+
+export interface TransferDetails {
+  route: Route;
+  fromToken: TokenDetails;
+  toToken: TokenDetails;
+  fromChain: ChainName | ChainId;
+  toChain: ChainName | ChainId;
+}
+
+export type TransferEventType =
+  | 'transfer.initiate'
+  | 'transfer.start'
+  | 'transfer.success'
+  | 'transfer.redeem.initiate'
+  | 'transfer.redeem.start'
+  | 'transfer.redeem.success';
+
+export interface TransferEvent {
+  type: TransferEventType;
+  details: TransferDetails;
+}
+
+export interface TransferErrorEvent {
+  type: 'transfer.error';
+  details: TransferDetails;
+  error: TransferError;
+}
+
+export interface TransferError {
+  type: TransferErrorType;
+  original: any;
+}
+
+export interface TokenDetails {
+  symbol: string;
+  tokenId:
+    | {
+        address: string;
+        chain: string;
+      }
+    | 'native';
+}
+
+export const ERR_INSUFFICIENT_ALLOWANCE = 'insufficient_allowance';
+export const ERR_SWAP_FAILED = 'swap_failed';
+// NTT errors
+export const ERR_NOT_ENOUGH_CAPACITY = 'swap_failed';
+export const ERR_SOURCE_CONTRACT_PAUSED = 'source_contract_paused';
+export const ERR_DESTINATION_CONTRACT_PAUSED = 'destination_contract_paused';
+export const ERR_UNSUPPORTED_ABI_VERSION = 'unsupported_abi_version';
+export const ERR_INSUFFICIENT_GAS = 'insufficient_gas';
+
+export const ERR_USER_REJECTED = 'user_rejected';
+export const ERR_TIMEOUT = 'user_timeout';
+export const ERR_UNKNOWN = 'unknown';
+
+export type TransferErrorType =
+  | typeof ERR_INSUFFICIENT_ALLOWANCE
+  | typeof ERR_SWAP_FAILED
+  | typeof ERR_NOT_ENOUGH_CAPACITY
+  | typeof ERR_SOURCE_CONTRACT_PAUSED
+  | typeof ERR_DESTINATION_CONTRACT_PAUSED
+  | typeof ERR_UNSUPPORTED_ABI_VERSION
+  | typeof ERR_USER_REJECTED
+  | typeof ERR_TIMEOUT
+  | typeof ERR_UNKNOWN;
+
+export interface ConnectWalletEvent {
+  type: 'wallet.connect';
+  details: {
+    side: TransferWallet;
+    chain: ChainName;
+    wallet: string;
+  };
+}
+
+export type WormholeConnectEvent =
+  | LoadEvent
+  | TransferEvent
+  | TransferErrorEvent
+  | ConnectWalletEvent;
+
+export interface WormholeConnectEventMeta {
+  meta: {
+    version: string;
+    host: string;
+  };
+}
+
+export type WormholeConnectEventWithMeta = WormholeConnectEvent &
+  WormholeConnectEventMeta;
+
+export type WormholeConnectEventHandler = (type: WormholeConnectEvent) => void;

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -12,7 +12,10 @@ import {
   ERR_UNKNOWN,
   ERR_USER_REJECTED,
 } from 'telemetry/types';
-import { INSUFFICIENT_ALLOWANCE } from '@wormhole-foundation/wormhole-connect-sdk';
+import {
+  INSUFFICIENT_ALLOWANCE,
+  InsufficientFundsForGasError,
+} from '@wormhole-foundation/wormhole-connect-sdk';
 import {
   DestinationContractIsPausedError,
   NotEnoughCapacityError,

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -1,0 +1,68 @@
+import config from 'config';
+import type { TransferErrorType, TransferError } from 'telemetry/types';
+import {
+  ERR_INSUFFICIENT_ALLOWANCE,
+  ERR_SWAP_FAILED,
+  ERR_NOT_ENOUGH_CAPACITY,
+  ERR_SOURCE_CONTRACT_PAUSED,
+  ERR_DESTINATION_CONTRACT_PAUSED,
+  ERR_UNSUPPORTED_ABI_VERSION,
+  ERR_INSUFFICIENT_GAS,
+  ERR_TIMEOUT,
+  ERR_UNKNOWN,
+  ERR_USER_REJECTED,
+} from 'telemetry/types';
+import { INSUFFICIENT_ALLOWANCE } from '@wormhole-foundation/wormhole-connect-sdk';
+import {
+  DestinationContractIsPausedError,
+  NotEnoughCapacityError,
+  ContractIsPausedError,
+  UnsupportedContractAbiVersion,
+} from 'routes/ntt/errors';
+import { SWAP_ERROR } from 'routes/porticoBridge/consts';
+import { TransferInputState } from 'store/transferInput';
+
+export function interpretTransferError(
+  e: any,
+  transferInput: TransferInputState,
+): [string, TransferError] {
+  // Fall-back values
+  let uiErrorMessage = 'Error with transfer, please try again';
+  let internalErrorCode: TransferErrorType = ERR_UNKNOWN;
+
+  if (e.message) {
+    if (e.message === INSUFFICIENT_ALLOWANCE) {
+      uiErrorMessage = 'Error with transfer, please try again';
+      internalErrorCode = ERR_INSUFFICIENT_ALLOWANCE;
+    } else if (e.name === 'TransactionExpiredTimeoutError') {
+      // Solana timeout
+      uiErrorMessage = 'Transfer timed out, please try again';
+      internalErrorCode = ERR_TIMEOUT;
+    } else if (e?.message === NotEnoughCapacityError.MESSAGE) {
+      uiErrorMessage = `This transfer would be rate-limited due to high volume on ${
+        config.chains[transferInput.fromChain!]?.displayName
+      }, please try again later`;
+      internalErrorCode = ERR_NOT_ENOUGH_CAPACITY;
+    } else if (e?.message === ContractIsPausedError.MESSAGE) {
+      uiErrorMessage = e.message;
+      internalErrorCode = ERR_SOURCE_CONTRACT_PAUSED;
+    } else if (e?.message === DestinationContractIsPausedError.MESSAGE) {
+      uiErrorMessage = e.message;
+      internalErrorCode = ERR_DESTINATION_CONTRACT_PAUSED;
+    } else if (e?.message === UnsupportedContractAbiVersion.MESSAGE) {
+      uiErrorMessage = 'Unsupported contract ABI version';
+      internalErrorCode = ERR_UNSUPPORTED_ABI_VERSION;
+    } else if (e?.message === InsufficientFundsForGasError.MESSAGE) {
+      uiErrorMessage = e.message;
+      internalErrorCode = ERR_INSUFFICIENT_GAS;
+    } else if (e.message.includes('rejected the request')) {
+      uiErrorMessage = 'Transfer rejected in wallet, please try again';
+      internalErrorCode = ERR_USER_REJECTED;
+    } else if (e.message === SWAP_ERROR) {
+      uiErrorMessage = SWAP_ERROR;
+      internalErrorCode = ERR_SWAP_FAILED;
+    }
+  }
+
+  return [uiErrorMessage, { type: internalErrorCode, original: e }];
+}

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -346,6 +346,7 @@ export const validate = async (
     portico: PorticoBridgeState;
   },
   dispatch: Dispatch<AnyAction>,
+  isCanceled: () => boolean,
 ) => {
   const validations = await validateAll(transferInput, relay, wallet, portico);
 
@@ -362,7 +363,10 @@ export const validate = async (
     transferInput.routeStates?.some((rs) => rs.supported) !== undefined
       ? true
       : false;
-  dispatch(setValidations({ validations, showValidationState }));
+
+  if (!isCanceled()) {
+    dispatch(setValidations({ validations, showValidationState }));
+  }
 };
 
 const VALIDATION_DELAY_MS = 250;
@@ -382,7 +386,11 @@ export const useValidate = () => {
     VALIDATION_DELAY_MS,
   );
   useEffect(() => {
-    validate(debouncedStateForValidation, dispatch);
+    let canceled = false;
+    validate(debouncedStateForValidation, dispatch, () => canceled);
+    return () => {
+      canceled = true;
+    };
   }, [debouncedStateForValidation, dispatch]);
 };
 

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -70,6 +70,16 @@ export const connectWallet = async (
 
   const { chainId, context } = chainConfig;
   await wallet.connect({ chainId });
+
+  config.triggerEvent({
+    type: 'wallet.connect',
+    details: {
+      side: type,
+      chain: chain,
+      wallet: walletInfo.name.toLowerCase(),
+    },
+  });
+
   const address = wallet.getAddress()!;
   const payload = {
     address,

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -158,6 +158,8 @@ function Bridge() {
   }, [route, fromChain, destToken, dispatch]);
 
   useEffect(() => {
+    let canceled = false;
+
     const computeDestTokens = async () => {
       let supported = await RouteOperator.allSupportedDestTokens(
         config.tokens[token],
@@ -180,7 +182,9 @@ function Bridge() {
       );
       dispatch(setAllSupportedDestTokens(allSupported));
       if (toChain && supported.length === 1) {
-        dispatch(setDestToken(supported[0].key));
+        if (!canceled) {
+          dispatch(setDestToken(supported[0].key));
+        }
       }
 
       // If all the supported tokens are the same token
@@ -197,7 +201,7 @@ function Bridge() {
             t.nativeChain === t.tokenId?.chain &&
             t.nativeChain === toChain,
         )?.key;
-        if (key) {
+        if (!canceled && key) {
           dispatch(setDestToken(key));
         }
       }
@@ -221,13 +225,16 @@ function Bridge() {
             const wrapped = getWrappedToken(config.tokens[token]);
             key = getNativeVersionOfToken(wrapped.symbol, toChain);
           }
-          if (key && isSupportedToken(key, supported)) {
+          if (!canceled && key && isSupportedToken(key, supported)) {
             dispatch(setDestToken(key));
           }
         }
       }
     };
     computeDestTokens();
+    return () => {
+      canceled = true;
+    };
     // IMPORTANT: do not include destToken in dependency array
   }, [route, token, fromChain, toChain, dispatch]);
 

--- a/wormhole-connect/src/views/Redeem/Redeem.tsx
+++ b/wormhole-connect/src/views/Redeem/Redeem.tsx
@@ -28,6 +28,9 @@ import useCheckInboundQueuedTransfer from 'hooks/useCheckInboundQueuedTransfer';
 import useConfirmBeforeLeaving from 'utils/confirmBeforeLeaving';
 import { INVALID_VAA_MESSAGE } from 'utils/repairVaa';
 
+import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import { getTokenDetails } from 'telemetry';
+
 function Redeem({
   setSignedMessage,
   setIsVaaEnqueued,
@@ -38,6 +41,10 @@ function Redeem({
   isVaaEnqueued,
   route,
   signedMessage,
+  fromChain,
+  toChain,
+  token,
+  destToken,
 }: {
   setSignedMessage: (signed: SignedMessage) => any;
   setIsVaaEnqueued: (isVaaEnqueued: boolean) => any;
@@ -48,6 +55,10 @@ function Redeem({
   isVaaEnqueued: boolean;
   route: Route | undefined;
   signedMessage: SignedMessage | undefined;
+  fromChain: ChainName;
+  toChain: ChainName;
+  token: string;
+  destToken: string;
 }) {
   // Warn user before closing tab if transaction is unredeemed
   useConfirmBeforeLeaving(!transferComplete);
@@ -142,6 +153,17 @@ function Redeem({
         }
         if (isComplete) {
           setTransferComplete();
+
+          config.triggerEvent({
+            type: 'transfer.success',
+            details: {
+              route,
+              fromToken: getTokenDetails(token),
+              toToken: getTokenDetails(destToken),
+              fromChain,
+              toChain,
+            },
+          });
         } else {
           await sleep(i < 10 ? 3000 : 30000);
         }
@@ -196,6 +218,8 @@ function mapStateToProps(state: RootState) {
     signedMessage,
   } = state.redeem;
 
+  const { fromChain, toChain, token, destToken } = state.transferInput;
+
   return {
     txData,
     transferComplete,
@@ -203,6 +227,10 @@ function mapStateToProps(state: RootState) {
     isInvalidVaa,
     route,
     signedMessage,
+    fromChain: fromChain!,
+    toChain: toChain!,
+    token,
+    destToken,
   };
 }
 

--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -5,6 +5,11 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import dts from 'vite-plugin-dts';
 import path from 'path';
 
+const packagePath = __dirname.endsWith('wormhole-connect')
+  ? './package.json'
+  : './wormhole-connect/package.json';
+const { version } = require(packagePath);
+
 // There are three configs this file can return.
 // 1. local dev server
 // 2. production build, for direct import
@@ -13,11 +18,19 @@ import path from 'path';
 // TODO: consider using the "VITE_APP_" prefix which is the default for Vite
 const envPrefix = 'REACT_APP_';
 
+const define = {
+  'import.meta.env.REACT_APP_CONNECT_VERSION':
+    process.env.CONNECT_VERSION ?? JSON.stringify(version),
+};
+
 const resolve = {
   alias: {
     utils: path.resolve(__dirname, './src/utils'),
     config: path.resolve(__dirname, './src/config'),
     components: path.resolve(__dirname, './src/components'),
+    // This was originally called "events" and that breaks some NPM dependency
+    // so do not rename it "events":
+    telemetry: path.resolve(__dirname, './src/telemetry'),
     store: path.resolve(__dirname, './src/store'),
     routes: path.resolve(__dirname, './src/routes'),
     icons: path.resolve(__dirname, './src/icons'),
@@ -82,6 +95,7 @@ export default defineConfig(({ command, mode }) => {
   if (command === 'serve' || (command === 'build' && isNetlify)) {
     // Local development
     return {
+      define,
       envPrefix,
       resolve,
       build: {
@@ -112,6 +126,7 @@ export default defineConfig(({ command, mode }) => {
 
     if (isHosted) {
       return {
+        define,
         envPrefix,
         resolve,
         build: {
@@ -131,6 +146,7 @@ export default defineConfig(({ command, mode }) => {
       };
     } else {
       return {
+        define,
         envPrefix,
         resolve,
         build: {


### PR DESCRIPTION
WIP

Addresses #1738 

Adds a way for integrators to react to the following events:

- [x] `transfer.initiate`: when the user first clicks the "Approve and begin transaction" button
- [x] `transfer.start`: when the user approves the transaction in their wallet and it attempts to send it to the chain
- [x] `transfer.error`: when the transaction fails for some reason (includes an error code explaining the reason)
- [x] `transfer.redeem.initiate`, `transfer.redeem.start`, `transfer.redeem.error`: same things for the second tx
- [x] `transfer.success`: when the transfer is shown as successful to the user (either 1 or 2tx)
- [x] `wallet.connect`

Each event includes simple, anonymous metadata:
- route being used
- source chain
- destination chain
- token

React users can provide a simple callback in `config`:

```ts
const config: WormholeConnectConfig = {
  eventHandler: (e: WormholeConnectEvent) => {
    console.log(e);
  }
};
```

Users of the hosted version can listen for events on the `#wormhole-connect` DOM element:

```ts
const root = document.getElementById('#wormhole-connect');
root.addEventListener('wormholeConnectEvent', (e) => {
  console.log(e);
});
```