### PR TITLE
Adding working dir change since workspaces were removed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+cd ./wormhole-connect && npx lint-staged

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -129,7 +129,7 @@
     "react-dom": "^18.2.0"
   },
   "lint-staged": {
-    "**/*": "prettier --workspaces --if-present --write --ignore-unknown"
+    "*": "prettier --write --ignore-unknown"
   },
   "overrides": {
     "@injectivelabs/sdk-ts@1.10.72": {


### PR DESCRIPTION
We need to move the current directory to `./wormhole-connect` for the `npx` commands to work. This is probably due to we no longer having workplaces in our repo.