### PR TITLE
Fix: Resume transaction always trigger 'transfer.success' event

### DIFF
--- a/wormhole-connect/src/store/redeem.ts
+++ b/wormhole-connect/src/store/redeem.ts
@@ -20,6 +20,7 @@ export interface RedeemState {
   route: Route | undefined;
   transferDestInfo: TransferDestInfo | undefined;
   deliveryStatus: DeliveryStatus | undefined;
+  isResumeTx: boolean;
 }
 
 const initialState: RedeemState = {
@@ -33,6 +34,7 @@ const initialState: RedeemState = {
   route: undefined,
   transferDestInfo: undefined,
   deliveryStatus: undefined,
+  isResumeTx: false,
 };
 
 export const redeemSlice = createSlice({
@@ -100,6 +102,12 @@ export const redeemSlice = createSlice({
     ) => {
       state.isInvalidVaa = payload;
     },
+    setIsResumeTx: (
+      state: RedeemState,
+      { payload }: PayloadAction<boolean>,
+    ) => {
+      state.isResumeTx = payload;
+    },
   },
 });
 
@@ -115,6 +123,7 @@ export const {
   setRoute,
   setSignedMessage,
   setDeliveryStatus,
+  setIsResumeTx,
 } = redeemSlice.actions;
 
 export default redeemSlice.reducer;

--- a/wormhole-connect/src/views/Redeem/Redeem.tsx
+++ b/wormhole-connect/src/views/Redeem/Redeem.tsx
@@ -38,6 +38,7 @@ function Redeem({
   txData,
   transferComplete,
   isVaaEnqueued,
+  isResumeTx,
   route,
   signedMessage,
 }: {
@@ -48,6 +49,7 @@ function Redeem({
   txData: ParsedMessage | ParsedRelayerMessage | undefined;
   transferComplete: boolean;
   isVaaEnqueued: boolean;
+  isResumeTx: boolean;
   route: Route | undefined;
   signedMessage: SignedMessage | undefined;
 }) {
@@ -144,17 +146,18 @@ function Redeem({
         }
         if (isComplete) {
           setTransferComplete();
-
-          config.triggerEvent({
-            type: 'transfer.success',
-            details: {
-              route,
-              fromToken: getTokenDetails(txData.tokenKey),
-              toToken: getTokenDetails(txData.receivedTokenKey),
-              fromChain: txData.fromChain,
-              toChain: txData.toChain,
-            },
-          });
+          if (!isResumeTx) {
+            config.triggerEvent({
+              type: 'transfer.success',
+              details: {
+                route,
+                fromToken: getTokenDetails(txData.tokenKey),
+                toToken: getTokenDetails(txData.receivedTokenKey),
+                fromChain: txData.fromChain,
+                toChain: txData.toChain,
+              },
+            });
+          }
         } else {
           await sleep(i < 10 ? 3000 : 30000);
         }
@@ -204,6 +207,7 @@ function mapStateToProps(state: RootState) {
     txData,
     transferComplete,
     isVaaEnqueued,
+    isResumeTx,
     isInvalidVaa,
     route,
     signedMessage,
@@ -213,6 +217,7 @@ function mapStateToProps(state: RootState) {
     txData,
     transferComplete,
     isVaaEnqueued,
+    isResumeTx,
     isInvalidVaa,
     route,
     signedMessage,

--- a/wormhole-connect/src/views/TxSearch.tsx
+++ b/wormhole-connect/src/views/TxSearch.tsx
@@ -7,7 +7,11 @@ import { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import config from 'config';
 import { isValidTxId } from 'utils';
 import RouteOperator from 'routes/operator';
-import { setTxDetails, setRoute as setRedeemRoute } from 'store/redeem';
+import {
+  setTxDetails,
+  setRoute as setRedeemRoute,
+  setIsResumeTx,
+} from 'store/redeem';
 import { setRoute as setAppRoute } from 'store/router';
 import PageHeader from 'components/PageHeader';
 import Search from 'components/Search';
@@ -90,6 +94,7 @@ function TxSearch() {
       );
       setError('');
       dispatch(setTxDetails(message));
+      dispatch(setIsResumeTx(true)); // To avoid send transfer.success event in Resume Transaction case
       dispatch(setRedeemRoute(route));
       dispatch(setAppRoute('redeem'));
       dispatch(setToChain(message.toChain));


### PR DESCRIPTION
Due every time a transaction is resumed, I decided to add a new variable to the store to avoid this behavior.