### PR TITLE
Automatically connect to previously used wallet for a given chain context

### DIFF
--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -13,11 +13,17 @@ import {
   Wallet,
   WalletState,
 } from '@xlabs-libs/wallet-aggregator-core';
+import {
+  connectReceivingWallet,
+  connectWallet as connectSourceWallet,
+  clearWallet,
+} from 'store/wallet';
 
 import config from 'config';
 import { getChainByChainId } from 'utils';
 
 import { AssetInfo } from './evm';
+import { Dispatch } from 'redux';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -42,6 +48,78 @@ export const walletAcceptedChains = (
 
 export const setWalletConnection = (type: TransferWallet, wallet: Wallet) => {
   walletConnection[type] = wallet;
+};
+
+export const connectWallet = async (
+  type: TransferWallet,
+  chain: ChainName,
+  walletInfo: WalletData,
+  dispatch: Dispatch<any>,
+) => {
+  const { wallet, name } = walletInfo;
+
+  setWalletConnection(type, wallet);
+
+  const chainConfig = config.chains[chain]!;
+  if (!chainConfig) {
+    throw new Error('');
+  }
+
+  const { chainId, context } = chainConfig;
+  await wallet.connect({ chainId });
+  const address = wallet.getAddress()!;
+  const payload = {
+    address,
+    type: walletInfo.type,
+    icon: wallet.getIcon(),
+    name: wallet.getName(),
+  };
+
+  if (type === TransferWallet.SENDING) {
+    dispatch(connectSourceWallet(payload));
+  } else {
+    dispatch(connectReceivingWallet(payload));
+  }
+
+  // clear wallet when the user manually disconnects from outside the app
+  wallet.on('disconnect', () => {
+    wallet.removeAllListeners();
+    dispatch(clearWallet(type));
+  });
+
+  // when the user has multiple wallets connected and either changes
+  // or disconnects the current wallet, clear the wallet
+  wallet.on('accountsChanged', (accs: string[]) => {
+    // disconnect only if there are no accounts, or if the new account is different from the current
+    const shouldDisconnect =
+      accs.length === 0 || (accs.length && address && accs[0] !== address);
+
+    if (shouldDisconnect) {
+      wallet.disconnect();
+    }
+  });
+
+  localStorage.setItem(`wormhole-connect:wallet:${context}`, name);
+};
+
+// Checks localStorage for previously used wallet for this chain
+// and connects to it automatically if it exists.
+export const connectLastUsedWallet = async (
+  type: TransferWallet,
+  chain: ChainName,
+  dispatch: Dispatch<any>,
+) => {
+  const chainConfig = config.chains[chain!]!;
+  const lastUsedWallet = localStorage.getItem(
+    `wormhole-connect:wallet:${chainConfig.context}`,
+  );
+  if (lastUsedWallet) {
+    const options = await getWalletOptions(chainConfig);
+    const wallet = options.find((w) => w.name === lastUsedWallet);
+    if (wallet) {
+      await connectWallet(type, chain, wallet, dispatch);
+    }
+  }
 };
 
 export const getWalletConnection = (type: TransferWallet) => {

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -22,8 +22,11 @@ import {
 import config from 'config';
 import { getChainByChainId } from 'utils';
 
+import { RootState } from 'store';
 import { AssetInfo } from './evm';
 import { Dispatch } from 'redux';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -120,6 +123,20 @@ export const connectLastUsedWallet = async (
       await connectWallet(type, chain, wallet, dispatch);
     }
   }
+};
+
+export const useConnectToLastUsedWallet = (): void => {
+  const dispatch = useDispatch();
+  const { toChain, fromChain } = useSelector(
+    (state: RootState) => state.transferInput,
+  );
+
+  useEffect(() => {
+    if (fromChain)
+      connectLastUsedWallet(TransferWallet.SENDING, fromChain, dispatch);
+    if (toChain)
+      connectLastUsedWallet(TransferWallet.RECEIVING, toChain, dispatch);
+  }, [fromChain, toChain]);
 };
 
 export const getWalletConnection = (type: TransferWallet) => {

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -63,9 +63,9 @@ export const connectWallet = async (
 
   setWalletConnection(type, wallet);
 
-  const chainConfig = config.chains[chain]!;
+  const chainConfig = config.chains[chain];
   if (!chainConfig) {
-    throw new Error('');
+    throw new Error(`Unable to find wallets for chain ${chain}`);
   }
 
   const { chainId, context } = chainConfig;

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -49,6 +49,7 @@ import { usePorticoRelayerFee } from 'hooks/usePorticoRelayerFee';
 import { useFetchTokenPrices } from 'hooks/useFetchTokenPrices';
 import NttInboundCapacityWarning from './NttInboundCapacityWarning';
 import { isNttRoute } from 'routes/utils';
+import { useConnectToLastUsedWallet } from 'utils/wallet';
 
 const useStyles = makeStyles()((_theme) => ({
   spacer: {
@@ -262,6 +263,7 @@ function Bridge() {
   usePorticoSwapInfo();
   usePorticoRelayerFee();
   useFetchTokenPrices();
+  useConnectToLastUsedWallet();
 
   // validate transfer inputs
   useValidate();

--- a/wormhole-connect/src/views/Bridge/Inputs/From.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/From.tsx
@@ -14,7 +14,7 @@ import {
   isDisabledChain,
 } from 'store/transferInput';
 import config from 'config';
-import { TransferWallet } from 'utils/wallet';
+import { TransferWallet, connectLastUsedWallet } from 'utils/wallet';
 import RouteOperator from 'routes/operator';
 import { getTokenPrice, hydrateHrefTemplate } from 'utils';
 import Inputs from './Inputs';
@@ -60,7 +60,8 @@ function FromInputs() {
   );
 
   const selectChain = async (chain: ChainName) => {
-    selectFromChain(dispatch, chain, wallet);
+    await selectFromChain(dispatch, chain, wallet);
+    await connectLastUsedWallet(TransferWallet.SENDING, chain, dispatch);
   };
 
   const selectToken = (token: string) => {

--- a/wormhole-connect/src/views/Bridge/Inputs/From.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/From.tsx
@@ -14,7 +14,7 @@ import {
   isDisabledChain,
 } from 'store/transferInput';
 import config from 'config';
-import { TransferWallet, connectLastUsedWallet } from 'utils/wallet';
+import { TransferWallet } from 'utils/wallet';
 import RouteOperator from 'routes/operator';
 import { getTokenPrice, hydrateHrefTemplate } from 'utils';
 import Inputs from './Inputs';
@@ -61,7 +61,6 @@ function FromInputs() {
 
   const selectChain = async (chain: ChainName) => {
     await selectFromChain(dispatch, chain, wallet);
-    await connectLastUsedWallet(TransferWallet.SENDING, chain, dispatch);
   };
 
   const selectToken = (token: string) => {

--- a/wormhole-connect/src/views/Bridge/Inputs/To.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/To.tsx
@@ -9,7 +9,7 @@ import {
   selectToChain,
   setDestToken,
 } from 'store/transferInput';
-import { TransferWallet } from 'utils/wallet';
+import { TransferWallet, connectLastUsedWallet } from 'utils/wallet';
 import { getTokenPrice, hydrateHrefTemplate } from 'utils';
 import config from 'config';
 
@@ -57,7 +57,8 @@ function ToInputs() {
   );
 
   const selectChain = async (chain: ChainName) => {
-    selectToChain(dispatch, chain, receiving);
+    await selectToChain(dispatch, chain, receiving);
+    await connectLastUsedWallet(TransferWallet.RECEIVING, chain, dispatch);
   };
 
   // token display jsx

--- a/wormhole-connect/src/views/Bridge/Inputs/To.tsx
+++ b/wormhole-connect/src/views/Bridge/Inputs/To.tsx
@@ -9,7 +9,7 @@ import {
   selectToChain,
   setDestToken,
 } from 'store/transferInput';
-import { TransferWallet, connectLastUsedWallet } from 'utils/wallet';
+import { TransferWallet } from 'utils/wallet';
 import { getTokenPrice, hydrateHrefTemplate } from 'utils';
 import config from 'config';
 
@@ -58,7 +58,6 @@ function ToInputs() {
 
   const selectChain = async (chain: ChainName) => {
     await selectToChain(dispatch, chain, receiving);
-    await connectLastUsedWallet(TransferWallet.RECEIVING, chain, dispatch);
   };
 
   // token display jsx


### PR DESCRIPTION
Addresses #1800

This change moves all the wallet connection logic out of `WalletModal` (☺️) as well as using a lil' localStorage magic to automatically do this when we select a chain, if the user has done it before. 

https://github.com/wormhole-foundation/wormhole-connect/assets/897596/9cedf880-cf99-464a-9773-4a6776d9714b

TODO

- [x] cover the case where there is a default chain in `bridgeDefaults`