### PR TITLE
replace deprecated sui explorer link

### DIFF
--- a/wormhole-connect/src/config/mainnet/chains.ts
+++ b/wormhole-connect/src/config/mainnet/chains.ts
@@ -95,7 +95,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
   sui: {
     ...chains.sui!,
     displayName: 'Sui',
-    explorerUrl: 'https://explorer.sui.io/',
+    explorerUrl: 'https://suivision.xyz/',
     explorerName: 'Sui Explorer',
     gasToken: 'SUI',
     chainId: 0,

--- a/wormhole-connect/src/config/testnet/chains.ts
+++ b/wormhole-connect/src/config/testnet/chains.ts
@@ -95,7 +95,7 @@ export const TESTNET_CHAINS: ChainsConfig = {
   sui: {
     ...chains.sui!,
     displayName: 'Sui',
-    explorerUrl: 'https://explorer.sui.io/',
+    explorerUrl: 'https://suivision.xyz/',
     explorerName: 'Sui Explorer',
     gasToken: 'SUI',
     chainId: 0,

--- a/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
+++ b/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
@@ -28,7 +28,7 @@ function ExplorerLink(props: ExplorerLinkProps) {
 
   const chainConfig = config.chains[props.chain]!;
 
-  let explorerLink;
+  let explorerLink = '';
   if (props.type === 'tx') {
     // TODO: refactor and use a map instead
     if (chainConfig.key === 'sui') {
@@ -69,6 +69,11 @@ function ExplorerLink(props: ExplorerLinkProps) {
     if (chainConfig.key === 'aptos') {
       explorerLink += '?network=testnet';
     }
+  }
+
+  // ensure explorerLink is defined before returning the JSX
+  if (!explorerLink) {
+    return null;
   }
 
   return (

--- a/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
+++ b/wormhole-connect/src/views/Redeem/ExplorerLink.tsx
@@ -64,7 +64,7 @@ function ExplorerLink(props: ExplorerLinkProps) {
       explorerLink += '?cluster=devnet';
     }
     if (chainConfig.key === 'sui') {
-      explorerLink += '?network=testnet';
+      explorerLink = explorerLink.replace('https://', 'https://testnet.');
     }
     if (chainConfig.key === 'aptos') {
       explorerLink += '?network=testnet';


### PR DESCRIPTION
explorer.sui.io has been deprecated, so this PR aims to link directly to the most used browser:

![Screenshot 2024-06-27 at 15 09 07](https://github.com/wormhole-foundation/wormhole-connect/assets/97796468/e8bb15c3-78e3-4187-bff2-0b3dfca93f06)
