### PR TITLE
Fixed destructure property error when resuming transaction

### DIFF
--- a/wormhole-connect/src/config/events.ts
+++ b/wormhole-connect/src/config/events.ts
@@ -18,6 +18,12 @@ export function wrapEventHandler(
     };
 
     console.info('Wormhole Connect event:', eventWithMeta);
-    if (integrationHandler) integrationHandler(eventWithMeta);
+    if (integrationHandler) {
+      try {
+        integrationHandler(eventWithMeta);
+      } catch (e) {
+        console.error('Error handling event:', e);
+      }
+    }
   };
 }

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -13,6 +13,7 @@ import {
   ERR_USER_REJECTED,
 } from 'telemetry/types';
 import {
+  ChainName,
   INSUFFICIENT_ALLOWANCE,
   InsufficientFundsForGasError,
 } from '@wormhole-foundation/wormhole-connect-sdk';
@@ -23,11 +24,10 @@ import {
   UnsupportedContractAbiVersion,
 } from 'routes/ntt/errors';
 import { SWAP_ERROR } from 'routes/porticoBridge/consts';
-import { TransferInputState } from 'store/transferInput';
 
 export function interpretTransferError(
   e: any,
-  transferInput: TransferInputState,
+  chain: ChainName,
 ): [string, TransferError] {
   // Fall-back values
   let uiErrorMessage = 'Error with transfer, please try again';
@@ -42,9 +42,7 @@ export function interpretTransferError(
       uiErrorMessage = 'Transfer timed out, please try again';
       internalErrorCode = ERR_TIMEOUT;
     } else if (e?.message === NotEnoughCapacityError.MESSAGE) {
-      uiErrorMessage = `This transfer would be rate-limited due to high volume on ${
-        config.chains[transferInput.fromChain!]?.displayName
-      }, please try again later`;
+      uiErrorMessage = `This transfer would be rate-limited due to high volume on ${config.chains[chain]?.displayName}, please try again later`;
       internalErrorCode = ERR_NOT_ENOUGH_CAPACITY;
     } else if (e?.message === ContractIsPausedError.MESSAGE) {
       uiErrorMessage = e.message;

--- a/wormhole-connect/src/views/Bridge/Send.tsx
+++ b/wormhole-connect/src/views/Bridge/Send.tsx
@@ -176,7 +176,7 @@ function Send(props: { valid: boolean }) {
     } catch (e: any) {
       console.error('Wormhole Connect: error completing transfer', e);
       dispatch(setIsTransactionInProgress(false));
-      const [uiError, transferError] = interpretTransferError(e, transferInput);
+      const [uiError, transferError] = interpretTransferError(e, fromChain!);
 
       // Show error in UI
       setSendError(uiError);

--- a/wormhole-connect/src/views/Redeem/Redeem.tsx
+++ b/wormhole-connect/src/views/Redeem/Redeem.tsx
@@ -28,7 +28,6 @@ import useCheckInboundQueuedTransfer from 'hooks/useCheckInboundQueuedTransfer';
 import useConfirmBeforeLeaving from 'utils/confirmBeforeLeaving';
 import { INVALID_VAA_MESSAGE } from 'utils/repairVaa';
 
-import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import { getTokenDetails } from 'telemetry';
 
 function Redeem({
@@ -41,10 +40,6 @@ function Redeem({
   isVaaEnqueued,
   route,
   signedMessage,
-  fromChain,
-  toChain,
-  token,
-  destToken,
 }: {
   setSignedMessage: (signed: SignedMessage) => any;
   setIsVaaEnqueued: (isVaaEnqueued: boolean) => any;
@@ -55,10 +50,6 @@ function Redeem({
   isVaaEnqueued: boolean;
   route: Route | undefined;
   signedMessage: SignedMessage | undefined;
-  fromChain: ChainName;
-  toChain: ChainName;
-  token: string;
-  destToken: string;
 }) {
   // Warn user before closing tab if transaction is unredeemed
   useConfirmBeforeLeaving(!transferComplete);
@@ -158,10 +149,10 @@ function Redeem({
             type: 'transfer.success',
             details: {
               route,
-              fromToken: getTokenDetails(token),
-              toToken: getTokenDetails(destToken),
-              fromChain,
-              toChain,
+              fromToken: getTokenDetails(txData.tokenKey),
+              toToken: getTokenDetails(txData.receivedTokenKey),
+              fromChain: txData.fromChain,
+              toChain: txData.toChain,
             },
           });
         } else {
@@ -218,8 +209,6 @@ function mapStateToProps(state: RootState) {
     signedMessage,
   } = state.redeem;
 
-  const { fromChain, toChain, token, destToken } = state.transferInput;
-
   return {
     txData,
     transferComplete,
@@ -227,10 +216,6 @@ function mapStateToProps(state: RootState) {
     isInvalidVaa,
     route,
     signedMessage,
-    fromChain: fromChain!,
-    toChain: toChain!,
-    token,
-    destToken,
   };
 }
 

--- a/wormhole-connect/src/views/Redeem/SendTo.tsx
+++ b/wormhole-connect/src/views/Redeem/SendTo.tsx
@@ -83,7 +83,6 @@ function SendTo() {
   } = useSelector((state: RootState) => state.redeem);
   const txData = useSelector((state: RootState) => state.redeem.txData)!;
   const wallet = useSelector((state: RootState) => state.wallet.receiving);
-  const transferInput = useSelector((state: RootState) => state.transferInput);
 
   const transferDestInfo = useSelector(
     (state: RootState) => state.redeem.transferDestInfo,
@@ -197,10 +196,10 @@ function SendTo() {
 
     const transferDetails = {
       route: routeName,
-      fromToken: getTokenDetails(transferInput.token),
-      toToken: getTokenDetails(transferInput.destToken),
-      fromChain: transferInput.fromChain!,
-      toChain: transferInput.toChain!,
+      fromToken: getTokenDetails(txData.tokenKey),
+      toToken: getTokenDetails(txData.receivedTokenKey),
+      fromChain: txData.fromChain,
+      toChain: txData.toChain,
     };
 
     config.triggerEvent({
@@ -245,7 +244,10 @@ function SendTo() {
       setInProgress(false);
       setClaimError('');
     } catch (e: any) {
-      const [uiError, transferError] = interpretTransferError(e, transferInput);
+      const [uiError, transferError] = interpretTransferError(
+        e,
+        txData.toChain,
+      );
 
       setClaimError(uiError);
 


### PR DESCRIPTION
`transferInput` will not have any values set when going through the resume transfer flow, so we just use the properties from `txData` instead