### PR TITLE
xlabs/portal-bridge-ui#965 - Cannot find token by contract address

### DIFF
--- a/wormhole-connect/src/components/TokensModal.tsx
+++ b/wormhole-connect/src/components/TokensModal.tsx
@@ -343,11 +343,14 @@ function TokensModal(props: Props) {
   const displayedTokens = useMemo(() => {
     if (!search) return tokens;
     return tokens.filter((c) => {
-      const symbol = c.symbol.toLowerCase();
-      return (
-        symbol.includes(search) ||
-        (c.tokenId && c.tokenId.address.toLowerCase().includes(search))
-      );
+      const tokenCriterias = [
+        c.symbol.toLowerCase(),
+        c.tokenId?.address?.toLowerCase?.(),
+        ...Object.values(c.foreignAssets || {}).map((foreignAsset) =>
+          foreignAsset.address.toLowerCase(),
+        ),
+      ].filter(Boolean);
+      return tokenCriterias.some((criteria) => criteria?.includes(search));
     });
   }, [tokens, search]);
 


### PR DESCRIPTION
Changed search functionality to also take into account possible matches from asset addresses present in other chains