### PR TITLE
[Redesign] Amount input and token warnings

### DIFF
--- a/wormhole-connect/src/components/v2/AlertBanner.tsx
+++ b/wormhole-connect/src/components/v2/AlertBanner.tsx
@@ -1,0 +1,60 @@
+import React, { CSSProperties } from 'react';
+import { Collapse, Typography, useTheme } from '@mui/material';
+import ErrorIcon from '@mui/icons-material/ErrorOutline';
+import { makeStyles } from 'tss-react/mui';
+
+const useStyles = makeStyles()((theme: any) => ({
+  container: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    gap: '8px',
+  },
+}));
+
+type Props = {
+  show: boolean;
+  content: React.ReactNode | undefined;
+  warning?: boolean;
+  error?: boolean;
+  style?: CSSProperties;
+  testId?: string;
+};
+
+function AlertBanner(props: Props) {
+  const { classes } = useStyles();
+  const theme = useTheme();
+
+  let themeColor;
+
+  if (props.warning) {
+    themeColor = theme.palette.warning.main;
+  } else if (props.error) {
+    themeColor = theme.palette.error.main;
+  }
+
+  return (
+    <Collapse in={props.show && !!props.content} unmountOnExit>
+      <div
+        className={classes.container}
+        style={props.style || {}}
+        data-testid={props.testId}
+      >
+        {
+          <ErrorIcon
+            fontSize="small"
+            htmlColor={themeColor}
+            sx={{ paddingTop: '2px' }}
+          />
+        }
+        <Typography color={themeColor} fontSize={14}>
+          {props.content}
+        </Typography>
+      </div>
+    </Collapse>
+  );
+}
+
+export default AlertBanner;

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -202,8 +202,8 @@ export const getIsAutomatic = (route: Route | undefined): boolean => {
 export const isCctp = (
   token: string,
   destToken: string,
-  toChain: ChainName | undefined,
   fromChain: ChainName | undefined,
+  toChain: ChainName | undefined,
 ): boolean => {
   const isUSDCToken =
     config.tokens[token]?.symbol === 'USDC' &&
@@ -249,7 +249,7 @@ export const validateAll = async (
   const availableRoutes = routeStates
     ?.filter((rs) => rs.supported)
     .map((val) => val.name);
-  const isCctpTx = isCctp(token, destToken, toChain, fromChain);
+  const isCctpTx = isCctp(token, destToken, fromChain, toChain);
   const baseValidations = {
     sendingWallet: await validateWallet(sending, fromChain),
     receivingWallet: await validateWallet(receiving, toChain),

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -10,8 +10,8 @@ import InputAdornment from '@mui/material/InputAdornment';
 import Stack from '@mui/material/Stack';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import WarningIcon from '@mui/icons-material/ReportOutlined';
 
+import AlertBannerV2 from 'components/v2/AlertBanner';
 import useGetTokenBalances from 'hooks/useGetTokenBalances';
 import { setAmount } from 'store/transferInput';
 import { toFixedDecimals } from 'utils/balance';
@@ -189,20 +189,11 @@ const AmountInput = (props: Props) => {
           />
         </CardContent>
       </Card>
-      {validationResult ? (
-        <div className={classes.errorContainer}>
-          <WarningIcon
-            fontSize="small"
-            htmlColor={theme.palette.error.main}
-            sx={{ marginRight: '4px' }}
-          />
-          <Typography color={theme.palette.error.main} fontSize={14}>
-            {validationResult}
-          </Typography>
-        </div>
-      ) : (
-        <></>
-      )}
+      <AlertBannerV2
+        error
+        content={validationResult}
+        show={!!validationResult}
+      />
     </div>
   );
 };

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenWarnings.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenWarnings.tsx
@@ -1,0 +1,348 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { makeStyles } from 'tss-react/mui';
+
+import { RootState } from 'store';
+import {
+  //setAssociatedTokenAddress,
+  setForeignAsset,
+} from 'store/transferInput';
+import config from 'config';
+import { /*getTokenById,*/ getWrappedTokenId } from 'utils';
+//import { TransferWallet, signAndSendTransaction } from 'utils/wallet';
+import { joinClass } from 'utils/style';
+//import { solanaContext } from 'utils/sdk';
+
+import { CircularProgress, Link, Typography } from '@mui/material';
+import AlertBanner from 'components/AlertBanner';
+import RouteOperator from 'routes/operator';
+import { Route } from 'config/types';
+import { isNttRoute } from 'routes';
+
+const useStyles = makeStyles()((theme: any) => ({
+  associatedTokenWarning: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'start',
+  },
+  link: {
+    textDecoration: 'underline',
+    opacity: '0.8',
+    padding: '4px 0',
+    cursor: 'pointer',
+    '&:hover': {
+      opacity: '1',
+    },
+  },
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: '0.6',
+    '&:hover': {
+      opacity: '0.6',
+    },
+  },
+  inProgress: {
+    marginRight: '8px',
+  },
+  error: {
+    color: theme.palette.error[500],
+    marginTop: '4px',
+  },
+}));
+
+type Props = {
+  createAssociatedTokenAccount: any;
+};
+
+const AssociatedTokenWarning = (props: Props) => {
+  const { classes } = useStyles();
+  const [inProgress, setInProgress] = useState(false);
+  const [error, setError] = useState('');
+
+  const createAccount = async () => {
+    // if `createAccount` is already in progress, disable function
+    if (inProgress) {
+      return;
+    }
+
+    setInProgress(true);
+    setError('');
+
+    try {
+      await props.createAssociatedTokenAccount();
+      setError('');
+    } catch (e) {
+      setError('Encountered an error, please try again.');
+      console.error(e);
+    } finally {
+      setInProgress(false);
+    }
+  };
+
+  return (
+    <div className={classes.associatedTokenWarning}>
+      No associated token account exists for your wallet on Solana. You must
+      create it before proceeding.
+      {error && <div className={classes.error}>{error}</div>}
+      <div
+        className={joinClass([classes.link, inProgress && classes.disabled])}
+        onClick={createAccount}
+      >
+        {inProgress && (
+          <CircularProgress size={18} className={classes.inProgress} />
+        )}
+        Create account
+      </div>
+    </div>
+  );
+};
+
+const TokenWarnings = () => {
+  const dispatch = useDispatch();
+
+  const {
+    fromChain: sourceChain,
+    toChain: destChain,
+    token: sourceToken,
+    destToken,
+    foreignAsset,
+    associatedTokenAddress,
+    route,
+  } = useSelector((state: RootState) => state.transferInput);
+
+  const { receiving } = useSelector((state: RootState) => state.wallet);
+
+  const [showErrors, setShowErrors] = useState(false);
+  const [usdcAndNoCCTP, setUsdcAndNoCCTP] = useState(false);
+
+  const sourceTokenConfig = config.tokens[sourceToken];
+  const destTokenConfig = config.tokens[destToken];
+
+  // check if the destination token contract is deployed
+  useEffect(() => {
+    // Avoid race conditions
+    let active = true;
+
+    const checkWrappedTokenExists = async () => {
+      if (!destChain || !sourceTokenConfig || !route) {
+        dispatch(setForeignAsset(''));
+        setShowErrors(false);
+        return;
+      }
+
+      const tokenId = getWrappedTokenId(sourceTokenConfig);
+
+      if (!tokenId) {
+        throw new Error('Could not retrieve target token info');
+      }
+
+      const address = await RouteOperator.getForeignAsset(
+        route,
+        tokenId,
+        destChain,
+        destTokenConfig,
+      );
+
+      if (!active) {
+        return;
+      }
+
+      if (address) {
+        dispatch(setForeignAsset(address));
+        setShowErrors(false);
+      } else {
+        dispatch(setForeignAsset(''));
+        setShowErrors(true);
+      }
+    };
+
+    checkWrappedTokenExists();
+
+    return () => {
+      active = false;
+    };
+  }, [destChain, sourceTokenConfig, route, destTokenConfig, dispatch]);
+
+  // the associated token account address is deterministic, so we still
+  // need to check if there is an account created for that address
+  const checkSolanaAssociatedTokenAccount =
+    useCallback(async (): Promise<boolean> => {
+      return true;
+
+      /* TODO SDKV2
+      if (!foreignAsset || !tokenConfig) {
+        setShowErrors(false);
+        return false;
+      }
+      const tokenId =
+        getTokenById({ chain: 'solana', address: foreignAsset })?.tokenId ||
+        getWrappedTokenId(tokenConfig);
+      const account = await solanaContext().getAssociatedTokenAccount(
+        tokenId,
+        receiving.address,
+      );
+      // only set address if that actual account exists
+      if (account) {
+        dispatch(setAssociatedTokenAddress(account.toString()));
+        setShowErrors(false);
+        return true;
+      } else {
+        dispatch(setAssociatedTokenAddress(''));
+        setShowErrors(true);
+        return false;
+      }
+       */
+    }, [foreignAsset, sourceTokenConfig, receiving, dispatch]);
+
+  const createAssociatedTokenAccount = useCallback(async () => {
+    /*
+     * TODO SDKV2
+    if (!receiving.address || !token)
+      throw new Error(
+        'Must fill in all fields before you can create a token account',
+      );
+    if (!foreignAsset)
+      throw new Error(
+        'The token must be registered on Solana before an associated token account can be created',
+      );
+    const tokenId =
+      getTokenById({ chain: 'solana', address: foreignAsset })?.tokenId ||
+      getWrappedTokenId(sourceTokenConfig);
+    const tx = await solanaContext().createAssociatedTokenAccount(
+      tokenId,
+      receiving.address,
+      'finalized',
+    );
+    // if `tx` is null it means the account already exists
+    if (!tx) return;
+    await signAndSendTransaction('solana', tx, TransferWallet.RECEIVING);
+
+    let accountExists = false;
+    let retries = 0;
+    return await new Promise((resolve) => {
+      const checkAccount = setInterval(async () => {
+        if (accountExists || retries > 20) {
+          clearInterval(checkAccount);
+          resolve(true);
+        } else {
+          accountExists = await checkSolanaAssociatedTokenAccount();
+          retries += 1;
+        }
+      }, 1000);
+    });
+     */
+  }, [
+    sourceToken,
+    receiving,
+    foreignAsset,
+    sourceTokenConfig,
+    checkSolanaAssociatedTokenAccount,
+  ]);
+
+  useEffect(() => {
+    // if the url it's empty that means the user doesn't want this feature
+    const cctpWarningFlag = !!config.cctpWarning;
+    // check if the tokens will be wrapped USDC
+    const isResultWrappedUSDC =
+      sourceTokenConfig?.symbol === 'USDC' &&
+      destTokenConfig?.symbol === 'USDC' &&
+      destTokenConfig?.nativeChain !== destChain;
+    // check if the chains support CCTP
+    const bothChainsSupportCCTP =
+      destChain &&
+      //CCTP_CHAINS.includes(destChain) && TODO SDKV2
+      sourceChain; //&&
+    //CCTP_CHAINS.includes(destChain); TODO SDKV2
+    // check if the result is wrapped USDC and the chains involved support CCTP
+    // rationale:
+    // - transferring wrapped USDC back home (unwrapping) shouldn't be a warning
+    // - CCTP would show as USDC on both ends, but the result would be native (the same check as above)
+    // - if both chains don't support CCTP, it doesn't make sense to suggest using it,
+    //   (at least not with this warning) as the user doesn't have a clear alternative
+    //   and using the USDC (CCTP) only bridge wouldn't help
+    const usdcAndNoCCTP =
+      cctpWarningFlag && isResultWrappedUSDC && bothChainsSupportCCTP;
+
+    if (!destChain || !sourceToken || !receiving.address) return;
+    // The tBTC associated token account will be created if it doesn't exist in the redeem tx
+    // The NTT ATA will be created if it doesn't exist in the redeem tx
+    if (
+      destChain === 'solana' &&
+      foreignAsset &&
+      route !== Route.TBTC &&
+      !isNttRoute(route)
+    ) {
+      checkSolanaAssociatedTokenAccount();
+    }
+    if (usdcAndNoCCTP) {
+      setShowErrors(true);
+      setUsdcAndNoCCTP(true);
+    } else {
+      setShowErrors(false);
+      setUsdcAndNoCCTP(false);
+    }
+  }, [
+    destChain,
+    sourceToken,
+    foreignAsset,
+    receiving,
+    associatedTokenAddress,
+    checkSolanaAssociatedTokenAccount,
+    route,
+    sourceTokenConfig?.symbol,
+    sourceTokenConfig?.nativeChain,
+    destTokenConfig?.symbol,
+    destTokenConfig?.nativeChain,
+    sourceChain,
+  ]);
+
+  const noForeignAssetWarning = (
+    <Typography>
+      This token is not registered, you must{' '}
+      <Link target={'_blank'} variant="inherit" href={config.attestUrl}>
+        register
+      </Link>{' '}
+      it before you continue. Newly registered tokens will not have liquid
+      markets.
+    </Typography>
+  );
+
+  const noAssociatedTokenAccount = (
+    <AssociatedTokenWarning
+      createAssociatedTokenAccount={createAssociatedTokenAccount}
+    />
+  );
+
+  // warning message for users that attempt to transfer USDC using a different corridor than CCTP
+  const warningNoCCTPOption = (
+    <Typography>
+      This transaction will transfer wrapped USDC (wUSDC) to the destination
+      chain. If you want to transfer native USDC on chains supported by Circle's
+      CCTP, use the{' '}
+      <Link target={'_blank'} variant="inherit" href={config.cctpWarning}>
+        USDC Bridge
+      </Link>
+      .
+    </Typography>
+  );
+
+  let content;
+  if (!foreignAsset) {
+    content = noForeignAssetWarning;
+  } else if (destChain === 'solana' && route !== Route.Relay) {
+    content = noAssociatedTokenAccount;
+  } else if (usdcAndNoCCTP) {
+    content = warningNoCCTPOption;
+  }
+
+  return (
+    <AlertBanner
+      show={showErrors}
+      content={content}
+      warning
+      margin="12px 0 0 0"
+    />
+  );
+};
+
+export default TokenWarnings;

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -11,7 +11,7 @@ import IconButton from '@mui/material/IconButton';
 import { getTokenDetails } from 'telemetry';
 import { Context } from 'sdklegacy';
 
-import AlertBanner from 'components/AlertBanner';
+import AlertBannerV2 from 'components/v2/AlertBanner';
 import Button from 'components/v2/Button';
 import config from 'config';
 import { RoutesConfig } from 'config/routes';
@@ -342,11 +342,10 @@ const ReviewTransaction = (props: Props) => {
           disabled={isGasSliderDisabled}
         />
       </Collapse>
-      <AlertBanner
-        show={!!sendError}
-        content={sendError}
+      <AlertBannerV2
         error
-        margin="0 0 16px 0"
+        content={sendError}
+        show={!!sendError}
         testId="send-error-message"
       />
       {confirmTransactionButton}

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -19,7 +19,7 @@ import { RootState } from 'store';
 import { TransferWallet, WalletData, connectWallet } from 'utils/wallet';
 
 import WalletIcon from 'icons/WalletIcons';
-import AlertBanner from 'components/AlertBanner';
+import AlertBannerV2 from 'components/v2/AlertBanner';
 import { useAvailableWallets } from 'hooks/useAvailableWallets';
 
 const useStyles = makeStyles()(() => ({
@@ -135,9 +135,7 @@ const WalletSidebar = (props: Props) => {
       case 'loading':
         return <CircularProgress />;
       case 'error':
-        return (
-          <AlertBanner show={true} content={walletOptionsResult.error} error />
-        );
+        return <AlertBannerV2 error show content={walletOptionsResult.error} />;
       case 'result':
         if (walletOptionsResult.options?.length === 0) {
           return <></>;

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -34,9 +34,11 @@ import {
   setTransferRoute,
   setDestToken,
 } from 'store/transferInput';
+import { isTransferValid, useValidate } from 'utils/transferValidation';
 import { useConnectToLastUsedWallet } from 'utils/wallet';
 import WalletConnector from 'views/v2/Bridge/WalletConnector';
 import AssetPicker from 'views/v2/Bridge/AssetPicker';
+import TokenWarnings from 'views/v2/Bridge/AssetPicker/TokenWarnings';
 import WalletController from 'views/v2/Bridge/WalletConnector/Controller';
 import AmountInput from 'views/v2/Bridge/AmountInput';
 import Routes from 'views/v2/Bridge/Routes';
@@ -122,6 +124,7 @@ const Bridge = () => {
     route,
     routeStates,
     amount,
+    validations,
   } = useSelector((state: RootState) => state.transferInput);
 
   // Set selectedRoute if the route is auto-selected
@@ -188,6 +191,12 @@ const Bridge = () => {
 
   // Connect to any previously used wallets for the selected networks
   useConnectToLastUsedWallet();
+
+  // Call to initiate transfer inputs validations
+  useValidate();
+
+  // Get input validation result
+  const isValid = useMemo(() => isTransferValid(validations), [validations]);
 
   // All supported chains from the given configuration and any custom override
   const supportedChains = useMemo(
@@ -364,7 +373,7 @@ const Bridge = () => {
       <Button
         variant="primary"
         className={classes.reviewTransaction}
-        disabled={isFetching}
+        disabled={!isValid || isFetching}
         onClick={() => {
           if (
             routeStates &&
@@ -408,6 +417,7 @@ const Bridge = () => {
       {bridgeHeader}
       {sourceAssetPicker}
       {destAssetPicker}
+      <TokenWarnings />
       <AmountInput supportedSourceTokens={supportedSourceTokens} />
       <Routes selectedRoute={selectedRoute} onRouteChange={setSelectedRoute} />
       {walletConnector}

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -330,6 +330,16 @@ const Bridge = () => {
     );
   }, []);
 
+  const routeList = useMemo(() => {
+    if (!isValid) {
+      return <></>;
+    }
+
+    return (
+      <Routes selectedRoute={selectedRoute} onRouteChange={setSelectedRoute} />
+    );
+  }, [isValid, selectedRoute]);
+
   const walletConnector = useMemo(() => {
     if (sendingWallet?.address && receivingWallet?.address) {
       return null;
@@ -419,7 +429,7 @@ const Bridge = () => {
       {destAssetPicker}
       <TokenWarnings />
       <AmountInput supportedSourceTokens={supportedSourceTokens} />
-      <Routes selectedRoute={selectedRoute} onRouteChange={setSelectedRoute} />
+      {routeList}
       {walletConnector}
       {reviewTransactionButton}
       {config.showHamburgerMenu ? null : <FooterNavBar />}


### PR DESCRIPTION
This PR adds the redesigned <AlertBanner /> for token warnings and amount input errors.

Sample Token warning:
<img width="573" alt="Screenshot 2024-07-29 at 4 00 43 PM" src="https://github.com/user-attachments/assets/8fc85fc2-7d42-4571-90d8-b403773401d9">

Amount input error when it's zero:
<img width="604" alt="Screenshot 2024-07-29 at 4 25 17 PM" src="https://github.com/user-attachments/assets/256243d9-2800-4e71-99c4-4fcb34e5df92">

Amount input error when it's more than wallet balance:
<img width="625" alt="Screenshot 2024-07-29 at 4 25 09 PM" src="https://github.com/user-attachments/assets/18afc7bb-9a34-4848-ab85-168113a65eae">
