### PR TITLE
remove warning which is no longer true

### DIFF
--- a/builder/src/App.tsx
+++ b/builder/src/App.tsx
@@ -910,9 +910,6 @@ function App() {
                     label="Mainnet"
                   />
                 </RadioGroup>
-                <Alert severity="info">
-                  Note: The preview always displays Testnet.
-                </Alert>
                 <Divider sx={{ mt: 2 }} />
                 <Typography variant="h5" component="h2" mt={4} mb={1}>
                   RPCs


### PR DESCRIPTION
forgot to remove this before :-) 

no longer true bc Builder can show a mainnet preview now (non-functional)

<img width="557" alt="image" src="https://github.com/wormhole-foundation/wormhole-connect/assets/897596/cb6b650f-680c-48c0-b61f-9c61c84c29f7">
