### PR TITLE
solana relayer: Added WSOL min send amount

### DIFF
--- a/wormhole-connect/src/routes/abstracts/routeAbstract.ts
+++ b/wormhole-connect/src/routes/abstracts/routeAbstract.ts
@@ -129,7 +129,11 @@ export abstract class RouteAbstract {
   /**
    * These operations have to be implemented in subclasses.
    */
-  public abstract getMinSendAmount(routeOptions: any): number;
+  public abstract getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number;
   public abstract getMaxSendAmount(): number;
 
   public abstract send(

--- a/wormhole-connect/src/routes/bridge/baseRoute.ts
+++ b/wormhole-connect/src/routes/bridge/baseRoute.ts
@@ -1,4 +1,8 @@
-import { ChainId, ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import {
+  ChainId,
+  ChainName,
+  TokenId,
+} from '@wormhole-foundation/wormhole-connect-sdk';
 import { TokenConfig } from 'config/types';
 import {
   MAX_DECIMALS,
@@ -298,7 +302,11 @@ export abstract class BaseRoute extends RouteAbstract {
     return Infinity;
   }
 
-  getMinSendAmount(routeOptions: any): number {
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
     return 0;
   }
 }

--- a/wormhole-connect/src/routes/bridge/bridge.ts
+++ b/wormhole-connect/src/routes/bridge/bridge.ts
@@ -151,6 +151,13 @@ export class BridgeRoute extends BaseRoute {
   /**
    * These operations have to be implemented in subclasses.
    */
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
+    return 0;
+  }
 
   async send(
     token: TokenId | 'native',

--- a/wormhole-connect/src/routes/cctpManual/cctpManual.ts
+++ b/wormhole-connect/src/routes/cctpManual/cctpManual.ts
@@ -237,6 +237,13 @@ export class CCTPManualRoute extends BaseRoute {
   /**
    * These operations have to be implemented in subclasses.
    */
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
+    return 0;
+  }
 
   async send(
     token: TokenId | 'native',

--- a/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
+++ b/wormhole-connect/src/routes/cctpRelay/cctpRelay.ts
@@ -205,6 +205,8 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
     sourceChain: ChainName | ChainId,
     destChain: ChainName | ChainId,
   ): Promise<boolean> {
+    const tokenConfig = config.tokens[sourceToken]!;
+    const tokenId = getWrappedTokenId(tokenConfig);
     let relayerFee;
     try {
       const result = await this.getRelayerFee(
@@ -220,7 +222,7 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
     return !(
       relayerFee === undefined ||
       parseFloat(amount) <
-        this.getMinSendAmount({
+        this.getMinSendAmount(tokenId, destChain, {
           relayerFee: toDecimals(relayerFee, 6),
           toNativeToken: 0,
         })
@@ -305,7 +307,11 @@ export class CCTPRelayRoute extends CCTPManualRoute implements RelayAbstract {
   /**
    * These operations have to be implemented in subclasses.
    */
-  getMinSendAmount(routeOptions: any): number {
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
     const { relayerFee, toNativeToken } = routeOptions;
     // has to be slightly higher than the minimum or else tx will revert
     const fees = parseFloat(relayerFee) + parseFloat(toNativeToken);

--- a/wormhole-connect/src/routes/cosmosGateway/cosmosGateway.ts
+++ b/wormhole-connect/src/routes/cosmosGateway/cosmosGateway.ts
@@ -148,6 +148,14 @@ export class CosmosGatewayRoute extends BaseRoute {
     return config.wh.getForeignAsset(token, chain);
   }
 
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
+    return 0;
+  }
+
   async send(
     token: TokenId | 'native',
     amount: string,

--- a/wormhole-connect/src/routes/hashflow/hashflow.ts
+++ b/wormhole-connect/src/routes/hashflow/hashflow.ts
@@ -107,7 +107,11 @@ export class HashflowRoute extends RouteAbstract {
   ): Promise<BigNumber> {
     throw new Error('Method not implemented.');
   }
-  getMinSendAmount(routeOptions: any): number {
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
     return 0;
   }
   getMaxSendAmount(): number {

--- a/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
@@ -368,6 +368,14 @@ export abstract class PorticoBridge extends BaseRoute {
     return BigNumber.from(0);
   }
 
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: PorticoBridgeState,
+  ): number {
+    return 0;
+  }
+
   getMaxSendAmount(): number {
     return this.maxAmount;
   }

--- a/wormhole-connect/src/routes/tbtc/tbtc.ts
+++ b/wormhole-connect/src/routes/tbtc/tbtc.ts
@@ -163,6 +163,14 @@ export class TBTCRoute extends BaseRoute {
     throw new Error('not implemented');
   }
 
+  getMinSendAmount(
+    token: TokenId | 'native',
+    recipientChain: ChainName | ChainId,
+    routeOptions: any,
+  ): number {
+    return 0;
+  }
+
   async send(
     token: TokenId | 'native',
     amount: string,

--- a/wormhole-connect/src/utils/gas.ts
+++ b/wormhole-connect/src/utils/gas.ts
@@ -11,20 +11,6 @@ import { GasEstimateOptions, Route } from 'config/types';
 import RouteOperator from '../routes/operator';
 import { SignedMessage, formatGasFee } from '../routes';
 
-export const simulateRelayAmount = (
-  route: Route,
-  amount: number,
-  relayerFee: number,
-  toNativeToken: number,
-  tokenDecimals: number,
-): BigNumber => {
-  const r = RouteOperator.getRoute(route);
-  const min = r.getMinSendAmount({ relayerFee, toNativeToken });
-  if (min === 0) return BigNumber.from(0);
-  const amountOrMin = Math.max(amount, min);
-  return utils.parseUnits(`${amountOrMin}`, tokenDecimals);
-};
-
 export const getGasFallback = (
   chain: ChainName | ChainId,
   route: Route,

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -219,15 +219,6 @@ export const validateReceiveAmount = (
   return '';
 };
 
-export const getMinAmt = (
-  route: Route | undefined,
-  routeOptions: any,
-): number => {
-  if (!route) return 0;
-  const r = RouteOperator.getRoute(route);
-  return r.getMinSendAmount(routeOptions);
-};
-
 export const getMaxAmt = (route: Route | undefined): number => {
   if (!route) return Infinity;
   const r = RouteOperator.getRoute(route);

--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -9,7 +9,12 @@ import { useDebounce } from 'use-debounce';
 import config from 'config';
 import { TokenConfig, Route } from 'config/types';
 import { RoutesConfig } from 'config/routes';
-import { getTokenDecimals, getDisplayName, calculateUSDPrice } from 'utils';
+import {
+  getTokenDecimals,
+  getDisplayName,
+  calculateUSDPrice,
+  getWrappedTokenId,
+} from 'utils';
 import { getConversion, toDecimals, toFixedDecimals } from 'utils/balance';
 import RouteOperator from 'routes/operator';
 import { RootState } from 'store';
@@ -135,7 +140,9 @@ function GasSlider(props: { disabled: boolean }) {
       amountNum === 0 ||
       !maxSwapAmt ||
       !route ||
-      !RouteOperator.getRoute(route).NATIVE_GAS_DROPOFF_SUPPORTED
+      !RouteOperator.getRoute(route).NATIVE_GAS_DROPOFF_SUPPORTED ||
+      !toChain ||
+      !sendingToken
     )
       return;
 
@@ -157,7 +164,7 @@ function GasSlider(props: { disabled: boolean }) {
       // actualMaxSwap (i.e. bringing it from 0.1 to 0.045)
       const theoreticalMinSendAmount = RouteOperator.getRoute(
         route,
-      ).getMinSendAmount({
+      ).getMinSendAmount(getWrappedTokenId(sendingToken), toChain, {
         toNativeToken: actualMaxSwap,
         relayerFee,
       });
@@ -181,7 +188,16 @@ function GasSlider(props: { disabled: boolean }) {
       ),
       max: formatAmount(actualMaxSwap),
     }));
-  }, [relayerFee, maxSwapAmt, amountNum, route, state.swapAmt, data, token]);
+  }, [
+    relayerFee,
+    maxSwapAmt,
+    amountNum,
+    route,
+    state.swapAmt,
+    data,
+    token,
+    toChain,
+  ]);
 
   useEffect(() => {
     if (


### PR DESCRIPTION
An attempt to relay WSOL less than the minimum rent exempt amount to a new account on Solana will result in a transaction failure. This PR sets the minimum transfer amount of WSOL to the min rent exempt amount when relaying to Solana. The amount is small enough that I don't think it justifies an extra network call / complexity to check if the account already exists / has a balance.