### PR TITLE
Include transfer.redeem.error in telemetry types

### DIFF
--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -28,7 +28,7 @@ export interface TransferEvent {
 }
 
 export interface TransferErrorEvent {
-  type: 'transfer.error';
+  type: 'transfer.error' | 'transfer.redeem.error';
   details: TransferDetails;
   error: TransferError;
 }

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -250,7 +250,7 @@ function SendTo() {
       setClaimError(uiError);
 
       config.triggerEvent({
-        type: 'transfer.error',
+        type: 'transfer.redeem.error',
         details: transferDetails,
         error: transferError,
       });


### PR DESCRIPTION
We would also like to differentiate when the error is in the first transfer or during the redeeming process.