### PR TITLE
Skip custom tokens that define foreign assets

### DIFF
--- a/wormhole-connect/src/config/utils.ts
+++ b/wormhole-connect/src/config/utils.ts
@@ -77,10 +77,8 @@ export const mergeCustomTokensConfig = (
       continue;
     }
     if (customToken.foreignAssets) {
-      console.warn(
-        `Skipping custom token config for "${key}" because it contains foreign assets`,
-      );
-      continue;
+      delete customToken.foreignAssets;
+      console.warn(`Ignoring custom token config "${key}" foreignAssets`);
     }
 
     // Accept custom token config

--- a/wormhole-connect/src/config/utils.ts
+++ b/wormhole-connect/src/config/utils.ts
@@ -76,6 +76,12 @@ export const mergeCustomTokensConfig = (
       );
       continue;
     }
+    if (customToken.foreignAssets) {
+      console.warn(
+        `Skipping custom token config for "${key}" because it contains foreign assets`,
+      );
+      continue;
+    }
 
     // Accept custom token config
     console.info(`Accepted custom token config for "${key}"`);


### PR DESCRIPTION
Incorrect foreign assets can result in issues such as an incorrect ATA being generated on Solana.