### PR TITLE
[Redesign] Network and token asset pickers

### DIFF
--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 
@@ -23,6 +23,8 @@ import { clearPorticoBridge } from 'store/porticoBridge';
 import { useExternalSearch } from 'hooks/useExternalSearch';
 import { clearNtt } from 'store/ntt';
 import internalConfig from 'config';
+
+import BridgeV2 from 'views/v2/Bridge';
 
 const useStyles = makeStyles()((theme: any) => ({
   appContent: {
@@ -96,10 +98,14 @@ function AppRouter(props: Props) {
     }
   }, [hasExternalSearch, dispatch]);
 
+  const bridge = useMemo(() => {
+    return props.config?.useRedesign ? <BridgeV2 /> : <Bridge />;
+  }, [props.config?.useRedesign]);
+
   return (
     <div className={classes.appContent}>
       {showWalletModal && <WalletModal type={showWalletModal} />}
-      {route === 'bridge' && <Bridge />}
+      {route === 'bridge' && bridge}
       {route === 'redeem' && <Redeem />}
       {route === 'search' && <TxSearch />}
       {route === 'terms' && <Terms />}

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -160,6 +160,9 @@ export function buildConfig(
 
     // Guardian Set
     guardianSet: networkData.guardianSet,
+
+    // Render Redesign views
+    useRedesign: customConfig?.useRedesign,
   };
 }
 

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -149,6 +149,9 @@ export interface WormholeConnectConfig {
 
   // NTT config
   nttGroups?: NttGroups;
+
+  // Override to load Redesign
+  useRedesign?: boolean;
 }
 
 // This is the exported config value used throughout the code base
@@ -209,6 +212,9 @@ export interface InternalConfig {
   // NTT config
   nttGroups: NttGroups;
   guardianSet: GuardianSetData;
+
+  // Redesign flag
+  useRedesign?: boolean;
 }
 
 export type ExplorerConfig = {

--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -23,12 +23,11 @@ type Props = {
   sourceChain: ChainName | undefined;
   sourceToken: string;
   destChain: ChainName | undefined;
-  destToken: string;
   route: Route | undefined;
 };
 
 export const useComputeDestinationTokens = (props: Props): void => {
-  const { sourceChain, destChain, sourceToken, destToken, route } = props;
+  const { sourceChain, destChain, sourceToken, route } = props;
 
   const dispatch = useDispatch();
 
@@ -89,12 +88,7 @@ export const useComputeDestinationTokens = (props: Props): void => {
 
       // If the source token is supported by a Portico bridge route,
       // then select the native version on the dest chain
-      if (
-        sourceToken &&
-        destToken === '' &&
-        destChain &&
-        (!route || isPorticoRoute(route))
-      ) {
+      if (sourceToken && destChain && (!route || isPorticoRoute(route))) {
         const tokenSymbol = config.tokens[sourceToken]?.symbol;
         const porticoTokens = [
           ...ETHBridge.SUPPORTED_TOKENS,
@@ -120,6 +114,5 @@ export const useComputeDestinationTokens = (props: Props): void => {
     return () => {
       canceled = true;
     };
-    // IMPORTANT: do not include destToken in dependency array
   }, [route, sourceToken, sourceChain, destChain, dispatch]);
 };

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -109,7 +109,6 @@ function Bridge() {
     sourceChain: fromChain,
     destChain: toChain,
     sourceToken: token,
-    destToken,
     route,
   });
 

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -15,14 +15,11 @@ import AddIcon from '@mui/icons-material/Add';
 import SearchIcon from '@mui/icons-material/Search';
 import TokenIcon from 'icons/TokenIcons';
 
-import config from 'config';
-
 import { makeStyles } from 'tss-react/mui';
 
 import { isDisabledChain, selectChain } from 'store/transferInput';
 
 import type { ChainConfig } from 'config/types';
-import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import type { WalletData } from 'store/wallet';
 
 const useStyles = makeStyles()((theme) => ({
@@ -40,7 +37,7 @@ const useStyles = makeStyles()((theme) => ({
 
 type Props = {
   chainList?: Array<ChainConfig> | undefined;
-  selectedChain?: ChainName | undefined;
+  selectedChainConfig?: ChainConfig | undefined;
   showSearch: boolean;
   setShowSearch: any;
   wallet: WalletData;
@@ -54,27 +51,22 @@ const ChainList = (props: Props) => {
 
   const { classes } = useStyles();
 
-  // Gets the config for the currently selected chain
-  const selectedChainConfig = useMemo(() => {
-    return props.selectedChain ? config.chains[props.selectedChain] : undefined;
-  }, [props.selectedChain]);
-
   const topChains = useMemo(() => {
     // Put the selected chain at the top of the list
-    const chains: Array<ChainConfig> = selectedChainConfig
-      ? [selectedChainConfig]
+    const chains: Array<ChainConfig> = props.selectedChainConfig
+      ? [props.selectedChainConfig]
       : [];
 
     props.chainList?.forEach((c) => {
       if (
         chains.length < SHORT_LIST_SIZE &&
-        c.key !== selectedChainConfig?.key
+        c.key !== props.selectedChainConfig?.key
       ) {
         chains.push(c);
       }
     });
     return chains;
-  }, [props.chainList, selectedChainConfig]);
+  }, [props.chainList, props.selectedChainConfig]);
 
   const shortList = useMemo(() => {
     return (
@@ -90,7 +82,7 @@ const ChainList = (props: Props) => {
             <ListItemButton
               key={i}
               disabled={disabled}
-              selected={props.selectedChain === chain.key}
+              selected={props.selectedChainConfig?.key === chain.key}
               sx={{
                 display: 'flex',
                 flexDirection: 'column',
@@ -187,7 +179,9 @@ const ChainList = (props: Props) => {
   return (
     <Card className={classes.card} variant="elevation">
       <CardContent className={classes.cardContent}>
-        <Typography className={classes.title}>Select a network</Typography>
+        <Typography className={classes.title} fontSize={14}>
+          Select a network
+        </Typography>
         {props.showSearch ? searchList : shortList}
       </CardContent>
     </Card>

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -19,7 +19,7 @@ import config from 'config';
 
 import { makeStyles } from 'tss-react/mui';
 
-import { isDisabledChain } from 'store/transferInput';
+import { isDisabledChain, selectChain } from 'store/transferInput';
 
 import type { ChainConfig } from 'config/types';
 import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
@@ -29,27 +29,8 @@ const useStyles = makeStyles()((theme) => ({
   card: {
     width: '420px',
   },
-  chainItem: {
-    display: 'flex',
-    alignItems: 'center',
-    width: '100%',
-    transition: 'background-color 0.4s',
-    cursor: 'pointer',
-    marginTop: '4px',
-  },
-  chainTile: {
-    width: '32px',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    transition: 'background-color 0.4s',
-    cursor: 'pointer',
-  },
-  disabled: {
-    opacity: '40%',
-    cursor: 'not-allowed',
-    clickEvent: 'none',
+  cardContent: {
+    paddingBottom: 0,
   },
   title: {
     fontSize: 14,
@@ -60,31 +41,35 @@ const useStyles = makeStyles()((theme) => ({
 type Props = {
   chainList?: Array<ChainConfig> | undefined;
   selectedChain?: ChainName | undefined;
+  showSearch: boolean;
+  onShowSearch: any;
   wallet: WalletData;
   onClick?: any;
 };
 
 const ChainList = (props: Props) => {
-  const [showSearch, setShowSearch] = useState(false);
   const [chainSearchQuery, setChainSearchQuery] = useState('');
 
   const { classes } = useStyles();
 
+  // Gets the config for the currently selected chain
+  const selectedChainConfig = useMemo(() => {
+    return props.selectedChain ? config.chains[props.selectedChain] : undefined;
+  }, [props.selectedChain]);
+
   const topChains = useMemo(() => {
-    const { selectedChain } = props;
-    const selectedChainConfig = selectedChain
-      ? config.chains[selectedChain]
-      : undefined;
+    // Put the selected chain at the top of the list
     const chains: Array<ChainConfig> = selectedChainConfig
       ? [selectedChainConfig]
       : [];
+
     props.chainList?.forEach((c) => {
       if (chains.length < 6 && c.key !== selectedChainConfig?.key) {
         chains.push(c);
       }
     });
     return chains;
-  }, [props.chainList]);
+  }, [props.chainList, selectedChainConfig]);
 
   const shortList = useMemo(() => {
     return (
@@ -108,7 +93,7 @@ const ChainList = (props: Props) => {
               onClick={() => props.onClick?.(chain.key)}
             >
               <TokenIcon icon={chain.icon} height={32} />
-              <Typography fontSize={12}>{chain.displayName}</Typography>
+              <Typography fontSize={14}>{chain.displayName}</Typography>
             </ListItemButton>
           );
         })}
@@ -118,7 +103,7 @@ const ChainList = (props: Props) => {
             flexDirection: 'column',
           }}
           onClick={() => {
-            setShowSearch(true);
+            props.onShowSearch(true);
           }}
         >
           <IconButton
@@ -134,7 +119,7 @@ const ChainList = (props: Props) => {
         </ListItemButton>
       </List>
     );
-  }, [topChains]);
+  }, [topChains, selectChain]);
 
   const searchList = useMemo(() => {
     const chains = chainSearchQuery
@@ -180,13 +165,13 @@ const ChainList = (props: Props) => {
               }}
               onClick={() => {
                 props.onClick?.(chain.key);
-                setShowSearch(false);
+                props.onShowSearch?.(false);
               }}
             >
               <ListItemIcon>
                 <TokenIcon icon={chain.icon} height={32} />
               </ListItemIcon>
-              <Typography fontSize={12}>{chain.displayName}</Typography>
+              <Typography fontSize={14}>{chain.displayName}</Typography>
             </ListItemButton>
           );
         })}
@@ -196,9 +181,9 @@ const ChainList = (props: Props) => {
 
   return (
     <Card className={classes.card} variant="elevation">
-      <CardContent>
+      <CardContent className={classes.cardContent}>
         <Typography className={classes.title}>Select a network</Typography>
-        {showSearch ? searchList : shortList}
+        {props.showSearch ? searchList : shortList}
       </CardContent>
     </Card>
   );

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -1,0 +1,207 @@
+import React, { useMemo, useState } from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import IconButton from '@mui/material/IconButton';
+import InputAdornment from '@mui/material/InputAdornment';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+
+import AddIcon from '@mui/icons-material/Add';
+import SearchIcon from '@mui/icons-material/Search';
+import TokenIcon from 'icons/TokenIcons';
+
+import config from 'config';
+
+import { makeStyles } from 'tss-react/mui';
+
+import { isDisabledChain } from 'store/transferInput';
+
+import type { ChainConfig } from 'config/types';
+import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import type { WalletData } from 'store/wallet';
+
+const useStyles = makeStyles()((theme) => ({
+  card: {
+    width: '420px',
+  },
+  chainItem: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    transition: 'background-color 0.4s',
+    cursor: 'pointer',
+    marginTop: '4px',
+  },
+  chainTile: {
+    width: '32px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+    transition: 'background-color 0.4s',
+    cursor: 'pointer',
+  },
+  disabled: {
+    opacity: '40%',
+    cursor: 'not-allowed',
+    clickEvent: 'none',
+  },
+  title: {
+    fontSize: 14,
+    marginBottom: '8px',
+  },
+}));
+
+type Props = {
+  chainList?: Array<ChainConfig> | undefined;
+  selectedChain?: ChainName | undefined;
+  wallet: WalletData;
+  onClick?: any;
+};
+
+const ChainList = (props: Props) => {
+  const [showSearch, setShowSearch] = useState(false);
+  const [chainSearchQuery, setChainSearchQuery] = useState('');
+
+  const { classes } = useStyles();
+
+  const topChains = useMemo(() => {
+    const { selectedChain } = props;
+    const selectedChainConfig = selectedChain
+      ? config.chains[selectedChain]
+      : undefined;
+    const chains: Array<ChainConfig> = selectedChainConfig
+      ? [selectedChainConfig]
+      : [];
+    props.chainList?.forEach((c) => {
+      if (chains.length < 6 && c.key !== selectedChainConfig?.key) {
+        chains.push(c);
+      }
+    });
+    return chains;
+  }, [props.chainList]);
+
+  const shortList = useMemo(() => {
+    return (
+      <List component={Stack} direction="row">
+        {topChains.map((chain: ChainConfig, i: number) => {
+          if (React.isValidElement(chain)) {
+            return chain;
+          }
+
+          const disabled = isDisabledChain(chain.key, props.wallet);
+
+          return (
+            <ListItemButton
+              key={i}
+              disabled={disabled}
+              selected={props.selectedChain === chain.key}
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+              }}
+              onClick={() => props.onClick?.(chain.key)}
+            >
+              <TokenIcon icon={chain.icon} height={32} />
+              <Typography fontSize={12}>{chain.displayName}</Typography>
+            </ListItemButton>
+          );
+        })}
+        <ListItemButton
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+          onClick={() => {
+            setShowSearch(true);
+          }}
+        >
+          <IconButton
+            sx={{
+              width: 32,
+              height: 32,
+              backgroundColor: 'transparent',
+            }}
+          >
+            <AddIcon />
+          </IconButton>
+          <Typography fontSize={12}>other</Typography>
+        </ListItemButton>
+      </List>
+    );
+  }, [topChains]);
+
+  const searchList = useMemo(() => {
+    const chains = chainSearchQuery
+      ? props.chainList?.filter((c: any) => {
+          return c.displayName
+            ?.toLowerCase()
+            .includes(chainSearchQuery.toLowerCase());
+        })
+      : topChains;
+
+    return (
+      <List>
+        <ListItem>
+          <TextField
+            fullWidth
+            inputProps={{
+              style: {
+                fontSize: 12,
+              },
+            }}
+            placeholder="Search for a network"
+            size="small"
+            variant="outlined"
+            onChange={(e) => setChainSearchQuery(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </ListItem>
+        {chains?.map((chain: any, i: number) => {
+          const disabled = isDisabledChain(chain.key, props.wallet);
+          return (
+            <ListItemButton
+              dense
+              disabled={disabled}
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+              onClick={() => {
+                props.onClick?.(chain.key);
+                setShowSearch(false);
+              }}
+            >
+              <ListItemIcon>
+                <TokenIcon icon={chain.icon} height={32} />
+              </ListItemIcon>
+              <Typography fontSize={12}>{chain.displayName}</Typography>
+            </ListItemButton>
+          );
+        })}
+      </List>
+    );
+  }, [chainSearchQuery, topChains]);
+
+  return (
+    <Card className={classes.card} variant="elevation">
+      <CardContent>
+        <Typography className={classes.title}>Select a network</Typography>
+        {showSearch ? searchList : shortList}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ChainList;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -42,10 +42,12 @@ type Props = {
   chainList?: Array<ChainConfig> | undefined;
   selectedChain?: ChainName | undefined;
   showSearch: boolean;
-  onShowSearch: any;
+  setShowSearch: any;
   wallet: WalletData;
   onClick?: any;
 };
+
+const SHORT_LIST_SIZE = 5;
 
 const ChainList = (props: Props) => {
   const [chainSearchQuery, setChainSearchQuery] = useState('');
@@ -64,7 +66,10 @@ const ChainList = (props: Props) => {
       : [];
 
     props.chainList?.forEach((c) => {
-      if (chains.length < 6 && c.key !== selectedChainConfig?.key) {
+      if (
+        chains.length < SHORT_LIST_SIZE &&
+        c.key !== selectedChainConfig?.key
+      ) {
         chains.push(c);
       }
     });
@@ -103,7 +108,7 @@ const ChainList = (props: Props) => {
             flexDirection: 'column',
           }}
           onClick={() => {
-            props.onShowSearch(true);
+            props.setShowSearch?.(true);
           }}
         >
           <IconButton
@@ -165,7 +170,7 @@ const ChainList = (props: Props) => {
               }}
               onClick={() => {
                 props.onClick?.(chain.key);
-                props.onShowSearch?.(false);
+                props.setShowSearch?.(false);
               }}
             >
               <ListItemIcon>

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -52,20 +52,28 @@ const ChainList = (props: Props) => {
   const { classes } = useStyles();
 
   const topChains = useMemo(() => {
-    // Put the selected chain at the top of the list
-    const chains: Array<ChainConfig> = props.selectedChainConfig
-      ? [props.selectedChainConfig]
-      : [];
+    const chains: Array<ChainConfig> = [];
+    const { chainList = [] } = props;
 
-    props.chainList?.forEach((c) => {
-      if (
-        chains.length < SHORT_LIST_SIZE &&
-        c.key !== props.selectedChainConfig?.key
-      ) {
-        chains.push(c);
-      }
+    // Find the selected chain in supported chains
+    const selectedChainIndex = props.chainList?.findIndex((c) => {
+      return c.key === props.selectedChainConfig?.key;
     });
-    return chains;
+
+    // If the selected chain is outside the top list, we add it to the top;
+    // otherwise we do not change its index in the top list
+    if (
+      props.selectedChainConfig &&
+      selectedChainIndex &&
+      selectedChainIndex >= SHORT_LIST_SIZE
+    ) {
+      return chains.concat(
+        [props.selectedChainConfig],
+        chainList.slice(0, SHORT_LIST_SIZE - 1),
+      );
+    }
+
+    return chains.concat(chainList.slice(0, SHORT_LIST_SIZE));
   }, [props.chainList, props.selectedChainConfig]);
 
   const shortList = useMemo(() => {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -41,6 +41,8 @@ type Props = {
   onClick?: any;
 };
 
+const SHORT_LIST_SIZE = 5;
+
 const TokenList = (props: Props) => {
   const [tokenSearchQuery, setTokenSearchQuery] = useState('');
 
@@ -57,7 +59,10 @@ const TokenList = (props: Props) => {
       ? [selectedTokenConfig]
       : [];
     props.tokenList?.forEach((t) => {
-      if (tokens.length < 6 && t.key !== selectedTokenConfig?.key) {
+      if (
+        tokens.length < SHORT_LIST_SIZE &&
+        t.key !== selectedTokenConfig?.key
+      ) {
         tokens.push(t);
       }
     });

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -1,0 +1,135 @@
+import React, { useMemo, useState } from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import InputAdornment from '@mui/material/InputAdornment';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import Typography from '@mui/material/Typography';
+import TextField from '@mui/material/TextField';
+
+import SearchIcon from '@mui/icons-material/Search';
+import TokenIcon from 'icons/TokenIcons';
+
+import config from 'config';
+
+import { makeStyles } from 'tss-react/mui';
+
+import type { TokenConfig } from 'config/types';
+import type { WalletData } from 'store/wallet';
+
+const useStyles = makeStyles()((theme) => ({
+  card: {
+    width: '420px',
+  },
+  cardContent: {
+    paddingTop: 0,
+  },
+  title: {
+    fontSize: 14,
+    marginBottom: '8px',
+  },
+}));
+
+type Props = {
+  tokenList?: Array<TokenConfig> | undefined;
+  selectedToken?: string | undefined;
+  wallet: WalletData;
+  onClick?: any;
+};
+
+const TokenList = (props: Props) => {
+  const [tokenSearchQuery, setTokenSearchQuery] = useState('');
+
+  const { classes } = useStyles();
+
+  const topTokens = useMemo(() => {
+    const { selectedToken } = props;
+    const selectedTokenConfig = selectedToken
+      ? config.tokens[selectedToken]
+      : undefined;
+    const tokens: Array<TokenConfig> = selectedTokenConfig
+      ? [selectedTokenConfig]
+      : [];
+    props.tokenList?.forEach((t) => {
+      if (tokens.length < 6 && t.key !== selectedTokenConfig?.key) {
+        tokens.push(t);
+      }
+    });
+    return tokens;
+  }, [props.tokenList]);
+
+  const searchList = useMemo(() => {
+    const tokens = tokenSearchQuery
+      ? props.tokenList?.filter((t: TokenConfig) => {
+          const query = tokenSearchQuery.toLowerCase();
+          return (
+            t.symbol?.toLowerCase().includes(query) ||
+            t.displayName?.toLowerCase().includes(query)
+          );
+        })
+      : topTokens;
+
+    return (
+      <List>
+        <ListItem>
+          <TextField
+            fullWidth
+            inputProps={{
+              style: {
+                fontSize: 12,
+              },
+            }}
+            placeholder="Search for a token"
+            size="small"
+            variant="outlined"
+            onChange={(e) => setTokenSearchQuery(e.target.value)}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
+        </ListItem>
+        {tokens?.map((token: TokenConfig, i: number) => {
+          const nativeChainConfig = config.chains[token.nativeChain];
+          const nativeChain = nativeChainConfig?.displayName || '';
+          return (
+            <ListItemButton
+              dense
+              sx={{
+                display: 'flex',
+                flexDirection: 'row',
+              }}
+              onClick={() => {
+                props.onClick?.(token.key);
+              }}
+            >
+              <ListItemIcon>
+                <TokenIcon icon={token.icon} height={32} />
+              </ListItemIcon>
+              <div>
+                <Typography fontSize={16}>{token.symbol}</Typography>
+                <Typography fontSize={10}>{nativeChain}</Typography>
+              </div>
+            </ListItemButton>
+          );
+        })}
+      </List>
+    );
+  }, [tokenSearchQuery, topTokens]);
+
+  return (
+    <Card className={classes.card} variant="elevation">
+      <CardContent className={classes.cardContent}>
+        <Typography className={classes.title}>Select a token</Typography>
+        {searchList}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TokenList;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from 'react';
+import { useTheme } from '@mui/material';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -16,7 +17,7 @@ import config from 'config';
 
 import { makeStyles } from 'tss-react/mui';
 
-import type { TokenConfig } from 'config/types';
+import type { ChainConfig, TokenConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
 
 const useStyles = makeStyles()((theme) => ({
@@ -34,6 +35,7 @@ const useStyles = makeStyles()((theme) => ({
 
 type Props = {
   tokenList?: Array<TokenConfig> | undefined;
+  selectedChainConfig?: ChainConfig | undefined;
   selectedToken?: string | undefined;
   wallet: WalletData;
   onClick?: any;
@@ -43,6 +45,8 @@ const TokenList = (props: Props) => {
   const [tokenSearchQuery, setTokenSearchQuery] = useState('');
 
   const { classes } = useStyles();
+
+  const theme = useTheme();
 
   const topTokens = useMemo(() => {
     const { selectedToken } = props;
@@ -94,6 +98,14 @@ const TokenList = (props: Props) => {
             }}
           />
         </ListItem>
+        {props.selectedChainConfig && (
+          <ListItem>
+            <Typography
+              fontSize={14}
+              color={theme.palette.text.secondary}
+            >{`Tokens on ${props.selectedChainConfig.displayName}`}</Typography>
+          </ListItem>
+        )}
         {tokens?.map((token: TokenConfig, i: number) => {
           const nativeChainConfig = config.chains[token.nativeChain];
           const nativeChain = nativeChainConfig?.displayName || '';

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -144,7 +144,7 @@ const AssetPicker = (props: Props) => {
       <Popover
         {...bindPopover(popupState)}
         anchorOrigin={{
-          vertical: 'bottom',
+          vertical: 'top',
           horizontal: 'center',
         }}
         className={classes.container}
@@ -155,7 +155,7 @@ const AssetPicker = (props: Props) => {
       >
         <ChainList
           chainList={props.chainList}
-          selectedChain={props.chain}
+          selectedChainConfig={chainConfig}
           showSearch={showChainSearch}
           setShowSearch={setShowChainSearch}
           wallet={props.wallet}
@@ -166,6 +166,7 @@ const AssetPicker = (props: Props) => {
         {!showChainSearch && (
           <TokenList
             tokenList={props.tokenList}
+            selectedChainConfig={chainConfig}
             selectedToken={props.token}
             wallet={props.wallet}
             onClick={(key: string) => {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
 import Badge from '@mui/material/Badge';
 import Card from '@mui/material/Card';
@@ -17,6 +17,7 @@ import type { ChainConfig, TokenConfig } from 'config/types';
 import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import type { WalletData } from 'store/wallet';
 import ChainList from './ChainList';
+import TokenList from './TokenList';
 
 const useStyles = makeStyles()((theme) => ({
   container: {
@@ -25,24 +26,13 @@ const useStyles = makeStyles()((theme) => ({
   card: {
     width: '100%',
     cursor: 'pointer',
-    maxHeight: '72px',
+    maxHeight: '80px',
     maxWidth: '420px',
   },
   cardContent: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  chainTile: {
-    width: '50px',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    textAlign: 'center',
-    margin: '4px',
-    padding: '4px',
-    transition: 'background-color 0.4s',
-    cursor: 'pointer',
   },
   chainSelector: {
     display: 'flex',
@@ -67,6 +57,7 @@ type Props = {
 };
 
 const AssetPicker = (props: Props) => {
+  const [showChainSearch, setShowChainSearch] = useState(false);
   const { classes } = useStyles();
 
   const chainConfig: ChainConfig | undefined = useMemo(() => {
@@ -84,8 +75,8 @@ const AssetPicker = (props: Props) => {
         sx={{
           marginRight: '8px',
           '& .MuiBadge-badge': {
-            right: 4,
-            top: 32,
+            right: 2,
+            top: 36,
           },
         }}
       >
@@ -96,13 +87,17 @@ const AssetPicker = (props: Props) => {
 
   const selection = useMemo(() => {
     if (!chainConfig && !tokenConfig) {
-      return <Typography component={'div'}>Select chain and token</Typography>;
+      return (
+        <Typography component={'div'} fontSize={16}>
+          Select chain and token
+        </Typography>
+      );
     }
 
     return (
       <div>
         <Typography component={'div'} fontSize={16}>
-          {tokenConfig?.displayName || 'Select token'}
+          {tokenConfig?.symbol || 'Select token'}
         </Typography>
         <Typography component={'div'} fontSize={12}>
           {chainConfig?.displayName}
@@ -147,12 +142,24 @@ const AssetPicker = (props: Props) => {
             <ChainList
               chainList={props.chainList}
               selectedChain={props.chain}
+              showSearch={showChainSearch}
               wallet={props.wallet}
+              onShowSearch={setShowChainSearch}
               onClick={(key: string) => {
                 props.setChain(key);
-                popupState.close();
               }}
             />
+            {!showChainSearch && (
+              <TokenList
+                tokenList={props.tokenList}
+                selectedToken={props.token}
+                wallet={props.wallet}
+                onClick={(key: string) => {
+                  props.setToken(key);
+                  popupState.close();
+                }}
+              />
+            )}
           </Popover>
         </React.Fragment>
       )}

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -1,0 +1,147 @@
+import React, { useMemo } from 'react';
+import { makeStyles } from 'tss-react/mui';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Popover from '@mui/material/Popover';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+import Typography from '@mui/material/Typography';
+
+import DownIcon from '@mui/icons-material/ExpandMore';
+import UpIcon from '@mui/icons-material/ExpandLess';
+
+import config from 'config';
+import TokenIcon from 'icons/TokenIcons';
+
+import type { ChainConfig, TokenConfig } from 'config/types';
+import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import type { WalletData } from 'store/wallet';
+import ChainList from './ChainList';
+
+const useStyles = makeStyles()((theme) => ({
+  container: {
+    marginTop: '4px',
+  },
+  card: {
+    width: '100%',
+    cursor: 'pointer',
+    maxHeight: '72px',
+    maxWidth: '420px',
+  },
+  cardContent: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  chainTile: {
+    width: '50px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+    margin: '4px',
+    padding: '4px',
+    transition: 'background-color 0.4s',
+    cursor: 'pointer',
+  },
+  chainSelector: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  disabled: {
+    opacity: '40%',
+    cursor: 'not-allowed',
+    clickEvent: 'none',
+  },
+}));
+
+type Props = {
+  chain?: ChainName | undefined;
+  chainList?: Array<ChainConfig> | undefined;
+  token?: string;
+  tokenList?: Array<TokenConfig> | undefined;
+  setToken: Function;
+  setChain: Function;
+  wallet: WalletData;
+};
+
+const AssetPicker = (props: Props) => {
+  const { classes } = useStyles();
+
+  const chainConfig: ChainConfig | undefined = useMemo(() => {
+    return props.chain && config.chains[props.chain];
+  }, [props.chain]);
+
+  const selection = useMemo(() => {
+    const { chain, token } = props;
+
+    const tokenConfig = token && config.tokens[token];
+
+    if (!chain) {
+      return 'Select chain and token';
+    }
+
+    if (!token) {
+      <Typography component={'div'}>{chain}</Typography>;
+    }
+
+    return (
+      <React.Fragment>
+        <Typography component={'div'}>
+          {tokenConfig && tokenConfig.symbol}
+        </Typography>
+        <Typography component={'div'}>{chain}</Typography>
+      </React.Fragment>
+    );
+  }, [props.chain, props.token]);
+
+  return (
+    <PopupState variant="popover" popupId="demo-popup-menu">
+      {(popupState: any) => (
+        <React.Fragment>
+          <Card
+            className={classes.card}
+            variant="elevation"
+            {...bindTrigger(popupState)}
+          >
+            <CardContent className={classes.cardContent}>
+              <Typography
+                className={classes.chainSelector}
+                component={'div'}
+                gap={1}
+              >
+                <TokenIcon icon={chainConfig?.icon} height={36} />
+                {selection}
+              </Typography>
+              {popupState.isOpen ? <UpIcon /> : <DownIcon />}
+            </CardContent>
+          </Card>
+          <Popover
+            {...bindPopover(popupState)}
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'center',
+            }}
+            className={classes.container}
+            transformOrigin={{
+              vertical: 'top',
+              horizontal: 'center',
+            }}
+          >
+            <ChainList
+              chainList={props.chainList}
+              selectedChain={props.chain}
+              wallet={props.wallet}
+              onClick={(key: string) => {
+                props.setChain(key);
+                popupState.close();
+              }}
+            />
+          </Popover>
+        </React.Fragment>
+      )}
+    </PopupState>
+  );
+};
+
+export default AssetPicker;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -69,29 +69,27 @@ const AssetPicker = (props: Props) => {
   const { classes } = useStyles();
 
   const chainConfig: ChainConfig | undefined = useMemo(() => {
-    return props.chain && config.chains[props.chain];
+    return props.chain ? config.chains[props.chain] : undefined;
   }, [props.chain]);
 
+  const tokenConfig: TokenConfig | undefined = useMemo(() => {
+    return props.token ? config.tokens[props.token] : undefined;
+  }, [props.token]);
+
   const selection = useMemo(() => {
-    const { chain, token } = props;
-
-    const tokenConfig = token && config.tokens[token];
-
-    if (!chain) {
-      return 'Select chain and token';
-    }
-
-    if (!token) {
-      <Typography component={'div'}>{chain}</Typography>;
+    if (!chainConfig && !tokenConfig) {
+      return <Typography component={'div'}>Select chain and token</Typography>;
     }
 
     return (
-      <React.Fragment>
-        <Typography component={'div'}>
-          {tokenConfig && tokenConfig.symbol}
+      <div>
+        <Typography component={'div'} fontSize={16}>
+          {tokenConfig?.displayName || 'Select token'}
         </Typography>
-        <Typography component={'div'}>{chain}</Typography>
-      </React.Fragment>
+        <Typography component={'div'} fontSize={12}>
+          {chainConfig?.displayName}
+        </Typography>
+      </div>
     );
   }, [props.chain, props.token]);
 
@@ -110,7 +108,8 @@ const AssetPicker = (props: Props) => {
                 component={'div'}
                 gap={1}
               >
-                <TokenIcon icon={chainConfig?.icon} height={36} />
+                <TokenIcon icon={tokenConfig?.icon} height={48} />
+                <TokenIcon icon={chainConfig?.icon} height={24} />
                 {selection}
               </Typography>
               {popupState.isOpen ? <UpIcon /> : <DownIcon />}

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { makeStyles } from 'tss-react/mui';
+import Badge from '@mui/material/Badge';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Popover from '@mui/material/Popover';
@@ -76,6 +77,23 @@ const AssetPicker = (props: Props) => {
     return props.token ? config.tokens[props.token] : undefined;
   }, [props.token]);
 
+  const badges = useMemo(() => {
+    return (
+      <Badge
+        badgeContent={<TokenIcon icon={chainConfig?.icon} height={24} />}
+        sx={{
+          marginRight: '8px',
+          '& .MuiBadge-badge': {
+            right: 4,
+            top: 32,
+          },
+        }}
+      >
+        <TokenIcon icon={tokenConfig?.icon} height={48} />
+      </Badge>
+    );
+  }, [chainConfig, tokenConfig]);
+
   const selection = useMemo(() => {
     if (!chainConfig && !tokenConfig) {
       return <Typography component={'div'}>Select chain and token</Typography>;
@@ -108,8 +126,7 @@ const AssetPicker = (props: Props) => {
                 component={'div'}
                 gap={1}
               >
-                <TokenIcon icon={tokenConfig?.icon} height={48} />
-                <TokenIcon icon={chainConfig?.icon} height={24} />
+                {badges}
                 {selection}
               </Typography>
               {popupState.isOpen ? <UpIcon /> : <DownIcon />}

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useTheme } from '@mui/material/styles';
+import { makeStyles } from 'tss-react/mui';
+import { ScopedCssBaseline, Tooltip, useMediaQuery } from '@mui/material';
+
+import { RootState } from 'store';
+import { setWalletModal } from 'store/router';
+import { disconnectWallet as disconnectFromStore } from 'store/wallet';
+import { TransferWallet } from 'utils/wallet';
+import { copyTextToClipboard, displayWalletAddress } from 'utils';
+
+import DownIcon from 'icons/Down';
+import WalletIcons from 'icons/WalletIcons';
+import PopupState, { bindTrigger, bindPopover } from 'material-ui-popup-state';
+import Popover from '@mui/material/Popover';
+import config from 'config';
+import { TransferSide } from 'config/types';
+import { ExplorerConfig } from 'config/types';
+
+type StyleProps = { disabled?: boolean };
+const useStyles = makeStyles<StyleProps>()((theme: any, { disabled }) => ({
+  connectWallet: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: '8px',
+    padding: '8px 16px',
+    borderRadius: '8px',
+    backgroundColor: theme.palette.button.primary,
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    opacity: disabled ? 0.7 : 1.0,
+    margin: 'auto',
+    maxWidth: '420px',
+    width: '100%',
+  },
+  walletIcon: {
+    width: '24px',
+    height: '24px',
+  },
+  down: {
+    marginRight: '-8px',
+  },
+  dropdown: {
+    backgroundColor: theme.palette.popover.background,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '8px',
+    padding: '8px',
+  },
+  dropdownItem: {
+    borderRadius: '8px',
+    padding: '16px',
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.popover.secondary,
+    },
+  },
+}));
+
+type Props = {
+  side: TransferSide;
+  type: TransferWallet;
+  disabled?: boolean;
+};
+
+type ExplorerLinkProps = {
+  address: string;
+} & ExplorerConfig;
+
+function ExplorerLink({
+  address,
+  href,
+  target = '_blank',
+  label = 'Transactions',
+}: ExplorerLinkProps) {
+  const { classes } = useStyles({ disabled: false });
+  const handleOpenExplorer = () =>
+    window.open(href.replace('{:address}', address), target);
+  return (
+    <div className={classes.dropdownItem} onClick={handleOpenExplorer}>
+      {label}
+    </div>
+  );
+}
+
+function WalletConnector(props: Props) {
+  const { disabled = false, type } = props;
+  const { classes } = useStyles({ disabled });
+  const theme = useTheme();
+  const dispatch = useDispatch();
+  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const wallet = useSelector((state: RootState) => state.wallet[type]);
+
+  const connectWallet = async (popupState?: any) => {
+    if (disabled) return;
+    if (popupState) popupState.close();
+    dispatch(setWalletModal(type));
+  };
+
+  const copy = async (popupState: any) => {
+    await copyTextToClipboard(wallet.address);
+    popupState.close();
+  };
+
+  const disconnectWallet = async () => {
+    dispatch(disconnectFromStore(type));
+  };
+
+  if (wallet && wallet.address) {
+    return (
+      <PopupState variant="popover" popupId="demo-popup-popover">
+        {(popupState) => {
+          const { onClick: triggerPopup, ...boundProps } =
+            bindTrigger(popupState);
+
+          const onClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+            if (disabled) return;
+            triggerPopup(e);
+          };
+
+          return (
+            <div>
+              <div
+                className={classes.connectWallet}
+                onClick={onClick}
+                {...boundProps}
+              >
+                <WalletIcons
+                  name={wallet.name}
+                  icon={wallet.icon}
+                  height={24}
+                />
+                {displayWalletAddress(wallet.type, wallet.address)}
+                {!disabled && <DownIcon className={classes.down} />}
+              </div>
+              <Popover
+                {...bindPopover(popupState)}
+                sx={{ marginTop: 1 }}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'right',
+                }}
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+              >
+                <ScopedCssBaseline enableColorScheme>
+                  <div className={classes.dropdown}>
+                    <div
+                      className={classes.dropdownItem}
+                      onClick={() => copy(popupState)}
+                    >
+                      Copy address
+                    </div>
+                    {config.explorer ? (
+                      <ExplorerLink
+                        address={wallet.address}
+                        href={config.explorer.href}
+                        target={config.explorer.target}
+                        label={config.explorer.label}
+                      />
+                    ) : null}
+                    <div
+                      className={classes.dropdownItem}
+                      onClick={() => connectWallet(popupState)}
+                    >
+                      Change wallet
+                    </div>
+                    <div
+                      className={classes.dropdownItem}
+                      onClick={disconnectWallet}
+                    >
+                      Disconnect
+                    </div>
+                  </div>
+                </ScopedCssBaseline>
+              </Popover>
+            </div>
+          );
+        }}
+      </PopupState>
+    );
+  } else {
+    const button = (
+      <div
+        className={classes.connectWallet}
+        onClick={() => connectWallet()}
+        data-testid={`${props.side}-section-connect-wallet-button`}
+      >
+        <div>{mobile ? 'Connect' : 'Connect wallet'}</div>
+      </div>
+    );
+
+    if (disabled) {
+      return (
+        <Tooltip title={'Please select a network first'}>{button}</Tooltip>
+      );
+    } else {
+      return button;
+    }
+  }
+}
+
+export default WalletConnector;

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -1,0 +1,216 @@
+import React, { useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+import { useTheme } from '@mui/material';
+
+import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
+import type { RootState } from 'store';
+
+import RouteOperator from 'routes/operator';
+
+import config from 'config';
+import { joinClass } from 'utils/style';
+import PoweredByIcon from 'icons/PoweredBy';
+import PageHeader from 'components/PageHeader';
+import Header, { Alignment } from 'components/Header';
+import FooterNavBar from 'components/FooterNavBar';
+import { TransferWallet } from 'utils/wallet';
+import { useComputeDestinationTokens } from 'hooks/useComputeDestinationTokens';
+import { useComputeSourceTokens } from 'hooks/useComputeSourceTokens';
+import {
+  selectFromChain,
+  selectToChain,
+  setToken,
+  setDestToken,
+} from 'store/transferInput';
+import WalletConnector from './WalletConnector';
+import AssetPicker from './AssetPicker';
+
+const useStyles = makeStyles()((_theme) => ({
+  spacer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  bridgeContent: {
+    margin: 'auto',
+    maxWidth: '420px',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+  },
+  poweredBy: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    marginTop: '24px',
+  },
+}));
+
+const Bridge = () => {
+  const { classes } = useStyles();
+  const theme = useTheme();
+  const dispatch = useDispatch();
+
+  const receivingWallet = useSelector(
+    (state: RootState) => state.wallet.receiving,
+  );
+  const sendingWallet = useSelector((state: RootState) => state.wallet.sending);
+
+  const {
+    supportedSourceTokens,
+    supportedDestTokens,
+    fromChain: sourceChain,
+    toChain: destChain,
+    token: sourceToken,
+    destToken,
+    route,
+  } = useSelector((state: RootState) => state.transferInput);
+
+  // Compute and set source tokens
+  useComputeSourceTokens({
+    sourceChain,
+    destChain,
+    sourceToken,
+    destToken,
+    route,
+  });
+
+  // Compute and set destination tokens
+  useComputeDestinationTokens({
+    sourceChain,
+    destChain,
+    sourceToken,
+    route,
+  });
+
+  const supportedChains = useMemo(
+    () => RouteOperator.allSupportedChains(),
+    [config.chainsArr],
+  );
+
+  const supportedSourceChains = useMemo(() => {
+    return config.chainsArr.filter((chain) => {
+      return (
+        chain.key !== destChain &&
+        !chain.disabledAsSource &&
+        supportedChains.includes(chain.key)
+      );
+    });
+  }, [config.chainsArr, destChain, supportedChains]);
+
+  const supportedDestChains = useMemo(() => {
+    return config.chainsArr.filter(
+      (chain) =>
+        chain.key !== sourceChain &&
+        !chain.disabledAsDestination &&
+        supportedChains.includes(chain.key),
+    );
+  }, [config.chainsArr, sourceChain, supportedChains]);
+
+  const header = useMemo(() => {
+    const defaults: { text: string; align: Alignment } = {
+      text: '',
+      align: 'left',
+    };
+
+    let headerConfig;
+
+    if (typeof config.pageHeader === 'string') {
+      headerConfig = { ...defaults, text: config.pageHeader };
+    } else {
+      headerConfig = { ...defaults, ...config.pageHeader };
+    }
+
+    return (
+      <PageHeader
+        title={headerConfig.text}
+        align={headerConfig.align}
+        showHamburgerMenu={config.showHamburgerMenu}
+      />
+    );
+  }, []);
+
+  const sourceAssetPicker = useMemo(() => {
+    return (
+      <AssetPicker
+        chain={sourceChain}
+        chainList={supportedSourceChains}
+        token={sourceToken}
+        tokenList={supportedSourceTokens}
+        setChain={(value: ChainName) => {
+          selectFromChain(dispatch, value, sendingWallet);
+        }}
+        setToken={(value: string) => {
+          dispatch(setToken(value));
+        }}
+        wallet={sendingWallet}
+      />
+    );
+  }, [
+    sourceChain,
+    supportedSourceChains,
+    sourceToken,
+    supportedSourceTokens,
+    sendingWallet,
+  ]);
+
+  const destAssetPicker = useMemo(() => {
+    return (
+      <AssetPicker
+        chain={destChain}
+        chainList={supportedDestChains}
+        token={destToken}
+        tokenList={supportedDestTokens}
+        setChain={(value: ChainName) => {
+          selectToChain(dispatch, value, receivingWallet);
+        }}
+        setToken={(value: string) => {
+          dispatch(setDestToken(value));
+        }}
+        wallet={receivingWallet}
+      />
+    );
+  }, [
+    destChain,
+    supportedDestChains,
+    destToken,
+    supportedDestTokens,
+    receivingWallet,
+  ]);
+
+  const bridgeHeader = useMemo(() => {
+    return (
+      <div>
+        <Header align="left" text="Bridge assets" size={16} />
+      </div>
+    );
+  }, []);
+
+  return (
+    <div className={joinClass([classes.bridgeContent, classes.spacer])}>
+      {header}
+      {bridgeHeader}
+      {sourceAssetPicker}
+      {destAssetPicker}
+      <WalletConnector
+        disabled={!sourceChain}
+        side="source"
+        type={TransferWallet.SENDING}
+      />
+      {config.showHamburgerMenu ? null : <FooterNavBar />}
+      <div className={classes.poweredBy}>
+        <PoweredByIcon color={theme.palette.text.primary} />
+      </div>
+    </div>
+  );
+};
+
+export default Bridge;

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -78,11 +78,10 @@ const Bridge = () => {
   const theme = useTheme();
   const dispatch = useDispatch();
 
-  const receivingWallet = useSelector(
-    (state: RootState) => state.wallet.receiving,
+  // Connected wallets, if any
+  const { sending: sendingWallet, receiving: receivingWallet } = useSelector(
+    (state: RootState) => state.wallet,
   );
-
-  const sendingWallet = useSelector((state: RootState) => state.wallet.sending);
 
   const {
     supportedSourceTokens,

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -4,6 +4,7 @@ import { makeStyles } from 'tss-react/mui';
 import { useTheme } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 
+import HistoryIcon from '@mui/icons-material/History';
 import SettingsIcon from '@mui/icons-material/Settings';
 
 import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
@@ -37,7 +38,7 @@ const useStyles = makeStyles()((_theme) => ({
   bridgeHeader: {
     width: '100%',
     display: 'flex',
-    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   header: {
     display: 'flex',
@@ -210,6 +211,9 @@ const Bridge = () => {
     return (
       <div className={classes.bridgeHeader}>
         <Header align="left" text="Bridge assets" size={16} />
+        <IconButton>
+          <HistoryIcon />
+        </IconButton>
         <IconButton>
           <SettingsIcon />
         </IconButton>

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import { useTheme } from '@mui/material';
+import { Typography, useTheme } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 
 import HistoryIcon from '@mui/icons-material/History';
@@ -30,7 +30,13 @@ import {
 import WalletConnector from './WalletConnector';
 import AssetPicker from './AssetPicker';
 
-const useStyles = makeStyles()((_theme) => ({
+const useStyles = makeStyles()((theme) => ({
+  assetPickerContainer: {
+    width: '100%',
+  },
+  assetPickerTitle: {
+    color: theme.palette.text.secondary,
+  },
   bridgeContent: {
     margin: 'auto',
     maxWidth: '420px',
@@ -159,19 +165,24 @@ const Bridge = () => {
   // Asset picker for the source network and token
   const sourceAssetPicker = useMemo(() => {
     return (
-      <AssetPicker
-        chain={sourceChain}
-        chainList={supportedSourceChains}
-        token={sourceToken}
-        tokenList={supportedSourceTokens}
-        setChain={(value: ChainName) => {
-          selectFromChain(dispatch, value, sendingWallet);
-        }}
-        setToken={(value: string) => {
-          dispatch(setToken(value));
-        }}
-        wallet={sendingWallet}
-      />
+      <div className={classes.assetPickerContainer}>
+        <Typography className={classes.assetPickerTitle} variant="body2">
+          From:
+        </Typography>
+        <AssetPicker
+          chain={sourceChain}
+          chainList={supportedSourceChains}
+          token={sourceToken}
+          tokenList={supportedSourceTokens}
+          setChain={(value: ChainName) => {
+            selectFromChain(dispatch, value, sendingWallet);
+          }}
+          setToken={(value: string) => {
+            dispatch(setToken(value));
+          }}
+          wallet={sendingWallet}
+        />
+      </div>
     );
   }, [
     sourceChain,
@@ -184,19 +195,24 @@ const Bridge = () => {
   // Asset picker for the destination network and token
   const destAssetPicker = useMemo(() => {
     return (
-      <AssetPicker
-        chain={destChain}
-        chainList={supportedDestChains}
-        token={destToken}
-        tokenList={supportedDestTokens}
-        setChain={(value: ChainName) => {
-          selectToChain(dispatch, value, receivingWallet);
-        }}
-        setToken={(value: string) => {
-          dispatch(setDestToken(value));
-        }}
-        wallet={receivingWallet}
-      />
+      <div className={classes.assetPickerContainer}>
+        <Typography className={classes.assetPickerTitle} variant="body2">
+          To:
+        </Typography>
+        <AssetPicker
+          chain={destChain}
+          chainList={supportedDestChains}
+          token={destToken}
+          tokenList={supportedDestTokens}
+          setChain={(value: ChainName) => {
+            selectToChain(dispatch, value, receivingWallet);
+          }}
+          setToken={(value: string) => {
+            dispatch(setDestToken(value));
+          }}
+          wallet={receivingWallet}
+        />
+      </div>
     );
   }, [
     destChain,

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -225,7 +225,7 @@ const Bridge = () => {
   const bridgeHeader = useMemo(() => {
     return (
       <div className={classes.bridgeHeader}>
-        <Header align="left" text="Bridge assets" size={16} />
+        <Header align="left" text="Bridge assets" size={20} />
         <IconButton>
           <HistoryIcon />
         </IconButton>

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -2,6 +2,9 @@ import React, { useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { useTheme } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
+
+import SettingsIcon from '@mui/icons-material/Settings';
 
 import type { ChainName } from '@wormhole-foundation/wormhole-connect-sdk';
 import type { RootState } from 'store';
@@ -27,17 +30,14 @@ import WalletConnector from './WalletConnector';
 import AssetPicker from './AssetPicker';
 
 const useStyles = makeStyles()((_theme) => ({
-  spacer: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '16px',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-  },
   bridgeContent: {
     margin: 'auto',
     maxWidth: '420px',
+  },
+  bridgeHeader: {
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
   },
   header: {
     display: 'flex',
@@ -52,8 +52,20 @@ const useStyles = makeStyles()((_theme) => ({
     gap: '8px',
     marginTop: '24px',
   },
+  spacer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  },
 }));
 
+/**
+ * Bridge is the main component for Bridge view
+ *
+ */
 const Bridge = () => {
   const { classes } = useStyles();
   const theme = useTheme();
@@ -62,6 +74,7 @@ const Bridge = () => {
   const receivingWallet = useSelector(
     (state: RootState) => state.wallet.receiving,
   );
+
   const sendingWallet = useSelector((state: RootState) => state.wallet.sending);
 
   const {
@@ -91,11 +104,13 @@ const Bridge = () => {
     route,
   });
 
+  // All supported chains from the given configuration and any custom override
   const supportedChains = useMemo(
     () => RouteOperator.allSupportedChains(),
     [config.chainsArr],
   );
 
+  // Supported chains for the source network
   const supportedSourceChains = useMemo(() => {
     return config.chainsArr.filter((chain) => {
       return (
@@ -106,6 +121,7 @@ const Bridge = () => {
     });
   }, [config.chainsArr, destChain, supportedChains]);
 
+  // Supported chains for the destination network
   const supportedDestChains = useMemo(() => {
     return config.chainsArr.filter(
       (chain) =>
@@ -115,6 +131,7 @@ const Bridge = () => {
     );
   }, [config.chainsArr, sourceChain, supportedChains]);
 
+  // Connect bridge header, which renders any custom overrides for the header
   const header = useMemo(() => {
     const defaults: { text: string; align: Alignment } = {
       text: '',
@@ -138,6 +155,7 @@ const Bridge = () => {
     );
   }, []);
 
+  // Asset picker for the source network and token
   const sourceAssetPicker = useMemo(() => {
     return (
       <AssetPicker
@@ -162,6 +180,7 @@ const Bridge = () => {
     sendingWallet,
   ]);
 
+  // Asset picker for the destination network and token
   const destAssetPicker = useMemo(() => {
     return (
       <AssetPicker
@@ -186,10 +205,14 @@ const Bridge = () => {
     receivingWallet,
   ]);
 
+  // Header for Bridge view, which includes the title and settings icon.
   const bridgeHeader = useMemo(() => {
     return (
-      <div>
+      <div className={classes.bridgeHeader}>
         <Header align="left" text="Bridge assets" size={16} />
+        <IconButton>
+          <SettingsIcon />
+        </IconButton>
       </div>
     );
   }, []);

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo } from 'react';
+import { makeStyles } from 'tss-react/mui';
+import config from 'config';
+import { joinClass } from 'utils/style';
+
+import { useTheme } from '@mui/material';
+import PageHeader from 'components/PageHeader';
+import PoweredByIcon from 'icons/PoweredBy';
+import { Alignment } from 'components/Header';
+import FooterNavBar from 'components/FooterNavBar';
+
+const useStyles = makeStyles()((_theme) => ({
+  spacer: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '16px',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+  },
+  bridgeContent: {
+    margin: 'auto',
+    maxWidth: '650px',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+  },
+  poweredBy: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    marginTop: '24px',
+  },
+}));
+
+const Redeem = () => {
+  const { classes } = useStyles();
+  const theme = useTheme();
+
+  const header = useMemo(() => {
+    const defaults: { text: string; align: Alignment } = {
+      text: '',
+      align: 'left',
+    };
+
+    let headerConfig;
+
+    if (typeof config.pageHeader === 'string') {
+      headerConfig = { ...defaults, text: config.pageHeader };
+    } else {
+      headerConfig = { ...defaults, ...config.pageHeader };
+    }
+
+    return (
+      <PageHeader
+        title={headerConfig.text}
+        align={headerConfig.align}
+        showHamburgerMenu={config.showHamburgerMenu}
+      />
+    );
+  }, []);
+
+  return (
+    <div className={joinClass([classes.bridgeContent, classes.spacer])}>
+      {header}
+      {config.showHamburgerMenu ? null : <FooterNavBar />}
+
+      <div className={classes.poweredBy}>
+        <PoweredByIcon color={theme.palette.text.primary} />
+      </div>
+    </div>
+  );
+};
+
+export default Redeem;

--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -40,6 +40,7 @@ const resolve = {
     hooks: path.resolve(__dirname, './src/hooks'),
     consts: path.resolve(__dirname, './src/consts'),
     public: path.resolve(__dirname, './public'),
+    views: path.resolve(__dirname, './src/views'),
     'process/': 'process',
     'buffer/': 'buffer',
   },


### PR DESCRIPTION
This is a draft PR to add the new asset pickers for connect redesign.
To enable the redesign view, you need to add a new property to the Custom config:
```
{ useRedesign: true }
```
Below are a few screenshots for the visuals:

<img width="812" alt="Screenshot 2024-06-14 at 12 30 46 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/10507890/d1be580b-a35a-4bcf-9215-4c663bae07f4">


<img width="813" alt="Screenshot 2024-06-14 at 12 31 34 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/10507890/48346830-99e5-4b23-82cb-badf18cf0f6c">


<img width="811" alt="Screenshot 2024-06-14 at 12 31 51 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/10507890/f2db6ab2-9d2d-41e1-9a62-ba8d6b4ae4df">


<img width="812" alt="Screenshot 2024-06-14 at 12 32 24 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/10507890/3b6f9aa5-6144-4363-87bf-cebcf1c6f54f">


<img width="813" alt="Screenshot 2024-06-14 at 12 32 40 AM" src="https://github.com/wormhole-foundation/wormhole-connect/assets/10507890/57de3a73-15b0-440c-934e-c8478b4b992b">




