### PR TITLE
TokensModal only show native token when possible

### DIFF
--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -158,11 +158,17 @@ function Bridge() {
 
   useEffect(() => {
     const computeDestTokens = async () => {
-      const supported = await RouteOperator.allSupportedDestTokens(
+      let supported = await RouteOperator.allSupportedDestTokens(
         config.tokens[token],
         fromChain,
         toChain,
       );
+      // If any of the tokens are native to the chain, only select those.
+      // This is to avoid users inadvertently receiving wrapped versions of the token.
+      const nativeTokens = supported.filter((t) => t.nativeChain === toChain);
+      if (nativeTokens.length > 0) {
+        supported = nativeTokens;
+      }
       dispatch(setSupportedDestTokens(supported));
       const allSupported = await RouteOperator.allSupportedDestTokens(
         undefined,


### PR DESCRIPTION
Prevent users from receiving wrapped tokens when they could receive the  native version.