### PR TITLE
Fix injective resume transaction

### DIFF
--- a/sdk/src/config/MAINNET.ts
+++ b/sdk/src/config/MAINNET.ts
@@ -358,7 +358,7 @@ const MAINNET_CONFIG: WormholeConfig = {
     cosmoshub: 'https://cosmos-rpc.polkachu.com',
     evmos: 'https://evmos-rpc.polkachu.com',
     kujira: 'https://kujira-rpc.polkachu.com',
-    injective: 'https://injective-rpc.polkachu.com',
+    injective: 'https://injective-rpc.publicnode.com/', // TODO: use the library to get the correct rpc https://docs.ts.injective.network/querying/querying-api/querying-indexer-explorer#fetch-transaction-using-transaction-hash
     klaytn: 'https://rpc.ankr.com/klaytn',
   },
   rest: {


### PR DESCRIPTION
Issue: https://github.com/XLabs/portal-bridge-ui/issues/795

Polkachu's rpc is not bringing the info of many injective transactions, the desired solution would be to use the injective labs library and do the following https://docs.ts.injective.network/querying/querying-api/querying-indexer-explorer#fetch-transaction-using-transaction-hash. But because the package `@certusone/wormhole-sdk` has old versions of these libraries, it generates conflict, so for now I have here the additional solution which is to use a different rpc (https://injective-rpc.publicnode.com/) while we can solve the problem.

![image](https://github.com/wormhole-foundation/wormhole-connect/assets/35125931/dd6b9108-399a-4b36-971b-1992c3643666)
