### PR TITLE
Only select native tokens when source token is selected

### DIFF
--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -163,11 +163,13 @@ function Bridge() {
         fromChain,
         toChain,
       );
-      // If any of the tokens are native to the chain, only select those.
-      // This is to avoid users inadvertently receiving wrapped versions of the token.
-      const nativeTokens = supported.filter((t) => t.nativeChain === toChain);
-      if (nativeTokens.length > 0) {
-        supported = nativeTokens;
+      if (token) {
+        // If any of the tokens are native to the chain, only select those.
+        // This is to avoid users inadvertently receiving wrapped versions of the token.
+        const nativeTokens = supported.filter((t) => t.nativeChain === toChain);
+        if (nativeTokens.length > 0) {
+          supported = nativeTokens;
+        }
       }
       dispatch(setSupportedDestTokens(supported));
       const allSupported = await RouteOperator.allSupportedDestTokens(


### PR DESCRIPTION
Fixes issue where dest chain is selected and automatically populated with the native token for some routes (e.g. Gateway).

Addresses #1932