### PR TITLE
[Redesign] Wallet auto-connect and main CTA styling

### DIFF
--- a/wormhole-connect/src/components/v2/Button.tsx
+++ b/wormhole-connect/src/components/v2/Button.tsx
@@ -26,7 +26,7 @@ type Props = Omit<ButtonProps, 'variant'> & { variant?: string };
 const Button = (props: Props) => {
   const { variant, ...rest } = props;
 
-  if (props?.variant === 'primary') {
+  if (variant === 'primary') {
     return <PrimaryButton variant="contained" {...rest} />;
   }
 

--- a/wormhole-connect/src/components/v2/Button.tsx
+++ b/wormhole-connect/src/components/v2/Button.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { styled } from '@mui/material';
+import { default as MUIButton, ButtonProps } from '@mui/material/Button';
+
+const PrimaryButton = styled(MUIButton)<ButtonProps>(({ theme }) => ({
+  color: theme.palette.getContrastText('#C1BBF6'),
+  backgroundColor: '#C1BBF6',
+  '&:hover': {
+    backgroundColor: '#C1BBF6',
+  },
+  '&:disabled': {
+    backgroundColor: '#C1BBF6',
+    color: '#1F2935',
+    opacity: '40%',
+  },
+}));
+
+type Props = Omit<ButtonProps, 'variant'> & { variant?: string };
+
+/**
+ * Custom Button component that extends MUI Button
+ * @param variant:  Optional propoerty to specify the style variant of the button
+ *                  Primary: The main CTA
+ *
+ */
+const Button = (props: Props) => {
+  const { variant, ...rest } = props;
+
+  if (props?.variant === 'primary') {
+    return <PrimaryButton variant="contained" {...rest} />;
+  }
+
+  return <MUIButton {...rest} />;
+};
+
+export default Button;

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -1,9 +1,11 @@
 import React, { useContext, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import { useMediaQuery, useTheme } from '@mui/material';
-import Button from '@mui/material/Button';
+import { styled, useMediaQuery, useTheme } from '@mui/material';
+import Button, { ButtonProps } from '@mui/material/Button';
+import CircularProgress from '@mui/material/CircularProgress';
 import Collapse from '@mui/material/Collapse';
+import { deepPurple } from '@mui/material/colors';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import ChevronLeft from '@mui/icons-material/ChevronLeft';
@@ -50,6 +52,17 @@ const useStyles = makeStyles()((theme) => ({
     margin: 'auto',
     maxWidth: '420px',
     width: '100%',
+  },
+}));
+
+const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
+  color: theme.palette.getContrastText(deepPurple[200]),
+  backgroundColor: deepPurple[200],
+  '&:hover': {
+    backgroundColor: deepPurple[300],
+  },
+  '&:disabled': {
+    backgroundColor: deepPurple[100],
   },
 }));
 
@@ -288,19 +301,31 @@ const ReviewTransaction = (props: Props) => {
     }
 
     return (
-      <Button
+      <StyledButton
         disabled={isTransactionInProgress}
         variant="contained"
         color="primary"
         className={classes.confirmTransaction}
         onClick={() => send()}
       >
-        <Typography textTransform="none">
-          {mobile ? 'Confirm' : 'Confirm transaction'}
-        </Typography>
-      </Button>
+        {isTransactionInProgress ? (
+          <CircularProgress size={24} />
+        ) : (
+          <Typography textTransform="none">
+            {mobile ? 'Confirm' : 'Confirm transaction'}
+          </Typography>
+        )}
+      </StyledButton>
     );
-  }, [sourceChain, sourceToken, destChain, destToken, route, amount]);
+  }, [
+    isTransactionInProgress,
+    sourceChain,
+    sourceToken,
+    destChain,
+    destToken,
+    route,
+    amount,
+  ]);
 
   if (!route || !walletsConnected) {
     return <></>;

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -1,8 +1,7 @@
 import React, { useContext, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import { styled, useMediaQuery, useTheme } from '@mui/material';
-import Button, { ButtonProps } from '@mui/material/Button';
+import { useMediaQuery, useTheme } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import Collapse from '@mui/material/Collapse';
 import Stack from '@mui/material/Stack';
@@ -13,6 +12,7 @@ import { getTokenDetails } from 'telemetry';
 import { Context } from 'sdklegacy';
 
 import AlertBanner from 'components/AlertBanner';
+import Button from 'components/v2/Button';
 import config from 'config';
 import { RoutesConfig } from 'config/routes';
 import { RouteContext } from 'contexts/RouteContext';
@@ -25,7 +25,7 @@ import {
   setRoute as setRedeemRoute,
 } from 'store/redeem';
 import { setRoute as setAppRoute } from 'store/router';
-import { setIsTransactionInProgress } from 'store/transferInput';
+import { setAmount, setIsTransactionInProgress } from 'store/transferInput';
 import { getTokenDecimals, getWrappedToken, getWrappedTokenId } from 'utils';
 import { interpretTransferError } from 'utils/errors';
 import { validate, isTransferValid } from 'utils/transferValidation';
@@ -51,19 +51,6 @@ const useStyles = makeStyles()((theme) => ({
     margin: 'auto',
     maxWidth: '420px',
     width: '100%',
-  },
-}));
-
-const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText('#C1BBF6'),
-  backgroundColor: '#C1BBF6',
-  '&:hover': {
-    backgroundColor: '#C1BBF6',
-  },
-  '&:disabled': {
-    backgroundColor: '#C1BBF6',
-    color: '#1F2935',
-    opacity: '40%',
   },
 }));
 
@@ -257,6 +244,9 @@ const ReviewTransaction = (props: Props) => {
         }),
       );
 
+      // Reset the amount for a successful transaction
+      dispatch(setAmount(''));
+
       routeContext.setRoute(sdkRoute);
       routeContext.setReceipt(receipt);
 
@@ -302,10 +292,9 @@ const ReviewTransaction = (props: Props) => {
     }
 
     return (
-      <StyledButton
+      <Button
         disabled={isTransactionInProgress}
-        variant="contained"
-        color="primary"
+        variant="primary"
         className={classes.confirmTransaction}
         onClick={() => send()}
       >
@@ -316,7 +305,7 @@ const ReviewTransaction = (props: Props) => {
             {mobile ? 'Confirm' : 'Confirm transaction'}
           </Typography>
         )}
-      </StyledButton>
+      </Button>
     );
   }, [
     isTransactionInProgress,

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -98,7 +98,7 @@ const ReviewTransaction = (props: Props) => {
   });
 
   // Compute the native gas to receive
-  const { receiveNativeAmt } = useComputeQuoteV2({
+  const { receiveNativeAmt, isFetching: isFetchingQuote } = useComputeQuoteV2({
     sourceChain,
     destChain,
     sourceToken,
@@ -293,7 +293,7 @@ const ReviewTransaction = (props: Props) => {
 
     return (
       <Button
-        disabled={isTransactionInProgress}
+        disabled={isFetchingQuote || isTransactionInProgress}
         variant="primary"
         className={classes.confirmTransaction}
         onClick={() => send()}
@@ -308,6 +308,7 @@ const ReviewTransaction = (props: Props) => {
       </Button>
     );
   }, [
+    isFetchingQuote,
     isTransactionInProgress,
     sourceChain,
     sourceToken,

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -5,7 +5,6 @@ import { styled, useMediaQuery, useTheme } from '@mui/material';
 import Button, { ButtonProps } from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Collapse from '@mui/material/Collapse';
-import { deepPurple } from '@mui/material/colors';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import ChevronLeft from '@mui/icons-material/ChevronLeft';
@@ -56,13 +55,15 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText(deepPurple[200]),
-  backgroundColor: deepPurple[200],
+  color: theme.palette.getContrastText('#C1BBF6'),
+  backgroundColor: '#C1BBF6',
   '&:hover': {
-    backgroundColor: deepPurple[300],
+    backgroundColor: '#C1BBF6',
   },
   '&:disabled': {
-    backgroundColor: deepPurple[100],
+    backgroundColor: '#C1BBF6',
+    color: '#1F2935',
+    opacity: '40%',
   },
 }));
 

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -2,7 +2,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
-import { Button, Tooltip, Typography, useMediaQuery } from '@mui/material';
+import { styled, useMediaQuery } from '@mui/material';
+import Button, { ButtonProps } from '@mui/material/Button';
+import { deepPurple } from '@mui/material/colors';
+import Tooltip from '@mui/material/Tooltip';
+import Typography from '@mui/material/Typography';
 
 import { RootState } from 'store';
 import { displayWalletAddress } from 'utils';
@@ -32,6 +36,17 @@ const useStyles = makeStyles()((theme: any) => ({
     margin: 'auto',
     maxWidth: '420px',
     width: '100%',
+  },
+}));
+
+const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
+  color: theme.palette.getContrastText(deepPurple[200]),
+  backgroundColor: deepPurple[200],
+  '&:hover': {
+    backgroundColor: deepPurple[300],
+  },
+  '&:disabled': {
+    backgroundColor: deepPurple[100],
   },
 }));
 
@@ -77,7 +92,7 @@ const WalletConnector = (props: Props) => {
 
   const disconnected = useMemo(() => {
     const button = (
-      <Button
+      <StyledButton
         variant="contained"
         color="primary"
         className={classes.connectWallet}
@@ -94,7 +109,7 @@ const WalletConnector = (props: Props) => {
         <Typography textTransform="none">
           {mobile ? 'Connect' : `Connect ${props.side} wallet`}
         </Typography>
-      </Button>
+      </StyledButton>
     );
 
     if (disabled) {

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -2,11 +2,11 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
-import { styled, useMediaQuery } from '@mui/material';
-import Button, { ButtonProps } from '@mui/material/Button';
+import { useMediaQuery } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
+import Button from 'components/v2/Button';
 import { RootState } from 'store';
 import { displayWalletAddress } from 'utils';
 import { TransferWallet } from 'utils/wallet';
@@ -35,19 +35,6 @@ const useStyles = makeStyles()((theme: any) => ({
     margin: 'auto',
     maxWidth: '420px',
     width: '100%',
-  },
-}));
-
-const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText('#C1BBF6'),
-  backgroundColor: '#C1BBF6',
-  '&:hover': {
-    backgroundColor: '#C1BBF6',
-  },
-  '&:disabled': {
-    backgroundColor: '#C1BBF6',
-    color: '#1F2935',
-    opacity: '40%',
   },
 }));
 
@@ -93,9 +80,8 @@ const WalletConnector = (props: Props) => {
 
   const disconnected = useMemo(() => {
     const button = (
-      <StyledButton
-        variant="contained"
-        color="primary"
+      <Button
+        variant="primary"
         className={classes.connectWallet}
         data-testid={`${props.side}-section-connect-wallet-button`}
         disabled={disabled}
@@ -110,7 +96,7 @@ const WalletConnector = (props: Props) => {
         <Typography textTransform="none">
           {mobile ? 'Connect' : `Connect ${props.side} wallet`}
         </Typography>
-      </StyledButton>
+      </Button>
     );
 
     if (disabled) {

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -4,7 +4,6 @@ import { useTheme } from '@mui/material/styles';
 import { makeStyles } from 'tss-react/mui';
 import { styled, useMediaQuery } from '@mui/material';
 import Button, { ButtonProps } from '@mui/material/Button';
-import { deepPurple } from '@mui/material/colors';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
@@ -40,13 +39,15 @@ const useStyles = makeStyles()((theme: any) => ({
 }));
 
 const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText(deepPurple[200]),
-  backgroundColor: deepPurple[200],
+  color: theme.palette.getContrastText('#C1BBF6'),
+  backgroundColor: '#C1BBF6',
   '&:hover': {
-    backgroundColor: deepPurple[300],
+    backgroundColor: '#C1BBF6',
   },
   '&:disabled': {
-    backgroundColor: deepPurple[100],
+    backgroundColor: '#C1BBF6',
+    color: '#1F2935',
+    opacity: '40%',
   },
 }));
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -3,7 +3,6 @@ import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
 import { styled, useMediaQuery, useTheme } from '@mui/material';
 import Button, { ButtonProps } from '@mui/material/Button';
-import { deepPurple } from '@mui/material/colors';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 
@@ -95,13 +94,15 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText(deepPurple[200]),
-  backgroundColor: deepPurple[200],
+  color: theme.palette.getContrastText('#C1BBF6'),
+  backgroundColor: '#C1BBF6',
   '&:hover': {
-    backgroundColor: deepPurple[300],
+    backgroundColor: '#C1BBF6',
   },
   '&:disabled': {
-    backgroundColor: deepPurple[100],
+    backgroundColor: '#C1BBF6',
+    color: '#1F2935',
+    opacity: '40%',
   },
 }));
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from 'tss-react/mui';
-import { styled, useMediaQuery, useTheme } from '@mui/material';
-import Button, { ButtonProps } from '@mui/material/Button';
+import { useMediaQuery, useTheme } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import Typography from '@mui/material/Typography';
 
@@ -15,6 +14,7 @@ import type { RootState } from 'store';
 
 import RouteOperator from 'routes/operator';
 
+import Button from 'components/v2/Button';
 import config from 'config';
 import { joinClass } from 'utils/style';
 import PoweredByIcon from 'icons/PoweredBy';
@@ -90,19 +90,6 @@ const useStyles = makeStyles()((theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
     width: '100%',
-  },
-}));
-
-const StyledButton = styled(Button)<ButtonProps>(({ theme }) => ({
-  color: theme.palette.getContrastText('#C1BBF6'),
-  backgroundColor: '#C1BBF6',
-  '&:hover': {
-    backgroundColor: '#C1BBF6',
-  },
-  '&:disabled': {
-    backgroundColor: '#C1BBF6',
-    color: '#1F2935',
-    opacity: '40%',
   },
 }));
 
@@ -374,8 +361,8 @@ const Bridge = () => {
     const isFetching = isFetchingFees || isFetchingQuote;
 
     return (
-      <StyledButton
-        variant="contained"
+      <Button
+        variant="primary"
         className={classes.reviewTransaction}
         disabled={isFetching}
         onClick={() => {
@@ -395,7 +382,7 @@ const Bridge = () => {
         <Typography textTransform="none">
           {mobile ? 'Review' : 'Review transaction'}
         </Typography>
-      </StyledButton>
+      </Button>
     );
   }, [
     sourceChain,

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -35,6 +35,7 @@ import {
   setTransferRoute,
   setDestToken,
 } from 'store/transferInput';
+import { useConnectToLastUsedWallet } from 'utils/wallet';
 import WalletConnector from 'views/v2/Bridge/WalletConnector';
 import AssetPicker from 'views/v2/Bridge/AssetPicker';
 import WalletController from 'views/v2/Bridge/WalletConnector/Controller';
@@ -194,7 +195,11 @@ const Bridge = () => {
     toNativeToken,
   });
 
+  // Pre-fetch available routes
   useAvailableRoutes();
+
+  // Connect to any previously used wallets for the selected networks
+  useConnectToLastUsedWallet();
 
   // All supported chains from the given configuration and any custom override
   const supportedChains = useMemo(


### PR DESCRIPTION
This PR adds the wallet auto-connect (existing functionality) to the new Bridge view. It also adds the styling around our main CTA.

Please see the details here:
https://www.loom.com/share/9375e3e3b9b14a31a903adb8b22d4ae1?sid=28a5f0d8-d14d-4af9-a968-31efb682f9a3