### PR TITLE
isRouteSupported unit test suite

### DIFF
--- a/wormhole-connect/src/routes/ntt/nttBase.ts
+++ b/wormhole-connect/src/routes/ntt/nttBase.ts
@@ -38,7 +38,7 @@ import { WormholeTransceiver, getMessageEvm } from './chains/evm';
 import { NttManagerSolana, getMessageSolana } from './chains/solana';
 import { formatGasFee } from 'routes/utils';
 import { NO_INPUT } from 'utils/style';
-import { estimateAverageGasFee } from 'utils/gas';
+import { estimateAverageGasFee } from '../utils';
 import config from 'config';
 import {
   getNttGroupKey,

--- a/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
@@ -65,7 +65,7 @@ import {
 } from './utils';
 import { PorticoBridgeState, PorticoSwapAmounts } from 'store/porticoBridge';
 import { TokenPrices } from 'store/tokenPrices';
-import { estimateAverageGasFee } from 'utils/gas';
+import { estimateAverageGasFee } from '../utils';
 
 export abstract class PorticoBridge extends BaseRoute {
   readonly NATIVE_GAS_DROPOFF_SUPPORTED: boolean = false;

--- a/wormhole-connect/src/routes/utils.ts
+++ b/wormhole-connect/src/routes/utils.ts
@@ -122,3 +122,13 @@ export const isIlliquidDestToken = (
 export const isNttRoute = (route?: Route) => {
   return route === Route.NttManual || route === Route.NttRelay;
 };
+
+export const estimateAverageGasFee = async (
+  chain: ChainName | ChainId,
+  gasLimit: BigNumberish,
+): Promise<BigNumber> => {
+  const provider = config.wh.mustGetProvider(chain);
+  const gasPrice = await provider.getGasPrice();
+  // This is a naive estimate 30% higher than what the oracle says
+  return gasPrice.mul(gasLimit).mul(130).div(100);
+};

--- a/wormhole-connect/src/routes/utils.ts
+++ b/wormhole-connect/src/routes/utils.ts
@@ -5,7 +5,7 @@ import {
   ParsedMessage as SdkParsedMessage,
   ParsedRelayerMessage as SdkParsedRelayerMessage,
 } from '@wormhole-foundation/wormhole-connect-sdk';
-import { BigNumber, utils } from 'ethers';
+import { BigNumber, BigNumberish, utils } from 'ethers';
 import config from 'config';
 import { toFixedDecimals } from 'utils/balance';
 import {

--- a/wormhole-connect/src/utils/gas.ts
+++ b/wormhole-connect/src/utils/gas.ts
@@ -78,13 +78,3 @@ export const estimateClaimGas = async (
   if (!gas) throw new Error('could not estimate send gas');
   return formatGasFee(destChain, gas);
 };
-
-export const estimateAverageGasFee = async (
-  chain: ChainName | ChainId,
-  gasLimit: BigNumberish,
-): Promise<BigNumber> => {
-  const provider = config.wh.mustGetProvider(chain);
-  const gasPrice = await provider.getGasPrice();
-  // This is a naive estimate 30% higher than what the oracle says
-  return gasPrice.mul(gasLimit).mul(130).div(100);
-};

--- a/wormhole-connect/src/utils/gas.ts
+++ b/wormhole-connect/src/utils/gas.ts
@@ -1,4 +1,4 @@
-import { BigNumber, BigNumberish, utils } from 'ethers';
+import { BigNumber, utils } from 'ethers';
 import {
   ChainName,
   ChainId,

--- a/wormhole-connect/tests/ci/routes.test.ts
+++ b/wormhole-connect/tests/ci/routes.test.ts
@@ -28,6 +28,8 @@ describe('supported routes', () => {
     // ETH bridge
     ['ETH', 'WETHbsc', 'ethereum', 'bsc', [Route.ETHBridge]],
     ['ETH', 'WETHpolygon', 'ethereum', 'polygon', [Route.ETHBridge]],
+    ['WETHarbitrum', 'WETHpolygon', 'arbitrum', 'polygon', [Route.ETHBridge]],
+    ['WETHpolygon', 'WETHarbitrum', 'polygon', 'arbitrum', [Route.ETHBridge]],
     // wstETHBridge
     ['wstETH', 'wstETHpolygon', 'ethereum', 'polygon', [Route.wstETHBridge]],
     ['wstETH', 'wstETHarbitrum', 'ethereum', 'arbitrum', [Route.wstETHBridge]],
@@ -54,9 +56,13 @@ describe('supported routes', () => {
       'polygon',
       [Route.CCTPManual, Route.CCTPRelay],
     ],
+    ['USDCeth', 'USDCsol', 'ethereum', 'solana', [Route.CCTPManual]],
+    ['USDCavax', 'USDCsol', 'avalanche', 'solana', [Route.CCTPManual]],
     // TBTC
     ['tBTC', 'tBTCpolygon', 'ethereum', 'polygon', [Route.TBTC]],
     ['tBTCoptimism', 'tBTC', 'optimism', 'ethereum', [Route.TBTC]],
+    ['tBTCpolygon', 'tBTCoptimism', 'polygon', 'optimism', [Route.TBTC]],
+    ['tBTCarbitrum', 'tBTCoptimism', 'arbitrum', 'optimism', [Route.TBTC]],
     // Cosmos Gateway
     ['CELO', 'CELO', 'osmosis', 'celo', [Route.CosmosGateway]],
     ['CELO', 'CELO', 'osmosis', 'moonbeam', [Route.CosmosGateway]],
@@ -71,7 +77,7 @@ describe('supported routes', () => {
     routes,
   ] of testCases) {
     for (let route of routes) {
-      test(`${route} ${sourceChain}:${sourceToken} -> ${destChain}${destToken}`, async () => {
+      test(`${route} ${sourceChain}:${sourceToken} -> ${destChain}:${destToken}`, async () => {
         const r = getRouteImpls(route).v1;
 
         const isSupported = await r.isRouteSupported(

--- a/wormhole-connect/tests/ci/routes.test.ts
+++ b/wormhole-connect/tests/ci/routes.test.ts
@@ -19,7 +19,7 @@ describe('supported routes', () => {
     // Token bridge
     ['ETH', 'WETH', 'ethereum', 'bsc', [Route.Bridge, Route.Relay]],
     ['DAI', 'DAI', 'ethereum', 'polygon', [Route.Bridge, Route.Relay]],
-    ['SOL', 'WSOL', 'solana', 'ethereum', [Route.Bridge, Route.Relay]],
+    ['WSOL', 'WSOL', 'solana', 'ethereum', [Route.Bridge, Route.Relay]],
     ['WSOL', 'WSOL', 'ethereum', 'solana', [Route.Bridge, Route.Relay]],
     ['ETH', 'WETH', 'ethereum', 'avalanche', [Route.Bridge, Route.Relay]],
     ['BNB', 'WBNB', 'bsc', 'polygon', [Route.Bridge, Route.Relay]],

--- a/wormhole-connect/tests/ci/routes.test.ts
+++ b/wormhole-connect/tests/ci/routes.test.ts
@@ -1,0 +1,55 @@
+import { ChainId, ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import RouteAbstract from 'routes/abstracts/routeAbstract';
+import { ETHBridge } from 'routes/porticoBridge/ethBridge';
+
+import { describe, expect, test } from 'vitest';
+
+import { setConfig } from 'config';
+import { Route } from 'config/types';
+import { is } from '@mysten/sui.js';
+
+describe('supported routes', () => {
+  interface testCase {
+    sourceToken: string;
+    destToken: string;
+    sourceChain: ChainName | ChainId;
+    destChain: ChainName | ChainId;
+    route: Route;
+  }
+
+  setConfig({ env: 'mainnet' });
+
+  const testCases: testCase[] = [
+    // Portico bridge
+    {
+      sourceToken: 'ETH',
+      destToken: 'WETHbsc',
+      sourceChain: 'ethereum',
+      destChain: 'bsc',
+      route: ETHBridge,
+    },
+    {
+      sourceToken: 'ETH',
+      destToken: 'WETHpolygon',
+      sourceChain: 'ethereum',
+      destChain: 'polygon',
+      route: ETHBridge,
+    },
+  ];
+
+  for (let tc of testCases) {
+    test(`${tc.route} ${tc.sourceChain}:${tc.sourceToken} -> ${tc.destChain}${tc.destToken}`, async () => {
+      const r = new tc.route();
+
+      const isSupported = await r.isRouteSupported(
+        tc.sourceToken,
+        tc.destToken,
+        '1.0',
+        tc.sourceChain,
+        tc.destChain,
+      );
+
+      expect(isSupported).toBeTruthy();
+    });
+  }
+});

--- a/wormhole-connect/tests/ci/routes.test.ts
+++ b/wormhole-connect/tests/ci/routes.test.ts
@@ -1,55 +1,89 @@
 import { ChainId, ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
-import RouteAbstract from 'routes/abstracts/routeAbstract';
-import { ETHBridge } from 'routes/porticoBridge/ethBridge';
-
 import { describe, expect, test } from 'vitest';
-
 import { setConfig } from 'config';
-import { Route } from 'config/types';
-import { is } from '@mysten/sui.js';
+import { Route, WormholeConnectConfig } from 'config/types';
+import { getRouteImpls } from 'routes/mappings';
 
 describe('supported routes', () => {
-  interface testCase {
-    sourceToken: string;
-    destToken: string;
-    sourceChain: ChainName | ChainId;
-    destChain: ChainName | ChainId;
-    route: Route;
-  }
+  type testCase = [
+    sourceToken: string,
+    destToken: string,
+    sourceChain: ChainName | ChainId,
+    destChain: ChainName | ChainId,
+    route: Route[],
+  ];
 
   setConfig({ env: 'mainnet' });
 
   const testCases: testCase[] = [
-    // Portico bridge
-    {
-      sourceToken: 'ETH',
-      destToken: 'WETHbsc',
-      sourceChain: 'ethereum',
-      destChain: 'bsc',
-      route: ETHBridge,
-    },
-    {
-      sourceToken: 'ETH',
-      destToken: 'WETHpolygon',
-      sourceChain: 'ethereum',
-      destChain: 'polygon',
-      route: ETHBridge,
-    },
+    // Token bridge
+    ['ETH', 'WETH', 'ethereum', 'bsc', [Route.Bridge, Route.Relay]],
+    ['DAI', 'DAI', 'ethereum', 'polygon', [Route.Bridge, Route.Relay]],
+    ['SOL', 'WSOL', 'solana', 'ethereum', [Route.Bridge, Route.Relay]],
+    ['WSOL', 'WSOL', 'ethereum', 'solana', [Route.Bridge, Route.Relay]],
+    ['ETH', 'WETH', 'ethereum', 'avalanche', [Route.Bridge, Route.Relay]],
+    ['BNB', 'WBNB', 'bsc', 'polygon', [Route.Bridge, Route.Relay]],
+    ['FTM', 'WFTM', 'fantom', 'polygon', [Route.Bridge, Route.Relay]],
+    ['CELO', 'CELO', 'celo', 'polygon', [Route.Bridge, Route.Relay]],
+    // ETH bridge
+    ['ETH', 'WETHbsc', 'ethereum', 'bsc', [Route.ETHBridge]],
+    ['ETH', 'WETHpolygon', 'ethereum', 'polygon', [Route.ETHBridge]],
+    // wstETHBridge
+    ['wstETH', 'wstETHpolygon', 'ethereum', 'polygon', [Route.wstETHBridge]],
+    ['wstETH', 'wstETHarbitrum', 'ethereum', 'arbitrum', [Route.wstETHBridge]],
+    // NTT
+    [
+      'USDCeth',
+      'USDCfantom',
+      'ethereum',
+      'fantom',
+      [Route.NttManual, Route.NttRelay],
+    ],
+    // CCTP
+    [
+      'USDCeth',
+      'USDCarbitrum',
+      'ethereum',
+      'arbitrum',
+      [Route.CCTPManual, Route.CCTPRelay],
+    ],
+    [
+      'USDCarbitrum',
+      'USDCpolygon',
+      'arbitrum',
+      'polygon',
+      [Route.CCTPManual, Route.CCTPRelay],
+    ],
+    // TBTC
+    ['tBTC', 'tBTCpolygon', 'ethereum', 'polygon', [Route.TBTC]],
+    ['tBTCoptimism', 'tBTC', 'optimism', 'ethereum', [Route.TBTC]],
+    // Cosmos Gateway
+    ['CELO', 'CELO', 'osmosis', 'celo', [Route.CosmosGateway]],
+    ['CELO', 'CELO', 'osmosis', 'moonbeam', [Route.CosmosGateway]],
+    ['GLMR', 'WGLMR', 'moonbeam', 'kujira', [Route.CosmosGateway]],
   ];
 
-  for (let tc of testCases) {
-    test(`${tc.route} ${tc.sourceChain}:${tc.sourceToken} -> ${tc.destChain}${tc.destToken}`, async () => {
-      const r = new tc.route();
+  for (let [
+    sourceToken,
+    destToken,
+    sourceChain,
+    destChain,
+    routes,
+  ] of testCases) {
+    for (let route of routes) {
+      test(`${route} ${sourceChain}:${sourceToken} -> ${destChain}${destToken}`, async () => {
+        const r = getRouteImpls(route).v1;
 
-      const isSupported = await r.isRouteSupported(
-        tc.sourceToken,
-        tc.destToken,
-        '1.0',
-        tc.sourceChain,
-        tc.destChain,
-      );
+        const isSupported = await r.isRouteSupported(
+          sourceToken,
+          destToken,
+          '1.0',
+          sourceChain,
+          destChain,
+        );
 
-      expect(isSupported).toBeTruthy();
-    });
+        expect(isSupported).toBeTruthy();
+      });
+    }
   }
 });

--- a/wormhole-connect/tests/ci/routes.test.ts
+++ b/wormhole-connect/tests/ci/routes.test.ts
@@ -19,8 +19,8 @@ describe('supported routes', () => {
     // Token bridge
     ['ETH', 'WETH', 'ethereum', 'bsc', [Route.Bridge, Route.Relay]],
     ['DAI', 'DAI', 'ethereum', 'polygon', [Route.Bridge, Route.Relay]],
-    ['WSOL', 'WSOL', 'solana', 'ethereum', [Route.Bridge, Route.Relay]],
-    ['WSOL', 'WSOL', 'ethereum', 'solana', [Route.Bridge, Route.Relay]],
+    ['WSOL', 'WSOL', 'solana', 'ethereum', [Route.Bridge]],
+    ['WSOL', 'WSOL', 'ethereum', 'solana', [Route.Bridge]],
     ['ETH', 'WETH', 'ethereum', 'avalanche', [Route.Bridge, Route.Relay]],
     ['BNB', 'WBNB', 'bsc', 'polygon', [Route.Bridge, Route.Relay]],
     ['FTM', 'WFTM', 'fantom', 'polygon', [Route.Bridge, Route.Relay]],


### PR DESCRIPTION
This adds unit tests which cover the very basic `isRouteSupported` check for inputs we expect to be supported for each route. This will catch any changes which cause an entire route to stop being recognized by Connect.