### PR TITLE
portico: hexlify missing prefix when looking up tx

### DIFF
--- a/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
@@ -789,7 +789,9 @@ export abstract class PorticoBridge extends BaseRoute {
       };
     }
     const provider = config.wh.mustGetProvider(txData.toChain);
-    const receipt = await provider.getTransactionReceipt(receiveTx);
+    const receipt = await provider.getTransactionReceipt(
+      hexlify(receiveTx, { allowMissingPrefix: true }),
+    );
     const payloadBuffer = Buffer.from(txData.payload!.slice(2), 'hex');
     const {
       finalTokenAddress,


### PR DESCRIPTION
`receiveTx` is not prefixed with a `0x`, so the call to `getTransactionReceipt` was throwing an exception causing destination chain swap details to now show.