### PR TITLE
add ntt support for multisign wallet SquadX

### DIFF
--- a/wormhole-connect/src/routes/ntt/chains/index.ts
+++ b/wormhole-connect/src/routes/ntt/chains/index.ts
@@ -3,15 +3,20 @@ import { isEvmChain, toChainName } from 'utils/sdk';
 import { NttManagerEvm } from './evm';
 import { NttManagerSolana } from './solana';
 
+export type NttFactoryOptions = {
+  multiSignWallet: boolean;
+};
+
 export const getNttManager = (
   chain: ChainName | ChainId,
   nttManagerAddress: string,
+  options: NttFactoryOptions = { multiSignWallet: false },
 ) => {
   if (isEvmChain(chain)) {
     return new NttManagerEvm(chain, nttManagerAddress);
   }
   if (toChainName(chain) === 'solana') {
-    return new NttManagerSolana(nttManagerAddress);
+    return new NttManagerSolana(nttManagerAddress, options.multiSignWallet);
   }
   throw new Error(`Unsupported chain: ${chain}`);
 };

--- a/wormhole-connect/src/routes/ntt/nttBase.ts
+++ b/wormhole-connect/src/routes/ntt/nttBase.ts
@@ -47,6 +47,11 @@ import {
   isNttToken,
   isNttTokenPair,
 } from 'utils/ntt';
+import {
+  TransferWallet,
+  getWalletConnection,
+  isMultiSignWallet,
+} from 'utils/wallet';
 
 export abstract class NttBase extends BaseRoute {
   isSupportedChain(chain: ChainName): boolean {
@@ -232,7 +237,12 @@ export abstract class NttBase extends BaseRoute {
     }
     const nttManagerAddress = getNttManagerAddress(tokenConfig, nttGroupKey);
     if (!nttManagerAddress) throw new Error('ntt manager not found');
-    const nttManager = getNttManager(sendingChain, nttManagerAddress);
+    const multiSignWallet = isMultiSignWallet(
+      getWalletConnection(TransferWallet.SENDING),
+    );
+    const nttManager = getNttManager(sendingChain, nttManagerAddress, {
+      multiSignWallet,
+    });
     if (await nttManager.isPaused()) {
       throw new ContractIsPausedError();
     }

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -154,6 +154,9 @@ export const getWalletConnection = (type: TransferWallet) => {
   return walletConnection[type];
 };
 
+export const isMultiSignWallet = (wallet?: Wallet): boolean =>
+  !!(wallet && ['SquadsX'].includes(wallet.getName()));
+
 export const swapWalletConnections = () => {
   const temp = walletConnection.sending;
   walletConnection.sending = walletConnection.receiving;


### PR DESCRIPTION
Scenarios:

- Send W token from a Solana Squad wallet to any other NTT-supported chain.
- Receive W token in a Solana Squad wallet from any other NTT-supported chain.