### PR TITLE
Fix Route resolution issue

### DIFF
--- a/wormhole-connect/src/routes/bridge/baseRoute.ts
+++ b/wormhole-connect/src/routes/bridge/baseRoute.ts
@@ -75,11 +75,11 @@ export abstract class BaseRoute extends RouteAbstract {
     tokens: TokenConfig[],
     destToken?: TokenConfig,
     sourceChain?: ChainName | ChainId,
+    destChain?: ChainName | ChainId,
   ): Promise<TokenConfig[]> {
-    if (!destToken) return tokens;
     const shouldAdd = await Promise.allSettled(
       tokens.map((token) =>
-        this.isSupportedSourceToken(token, destToken, sourceChain),
+        this.isSupportedSourceToken(token, destToken, sourceChain, destChain),
       ),
     );
     return tokens.filter((_token, i) => {
@@ -91,10 +91,14 @@ export abstract class BaseRoute extends RouteAbstract {
   async supportedDestTokens(
     tokens: TokenConfig[],
     sourceToken?: TokenConfig,
+    sourceChain?: ChainName | ChainId,
+    destChain?: ChainName | ChainId,
   ): Promise<TokenConfig[]> {
-    if (!sourceToken) return tokens;
+    console.trace();
     const shouldAdd = await Promise.allSettled(
-      tokens.map((token) => this.isSupportedDestToken(token, sourceToken)),
+      tokens.map((token) =>
+        this.isSupportedDestToken(token, sourceToken, sourceChain, destChain),
+      ),
     );
     return tokens.filter((_token, i) => {
       const res = shouldAdd[i];

--- a/wormhole-connect/src/routes/bridge/baseRoute.ts
+++ b/wormhole-connect/src/routes/bridge/baseRoute.ts
@@ -94,7 +94,6 @@ export abstract class BaseRoute extends RouteAbstract {
     sourceChain?: ChainName | ChainId,
     destChain?: ChainName | ChainId,
   ): Promise<TokenConfig[]> {
-    console.trace();
     const shouldAdd = await Promise.allSettled(
       tokens.map((token) =>
         this.isSupportedDestToken(token, sourceToken, sourceChain, destChain),

--- a/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
@@ -129,40 +129,6 @@ export abstract class PorticoBridge extends BaseRoute {
     );
   }
 
-  async supportedSourceTokens(
-    tokens: TokenConfig[],
-    destToken?: TokenConfig,
-    sourceChain?: ChainName | ChainId,
-    destChain?: ChainName | ChainId,
-  ): Promise<TokenConfig[]> {
-    const shouldAdd = await Promise.allSettled(
-      tokens.map((token) =>
-        this.isSupportedSourceToken(token, destToken, sourceChain, destChain),
-      ),
-    );
-    return tokens.filter((_token, i) => {
-      const res = shouldAdd[i];
-      return res.status === 'fulfilled' && res.value;
-    });
-  }
-
-  async supportedDestTokens(
-    tokens: TokenConfig[],
-    sourceToken?: TokenConfig,
-    sourceChain?: ChainName | ChainId,
-    destChain?: ChainName | ChainId,
-  ): Promise<TokenConfig[]> {
-    const shouldAdd = await Promise.allSettled(
-      tokens.map((token) =>
-        this.isSupportedDestToken(token, sourceToken, sourceChain, destChain),
-      ),
-    );
-    return tokens.filter((_token, i) => {
-      const res = shouldAdd[i];
-      return res.status === 'fulfilled' && res.value;
-    });
-  }
-
   async isRouteSupported(
     sourceToken: string,
     destToken: string,


### PR DESCRIPTION
This fixes route resolution by adding some missing parameters to old implementation of `supportedSourceTokens` and `supportedDestTokens` in `baseRoute.ts`.