### PR TITLE
Gas dropoff slider conversion rate fix

### DIFF
--- a/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
+++ b/wormhole-connect/src/views/Bridge/NativeGasSlider.tsx
@@ -282,11 +282,9 @@ function GasSlider(props: { disabled: boolean }) {
   const handleChange = (e: any) => {
     if (!amountNum || !state.conversionRate) return;
     const value = e.target.value < state.min ? 0 : e.target.value;
-    const newGasAmount = value * state.conversionRate;
     const newTokenAmount = amountNum - value;
     const swapAmount = value;
     const conversion = {
-      nativeGas: formatAmount(newGasAmount),
       token: formatAmount(newTokenAmount),
       swapAmt: formatAmount(swapAmount),
     };


### PR DESCRIPTION
Previously the gas dropoff slider was setting the native gas amount using the conversion rate from CoinGecko. However the conversion rate from CoinGecko may not be the same as the conversion rate used by the relayer contract. This commit fixes the gas dropoff slider to use the conversion rate from the relayer contract instead. A side effect of this change is that the native gas amount is not displayed in the UI until the conversion rate is fetched from the relayer contract, after the debounced debounced value from the slider changes.

Addresses #1076