### PR TITLE
portico: define supported tokens by key instead of symbol

### DIFF
--- a/wormhole-connect/src/routes/porticoBridge/ethBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/ethBridge.ts
@@ -4,7 +4,19 @@ import { Route } from 'config/types';
 
 export class ETHBridge extends PorticoBridge {
   readonly TYPE: Route = Route.ETHBridge;
-  static readonly SUPPORTED_TOKENS: string[] = ['ETH', 'WETH'];
+  static readonly SUPPORTED_TOKENS: string[] = [
+    'ETH',
+    'WETH',
+    'WETHpolygon',
+    'WETHavax',
+    'ETHarbitrum',
+    'WETHarbitrum',
+    'ETHoptimism',
+    'WETHoptimism',
+    'WETHbsc',
+    'ETHbase',
+    'WETHbase',
+  ];
 
   constructor() {
     super(ETHBridge.SUPPORTED_TOKENS, config.ethBridgeMaxAmount);

--- a/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/porticoBridge.ts
@@ -124,7 +124,7 @@ export abstract class PorticoBridge extends BaseRoute {
   isSupportedToken(token: TokenConfig, chain: ChainName | ChainId): boolean {
     return (
       this.isSupportedChain(token.nativeChain) &&
-      this.supportedTokenSymbols.includes(token.symbol) &&
+      this.supportedTokenSymbols.includes(token.key) &&
       toChainName(chain) === token.nativeChain
     );
   }

--- a/wormhole-connect/src/routes/porticoBridge/wstETHBridge.ts
+++ b/wormhole-connect/src/routes/porticoBridge/wstETHBridge.ts
@@ -4,7 +4,13 @@ import { Route } from 'config/types';
 
 export class wstETHBridge extends PorticoBridge {
   readonly TYPE: Route = Route.wstETHBridge;
-  static readonly SUPPORTED_TOKENS: string[] = ['wstETH'];
+  static readonly SUPPORTED_TOKENS: string[] = [
+    'wstETH',
+    'wstETHarbitrum',
+    'wstETHoptimism',
+    'wstETHpolygon',
+    'wstETHbase',
+  ];
 
   constructor() {
     super(wstETHBridge.SUPPORTED_TOKENS, config.wstETHBridgeMaxAmount);

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -234,7 +234,7 @@ function Bridge() {
           ...ETHBridge.SUPPORTED_TOKENS,
           ...wstETHBridge.SUPPORTED_TOKENS,
         ];
-        if (porticoTokens.includes(tokenSymbol)) {
+        if (porticoTokens.includes(token)) {
           let key = getNativeVersionOfToken(tokenSymbol, toChain);
           if (!key) {
             const wrapped = getWrappedToken(config.tokens[token]);


### PR DESCRIPTION
Explicitly define supported tokens by key instead
of symbol which is brittle.