### PR TITLE
Use semver when matching NTT ABIs

### DIFF
--- a/wormhole-connect/src/routes/ntt/chains/evm/nttManager.ts
+++ b/wormhole-connect/src/routes/ntt/chains/evm/nttManager.ts
@@ -19,6 +19,7 @@ import {
 import {
   encodeTransceiverInstructions,
   encodeWormholeTransceiverInstruction,
+  abiVersionMatches,
 } from 'routes/ntt/utils';
 import { NttManager__factory as NttManager__factory_0_1_0 } from './abis/0.1.0/NttManager__factory';
 import { NttManager as NttManager_0_1_0 } from './abis/0.1.0/NttManager';
@@ -27,8 +28,17 @@ import { NttManager as NttManager_1_0_0 } from './abis/1.0.0/NttManager';
 import config from 'config';
 import { toChainId, toChainName } from 'utils/sdk';
 
-const ABI_VERSION_0_1_0 = '0.1.0';
-const ABI_VERSION_1_0_0 = '1.0.0';
+type NttManagerFactory =
+  | typeof NttManager__factory_1_0_0
+  | typeof NttManager__factory_0_1_0;
+
+// This is a descending list of all ABI versions Connect is aware of.
+// We check for the first match in descending order, allowing for higher minor and patch versions
+// being used by the live contract (these are supposed to still be compatible with older ABIs).
+const KNOWN_ABI_VERSIONS: [string, NttManagerFactory][] = [
+  ['1.0.0', NttManager__factory_1_0_0],
+  ['0.1.0', NttManager__factory_0_1_0],
+];
 
 export class NttManagerEvm {
   static readonly abiVersionCache = new Map<string, string>();
@@ -243,18 +253,16 @@ export class NttManagerEvm {
       }
       NttManagerEvm.abiVersionCache.set(abiVersionKey, abiVersion);
     }
-    if (abiVersion === ABI_VERSION_0_1_0) {
-      return {
-        abi: NttManager__factory_0_1_0.connect(this.address, provider),
-        version: abiVersion,
-      };
+
+    for (let [version, factory] of KNOWN_ABI_VERSIONS) {
+      if (abiVersionMatches(abiVersion, version)) {
+        return {
+          abi: factory.connect(this.address, provider),
+          version: abiVersion,
+        };
+      }
     }
-    if (abiVersion === ABI_VERSION_1_0_0) {
-      return {
-        abi: NttManager__factory_1_0_0.connect(this.address, provider),
-        version: abiVersion,
-      };
-    }
+
     console.error(
       `Unsupported NttManager version ${abiVersion} for chain ${toChainName(
         this.chain,

--- a/wormhole-connect/src/routes/ntt/chains/evm/nttManager.ts
+++ b/wormhole-connect/src/routes/ntt/chains/evm/nttManager.ts
@@ -254,7 +254,7 @@ export class NttManagerEvm {
       NttManagerEvm.abiVersionCache.set(abiVersionKey, abiVersion);
     }
 
-    for (let [version, factory] of KNOWN_ABI_VERSIONS) {
+    for (const [version, factory] of KNOWN_ABI_VERSIONS) {
       if (abiVersionMatches(abiVersion, version)) {
         return {
           abi: factory.connect(this.address, provider),

--- a/wormhole-connect/src/routes/ntt/chains/solana/nttManager.ts
+++ b/wormhole-connect/src/routes/ntt/chains/solana/nttManager.ts
@@ -46,6 +46,7 @@ import {
   NotEnoughCapacityError,
   UnsupportedContractAbiVersion,
 } from 'routes/ntt/errors';
+import { abiVersionMatches } from 'routes/ntt/utils';
 
 const RATE_LIMIT_DURATION = 24 * 60 * 60;
 
@@ -868,7 +869,8 @@ export class NttManagerSolana {
     let program = NttManagerSolana.abiVersionCache.get(this.nttId);
     if (!program) {
       const abiVersion = await this.getVersion();
-      if (abiVersion !== '1.0.0') {
+      // For now we only have a single interface version for Solana
+      if (!abiVersionMatches(abiVersion, '1.0.0')) {
         throw new UnsupportedContractAbiVersion();
       }
       program = new Program(IDL, this.nttId, { connection: this.connection });

--- a/wormhole-connect/src/routes/ntt/utils.ts
+++ b/wormhole-connect/src/routes/ntt/utils.ts
@@ -43,3 +43,19 @@ export const encodeTransceiverInstructions = (
 
   return Buffer.concat([instructionsLength, encoded]);
 };
+
+// Checks for compatibility between the NTT Manager version in use on chain,
+// and the ABI version Connect has. Major version must match, minor version on chain
+// should be gte Connect's ABI version.
+//
+// For example, if the contract is using 1.1.0, we would use 1.0.0 but not 1.2.0.
+export const abiVersionMatches = (
+  targetVersion: string,
+  abiVersion: string,
+): boolean => {
+  let [majorTarget, minorTarget] = targetVersion
+    .split('.')
+    .map((n) => parseInt(n, 10));
+  let [majorAbi, minorAbi] = abiVersion.split('.').map((n) => parseInt(n, 10));
+  return majorTarget == majorAbi && minorTarget >= minorAbi;
+};

--- a/wormhole-connect/src/routes/ntt/utils.ts
+++ b/wormhole-connect/src/routes/ntt/utils.ts
@@ -53,9 +53,11 @@ export const abiVersionMatches = (
   targetVersion: string,
   abiVersion: string,
 ): boolean => {
-  let [majorTarget, minorTarget] = targetVersion
+  const [majorTarget, minorTarget] = targetVersion
     .split('.')
     .map((n) => parseInt(n, 10));
-  let [majorAbi, minorAbi] = abiVersion.split('.').map((n) => parseInt(n, 10));
+  const [majorAbi, minorAbi] = abiVersion
+    .split('.')
+    .map((n) => parseInt(n, 10));
   return majorTarget == majorAbi && minorTarget >= minorAbi;
 };

--- a/wormhole-connect/tests/ci/ntt.test.ts
+++ b/wormhole-connect/tests/ci/ntt.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+import { abiVersionMatches } from 'routes/ntt/utils';
+
+describe('NTT ABI version matching', () => {
+  test('should return true if major versions match and target minor version is greater, ignoring patch version', () => {
+    expect(abiVersionMatches('1.1.0', '1.0.0')).toBeTruthy();
+  });
+
+  test('should return true if major, minor, and patch versions match exactly', () => {
+    expect(abiVersionMatches('1.0.0', '1.0.0')).toBeTruthy();
+  });
+
+  test('should return false if major versions do not match, ignoring minor and patch versions', () => {
+    expect(abiVersionMatches('1.0.0', '2.0.0')).toBeFalsy();
+  });
+
+  test('should return false if major versions match but target minor version is less, ignoring patch version', () => {
+    expect(abiVersionMatches('1.0.0', '1.1.0')).toBeFalsy();
+  });
+
+  test('should handle versions with more than one digit correctly, ignoring patch version', () => {
+    expect(abiVersionMatches('10.20.0', '10.15.5')).toBeTruthy();
+  });
+
+  test('should return false if any version is not in correct format', () => {
+    expect(abiVersionMatches('1..0.0', '2.0.0')).toBeFalsy();
+    expect(abiVersionMatches('1.0.0', '2..0.0')).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This change will make it so Connect uses an older ABI with matching major version for a given NTT deployment version. For example, a `1.0.0` ABI could be used for a `1.1.0` NTT deployment. @kcsongor and I agreed to treat minor version bumps as non-breaking, for the purposes of Connect.