### PR TITLE
Unable to send native token via token bridge route

### DIFF
--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -92,30 +92,6 @@ export const useComputeDestinationTokens = (props: Props): void => {
           dispatch(setDestToken(key));
         }
       }
-
-      /*
-      // If the source token is supported by a Portico bridge route,
-      // then select the native version on the dest chain
-      if (sourceToken && destChain && (!route || isPorticoRoute(route))) {
-        const tokenSymbol = config.tokens[sourceToken]?.symbol;
-        const porticoTokens = [
-          ...ETHBridge.SUPPORTED_TOKENS,
-          ...wstETHBridge.SUPPORTED_TOKENS,
-        ];
-        if (porticoTokens.includes(tokenSymbol)) {
-          const isTokenSupported =
-            sourceToken && supported.some((t) => t.key === sourceToken);
-          let key = getNativeVersionOfToken(tokenSymbol, destChain);
-          if (!key) {
-            const wrapped = getWrappedToken(config.tokens[sourceToken]);
-            key = getNativeVersionOfToken(wrapped.symbol, destChain);
-          }
-          if (!canceled && key && isTokenSupported) {
-            dispatch(setDestToken(key));
-          }
-        }
-      }
-      */
     };
 
     computeDestTokens();

--- a/wormhole-connect/src/hooks/useComputeQuote.ts
+++ b/wormhole-connect/src/hooks/useComputeQuote.ts
@@ -13,9 +13,6 @@ import type { PorticoBridgeState } from 'store/porticoBridge';
 import { getRoute } from 'routes/mappings';
 import { setReceiveNativeAmt, setRelayerFee } from 'store/relay';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
-import { getTokenDecimals } from 'utils';
-import config from 'config';
-import { toChainId } from 'utils/sdk';
 import { toDecimals } from 'utils/balance';
 
 type Props = {
@@ -102,11 +99,9 @@ export const useComputeQuote = (props: Props): void => {
             dispatch(setReceiveNativeAmt(0));
           }
           if (quote.relayFee) {
-            const { token, amount } = quote.relayFee;
-            const feeToken = config.sdkConverter.toTokenIdV1(token);
-            const decimals = getTokenDecimals(toChainId(sourceChain), feeToken);
+            const { amount } = quote.relayFee;
             const formattedFee = Number.parseFloat(
-              toDecimals(amount.amount, decimals, 6),
+              toDecimals(amount.amount, amount.decimals, 6),
             );
             dispatch(setRelayerFee(formattedFee));
           } else {

--- a/wormhole-connect/src/hooks/useGetTokenBalances.ts
+++ b/wormhole-connect/src/hooks/useGetTokenBalances.ts
@@ -101,7 +101,9 @@ const useGetTokenBalances = (
                 if (foreignAddress) {
                   address = foreignAddress.toString();
                 } else {
-                  console.error('no fa', tokenConfig);
+                  console.warn(
+                    `No foreign address for ${tokenConfig.key} on chain ${chainV2}`,
+                  );
                   continue;
                 }
                 tokenIdMapping[address] = tokenConfig;

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -369,15 +369,19 @@ export class Operator {
     for (const route of config.routes) {
       const r = this.getRoute(route as Route);
 
-      const sourceTokens = await r.supportedSourceTokens(
-        config.tokensArr,
-        destToken,
-        sourceChain,
-        destChain,
-      );
+      try {
+        const sourceTokens = await r.supportedSourceTokens(
+          config.tokensArr,
+          destToken,
+          sourceChain,
+          destChain,
+        );
 
-      for (const token of sourceTokens) {
-        supported[token.key] = token;
+        for (const token of sourceTokens) {
+          supported[token.key] = token;
+        }
+      } catch (e) {
+        console.error(e);
       }
     }
     return Object.values(supported);
@@ -392,9 +396,7 @@ export class Operator {
     for (const route of config.routes) {
       const r = this.getRoute(route as Route);
 
-      // This is ugly hack TODO clean up with proper types
       try {
-        /* @ts-ignore */
         const destTokens = await r.supportedDestTokens(
           config.tokensArr,
           sourceToken,

--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -29,7 +29,7 @@ import {
   SourceFinalizedTransferReceipt,
 } from '@wormhole-foundation/sdk';
 import config, { getWormholeContextV2 } from 'config';
-import { calculateUSDPrice, getDisplayName } from 'utils';
+import { calculateUSDPrice, getDisplayName, getWrappedToken } from 'utils';
 import { toFixedDecimals } from 'utils/balance';
 import { TransferWallet } from 'utils/wallet';
 
@@ -227,7 +227,7 @@ export class SDKv2Route {
     // point all that would be required would be an address.
     if (['bridge', 'relay', 'cosmosGateway'].includes(this.TYPE)) {
       if (destTokenIds.length > 0) {
-        return [sourceToken];
+        return [getWrappedToken(sourceToken)];
       }
     }
 


### PR DESCRIPTION
supportedDestTokens should return the wrapped version of the token otherwise the token bridge routes don't support it