### PR TITLE
[Bug] Connect should not automatically connect a Wallet Connect wallet for the destination wallet

### DIFF
--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -128,6 +128,10 @@ export const connectLastUsedWallet = async (
     `wormhole-connect:wallet:${chainConfig.context}`,
   );
   if (lastUsedWallet) {
+    // If the source wallet was connected with Wallet Connect, disable logic that auto-connects
+    if (lastUsedWallet === 'WalletConnect' && type === TransferWallet.RECEIVING)
+      return;
+
     const options = await getWalletOptions(chainConfig);
     const wallet = options.find((w) => w.name === lastUsedWallet);
     if (wallet) {


### PR DESCRIPTION
Issue: https://github.com/wormhole-foundation/wormhole-connect/issues/2240

With a condition we prevent the auto-connect from being executed in the case of the target wallet