### PR TITLE
Removing unnecessary SDK calls during initial load

### DIFF
--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -101,10 +101,10 @@ export class SDKv2Route<N extends Network> extends RouteAbstract {
 
     return routes.RouteTransferRequest.create(
       wh,
+      /* @ts-ignore */
       {
         source: srcTokenV2,
         destination: dstTokenV2,
-        /* @ts-ignore */
       },
       srcChain,
       dstChain,

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -115,8 +115,12 @@ function Bridge() {
 
   // check destination native balance
   useEffect(() => {
-    if (!fromChain || !toChain || !receiving.address) return;
+    if (!fromChain || !toChain || !receiving.address) {
+      return;
+    }
+
     const chainConfig = config.chains[toChain]!;
+
     config.wh
       .getNativeBalance(receiving.address, toChain)
       .then((res: BigNumber) => {
@@ -132,7 +136,12 @@ function Bridge() {
   }, [fromChain, toChain, receiving.address, dispatch]);
 
   useEffect(() => {
+    if (!fromChain) {
+      return;
+    }
+
     let active = true;
+
     const computeSrcTokens = async () => {
       const supported = await RouteOperator.allSupportedSourceTokens(
         config.tokens[destToken],
@@ -150,7 +159,9 @@ function Bridge() {
         }
       }
     };
+
     computeSrcTokens();
+
     return () => {
       active = false;
     };
@@ -158,6 +169,10 @@ function Bridge() {
   }, [route, fromChain, destToken, dispatch]);
 
   useEffect(() => {
+    if (!toChain) {
+      return;
+    }
+
     let canceled = false;
 
     const computeDestTokens = async () => {
@@ -231,7 +246,9 @@ function Bridge() {
         }
       }
     };
+
     computeDestTokens();
+
     return () => {
       canceled = true;
     };
@@ -239,13 +256,18 @@ function Bridge() {
   }, [route, token, fromChain, toChain, dispatch]);
 
   useEffect(() => {
+    if (!route || !amount || !token || !destToken || !fromChain || !toChain) {
+      return;
+    }
+
     const recomputeReceive = async () => {
-      if (!route) return;
       try {
         const routeOptions = isPorticoRoute(route)
           ? portico
           : { toNativeToken, relayerFee };
+
         dispatch(setFetchingReceiveAmount());
+
         const newReceiveAmount = await RouteOperator.computeReceiveAmount(
           route,
           Number.parseFloat(amount),


### PR DESCRIPTION
During initial load of the Connect bridge, we are making unnecessary calls to fetch supported source and destination tokens, even before user selects those networks. In this PR I'm skipping those calls if the networks not selected yet.

Please see the loom for more details:
https://www.loom.com/share/231cc074f3e742b38b06ce13dd75de67?sid=17ea8b52-a2d9-4e68-8dc2-6f253a80d657