### PR TITLE
[Redesign] Asset selector redesign and bug fixes

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -21,6 +21,7 @@ import { isDisabledChain } from 'store/transferInput';
 
 import type { ChainConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
+import { WormholeConnectTheme } from 'theme';
 
 const useStyles = makeStyles()((theme) => ({
   card: {
@@ -33,6 +34,16 @@ const useStyles = makeStyles()((theme) => ({
     fontSize: 14,
     marginBottom: '8px',
   },
+  searchList: {
+    maxHeight: 240,
+    overflow: 'auto',
+    paddingTop: 0,
+  },
+  searchBar: {
+    position: 'sticky',
+    top: 0,
+    background: (theme.palette as unknown as WormholeConnectTheme)?.modal?.background,
+  }
 }));
 
 type Props = {
@@ -136,11 +147,11 @@ const ChainList = (props: Props) => {
             ?.toLowerCase()
             .includes(chainSearchQuery.toLowerCase());
         })
-      : topChains;
+      : props.chainList;
 
     return (
-      <List>
-        <ListItem>
+      <List className={classes.searchList}>
+        <ListItem className={classes.searchBar}>
           <TextField
             autoFocus
             fullWidth

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -41,6 +41,13 @@ const useStyles = makeStyles()((theme) => ({
       border: '1px solid #C1BBF6',
     },
   },
+  chainItem: {
+    display: 'flex',
+    flexDirection: 'row',
+    padding: 8,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
 }));
 
 type Props = {
@@ -127,12 +134,7 @@ const ChainList = (props: Props) => {
             key={chain.key}
             dense
             disabled={isDisabledChain(chain.key, props.wallet)}
-            sx={{
-              display: 'flex',
-              flexDirection: 'row',
-              paddingLeft: 0,
-              marginBottom: 1,
-            }}
+            className={classes.chainItem}
             onClick={() => {
               props.onChainSelect(chain.key);
               props.setShowSearch(false);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { makeStyles } from 'tss-react/mui';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import List from '@mui/material/List';
@@ -10,14 +11,11 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import TokenIcon from 'icons/TokenIcons';
 
-import { makeStyles } from 'tss-react/mui';
-
+import { ChainName } from 'sdklegacy';
 import { isDisabledChain } from 'store/transferInput';
-
 import type { ChainConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
-import SearchableList from './SearchableList';
-import { ChainName } from 'sdklegacy';
+import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
 
 const useStyles = makeStyles()((theme) => ({
   card: {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -1,18 +1,13 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import IconButton from '@mui/material/IconButton';
-import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
 
 import AddIcon from '@mui/icons-material/Add';
-import SearchIcon from '@mui/icons-material/Search';
 import TokenIcon from 'icons/TokenIcons';
 
 import { makeStyles } from 'tss-react/mui';
@@ -21,7 +16,8 @@ import { isDisabledChain } from 'store/transferInput';
 
 import type { ChainConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
-import { WormholeConnectTheme } from 'theme';
+import SearchableList from './SearchableList';
+import { ChainName } from 'sdklegacy';
 
 const useStyles = makeStyles()((theme) => ({
   card: {
@@ -32,179 +28,133 @@ const useStyles = makeStyles()((theme) => ({
   },
   title: {
     fontSize: 14,
-    marginBottom: '8px',
+    marginBottom: 12,
   },
-  searchList: {
-    maxHeight: 240,
-    overflow: 'auto',
-    paddingTop: 0,
+  chainSearch: {
+    maxHeight: 400,
   },
-  searchBar: {
-    position: 'sticky',
-    top: 0,
-    background: (theme.palette as unknown as WormholeConnectTheme)?.modal?.background,
-    zIndex: 1,
-  }
+  chainButton: {
+    display: 'flex',
+    flexDirection: 'column',
+    borderRadius: 8,
+    '&.Mui-selected': {
+      border: '1px solid #C1BBF6',
+    },
+  },
 }));
 
 type Props = {
-  chainList?: Array<ChainConfig> | undefined;
-  selectedChainConfig?: ChainConfig | undefined;
+  chainList?: ChainConfig[];
+  selectedChainConfig?: ChainConfig;
   showSearch: boolean;
-  setShowSearch: any;
+  setShowSearch: (value: boolean) => void;
   wallet: WalletData;
-  onClick?: any;
+  onChainSelect: (chain: ChainName) => void;
 };
 
 const SHORT_LIST_SIZE = 5;
 
 const ChainList = (props: Props) => {
-  const [chainSearchQuery, setChainSearchQuery] = useState('');
-
   const { classes } = useStyles();
 
   const topChains = useMemo(() => {
-    const chains: Array<ChainConfig> = [];
-    const { chainList = [] } = props;
+    const allChains = props.chainList ?? [];
+    const selectedChain = props.selectedChainConfig;
 
     // Find the selected chain in supported chains
-    const selectedChainIndex = props.chainList?.findIndex((c) => {
-      return c.key === props.selectedChainConfig?.key;
+    const selectedChainIndex = allChains.findIndex((chain) => {
+      return chain.key === selectedChain?.key;
     });
 
     // If the selected chain is outside the top list, we add it to the top;
     // otherwise we do not change its index in the top list
     if (
-      props.selectedChainConfig &&
+      selectedChain &&
       selectedChainIndex &&
       selectedChainIndex >= SHORT_LIST_SIZE
     ) {
-      return chains.concat(
-        [props.selectedChainConfig],
-        chainList.slice(0, SHORT_LIST_SIZE - 1),
-      );
+      return [selectedChain, ...allChains.slice(0, SHORT_LIST_SIZE - 1)];
     }
 
-    return chains.concat(chainList.slice(0, SHORT_LIST_SIZE));
+    return allChains.slice(0, SHORT_LIST_SIZE);
   }, [props.chainList, props.selectedChainConfig]);
 
   const shortList = useMemo(() => {
     return (
-      <List component={Stack} direction="row">
-        {topChains.map((chain: ChainConfig, i: number) => {
-          if (React.isValidElement(chain)) {
-            return chain;
-          }
-
-          const disabled = isDisabledChain(chain.key, props.wallet);
-
-          return (
-            <ListItemButton
-              key={i}
-              disabled={disabled}
-              selected={props.selectedChainConfig?.key === chain.key}
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-              }}
-              onClick={() => props.onClick?.(chain.key)}
-            >
-              <TokenIcon icon={chain.icon} height={32} />
-              <Typography fontSize={14}>{chain.displayName}</Typography>
-            </ListItemButton>
-          );
-        })}
+      <List component={Stack} direction="row" gap={1}>
+        {topChains.map((chain: ChainConfig) => (
+          <ListItemButton
+            key={chain.key}
+            disabled={isDisabledChain(chain.key, props.wallet)}
+            selected={props.selectedChainConfig?.key === chain.key}
+            className={classes.chainButton}
+            onClick={() => props.onChainSelect(chain.key)}
+          >
+            <TokenIcon icon={chain.icon} height={32} />
+            <Typography fontSize={12}>{chain.displayName}</Typography>
+          </ListItemButton>
+        ))}
         <ListItemButton
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-          }}
+          className={classes.chainButton}
           onClick={() => {
-            props.setShowSearch?.(true);
+            props.setShowSearch(true);
           }}
         >
-          <IconButton
+          <AddIcon
             sx={{
-              width: 32,
-              height: 32,
-              '&:hover': {
-                // removing the hover effect, which the parent ListItemButton already has
-                backgroundColor: 'unset',
-              },
+              width: '32px',
+              height: '32px',
             }}
-          >
-            <AddIcon />
-          </IconButton>
+          />
           <Typography fontSize={12}>other</Typography>
         </ListItemButton>
       </List>
     );
   }, [topChains]);
 
-  const searchList = useMemo(() => {
-    const chains = chainSearchQuery
-      ? props.chainList?.filter((c: any) => {
-          return c.displayName
-            ?.toLowerCase()
-            .includes(chainSearchQuery.toLowerCase());
-        })
-      : props.chainList;
-
-    return (
-      <List className={classes.searchList}>
-        <ListItem className={classes.searchBar}>
-          <TextField
-            autoFocus
-            fullWidth
-            inputProps={{
-              style: {
-                fontSize: 12,
-              },
+  const searchList = useMemo(
+    () => (
+      <SearchableList<ChainConfig>
+        searchPlaceholder="Search for a network"
+        className={classes.chainSearch}
+        items={props.chainList ?? []}
+        filterFn={(chain, query) =>
+          !query ||
+          chain.displayName.toLowerCase().includes(query.toLowerCase())
+        }
+        renderFn={(chain) => (
+          <ListItemButton
+            key={chain.key}
+            dense
+            disabled={isDisabledChain(chain.key, props.wallet)}
+            sx={{
+              display: 'flex',
+              flexDirection: 'row',
+              paddingLeft: 0,
+              marginBottom: 1,
             }}
-            placeholder="Search for a network"
-            size="small"
-            variant="outlined"
-            onChange={(e) => setChainSearchQuery(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon />
-                </InputAdornment>
-              ),
+            onClick={() => {
+              props.onChainSelect(chain.key);
+              props.setShowSearch(false);
             }}
-          />
-        </ListItem>
-        {chains?.map((chain: ChainConfig, i: number) => {
-          const disabled = isDisabledChain(chain.key, props.wallet);
-          return (
-            <ListItemButton
-              key={chain.key}
-              dense
-              disabled={disabled}
-              sx={{
-                display: 'flex',
-                flexDirection: 'row',
-              }}
-              onClick={() => {
-                props.onClick?.(chain.key);
-                props.setShowSearch?.(false);
-              }}
-            >
-              <ListItemIcon>
-                <TokenIcon icon={chain.icon} height={32} />
-              </ListItemIcon>
-              <Typography fontSize={14}>{chain.displayName}</Typography>
-            </ListItemButton>
-          );
-        })}
-      </List>
-    );
-  }, [chainSearchQuery, topChains]);
+          >
+            <ListItemIcon sx={{ minWidth: 50 }}>
+              <TokenIcon icon={chain.icon} height={36} />
+            </ListItemIcon>
+            <Typography fontSize={16} fontWeight={500}>
+              {chain.displayName}
+            </Typography>
+          </ListItemButton>
+        )}
+      />
+    ),
+    [props.chainList, props.wallet],
+  );
 
   return (
     <Card className={classes.card} variant="elevation">
       <CardContent className={classes.cardContent}>
-        <Typography className={classes.title} fontSize={14}>
+        <Typography className={classes.title} fontSize={16} fontWeight={500}>
           Select a network
         </Typography>
         {props.showSearch ? searchList : shortList}

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles()((theme) => ({
     position: 'sticky',
     top: 0,
     background: (theme.palette as unknown as WormholeConnectTheme)?.modal?.background,
+    zIndex: 1,
   }
 }));
 

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/SearchInput.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/SearchInput.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import InputAdornment from '@mui/material/InputAdornment';
+import TextField from '@mui/material/TextField';
+import { makeStyles } from 'tss-react/mui';
+
+import SearchIcon from 'icons/Search';
+
+const useStyles = makeStyles()(() => ({
+  input: {
+    border: '1px solid #C1BBF6',
+    borderRadius: '100vh',
+    '& fieldset': {
+      border: 'none',
+    },
+    '& input::placeholder': {
+      color: 'white',
+      opacity: 0.2,
+    },
+  },
+  icon: {
+    height: 20,
+    width: 20,
+    color: 'white',
+    opacity: 0.2,
+  },
+}));
+
+type SearchInputProps = {
+  value: string;
+  onChange: (newValue: string) => void;
+  placeholder?: string;
+};
+
+export default function SearchInput(props: SearchInputProps) {
+  const { classes } = useStyles();
+
+  return (
+    <TextField
+      className={classes.input}
+      autoFocus
+      fullWidth
+      inputProps={{
+        style: {
+          fontSize: 14,
+          height: 22,
+          lineHeight: 22,
+        },
+      }}
+      placeholder={props.placeholder}
+      size="small"
+      variant="outlined"
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon className={classes.icon} />
+          </InputAdornment>
+        ),
+      }}
+    />
+  );
+}

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
@@ -1,0 +1,58 @@
+import React, { memo, useState, ReactNode, useMemo } from 'react';
+
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import { makeStyles } from 'tss-react/mui';
+
+import SearchInput from './SearchInput';
+
+const useStyles = makeStyles()(() => ({
+  wrapper: {
+    maxHeight: 240,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  searchList: {
+    marginTop: 12,
+    overflow: 'auto',
+  },
+}));
+
+type SearchableListProps<T> = {
+  title?: ReactNode;
+  listTitle?: ReactNode;
+  searchPlaceholder?: string;
+  className?: string;
+  initialItems?: T[]; // Items to render when search is not performed
+  items: T[];
+  loading?: ReactNode;
+  renderFn: (item: T, index: number) => ReactNode;
+  filterFn: (item: T, query: string) => boolean;
+};
+
+function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
+  const { classes } = useStyles();
+  const [query, setQuery] = useState('');
+
+  const filteredList = useMemo(() => {
+    if (!query && props.initialItems) return props.initialItems;
+    else return props.items.filter((item) => props.filterFn(item, query));
+  }, [props.items, props.filterFn, query]);
+
+  return (
+    <Box className={`${classes.wrapper} ${props?.className ?? ''}`}>
+      {props.title}
+      <SearchInput
+        value={query}
+        onChange={setQuery}
+        placeholder={props.searchPlaceholder}
+      />
+      <List className={classes.searchList}>
+        {props.listTitle}
+        {props.loading || filteredList.map(props.renderFn)}
+      </List>
+    </Box>
+  );
+}
+
+export default memo(SearchableList) as typeof SearchableList;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
@@ -35,8 +35,11 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
   const [query, setQuery] = useState('');
 
   const filteredList = useMemo(() => {
-    if (!query && props.initialItems) return props.initialItems;
-    else return props.items.filter((item) => props.filterFn(item, query));
+    if (!query && props.initialItems) {
+      return props.initialItems;
+    } else {
+      return props.items.filter((item) => props.filterFn(item, query));
+    }
   }, [props.items, props.filterFn, query]);
 
   return (

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -1,14 +1,15 @@
 import React, { memo } from 'react';
+import { makeStyles } from 'tss-react/mui';
+import { useTheme } from '@mui/material';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
-import { useTheme } from '@mui/material';
-import OpenInNew from '@mui/icons-material/OpenInNew';
-import { makeStyles } from 'tss-react/mui';
 
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import TokenIcon from 'icons/TokenIcons';
+
 import { ChainConfig, TokenConfig } from 'config/types';
 import config from 'config';
 
@@ -75,7 +76,7 @@ function TokenItem(props: TokenItemProps) {
                 target="_blank"
               >
                 {addressDisplay}
-                <OpenInNew sx={{ height: '8px', width: '12px' }} />
+                <OpenInNewIcon sx={{ height: '8px', width: '12px' }} />
               </Link>
             )}
           </Typography>

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -1,0 +1,70 @@
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import CircularProgress from '@mui/material/CircularProgress';
+import React, { memo } from 'react';
+import { makeStyles } from 'tss-react/mui';
+import TokenIcon from 'icons/TokenIcons';
+import Typography from '@mui/material/Typography';
+import { TokenConfig } from 'config/types';
+import config from 'config';
+import { useTheme } from '@mui/material';
+
+const useStyles = makeStyles()(() => ({
+  tokenListItem: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    paddingLeft: 8,
+    borderRadius: 8,
+  },
+  tokenDetails: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+}));
+
+type TokenItemProps = {
+  token: TokenConfig;
+  disabled?: boolean;
+  onClick: () => void;
+  balance?: string;
+  isFetchingBalance?: boolean;
+};
+
+function TokenItem(props: TokenItemProps) {
+  const { classes } = useStyles();
+  const theme = useTheme();
+
+  const nativeChainConfig = config.chains[props.token.nativeChain];
+  const nativeChain = nativeChainConfig?.displayName || '';
+
+  return (
+    <ListItemButton
+      className={classes.tokenListItem}
+      dense
+      disabled={props.disabled}
+      onClick={props.onClick}
+    >
+      <div className={classes.tokenDetails}>
+        <ListItemIcon>
+          <TokenIcon icon={props.token.icon} height={32} />
+        </ListItemIcon>
+        <div>
+          <Typography fontSize={16}>{props.token.symbol}</Typography>
+          <Typography fontSize={10} color={theme.palette.text.secondary}>
+            {nativeChain}
+          </Typography>
+        </div>
+      </div>
+      <Typography fontSize={14}>
+        {props.isFetchingBalance ? (
+          <CircularProgress size={24} />
+        ) : (
+          props.balance
+        )}
+      </Typography>
+    </ListItemButton>
+  );
+}
+
+export default memo(TokenItem);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -1,13 +1,16 @@
+import React, { memo } from 'react';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import CircularProgress from '@mui/material/CircularProgress';
-import React, { memo } from 'react';
-import { makeStyles } from 'tss-react/mui';
-import TokenIcon from 'icons/TokenIcons';
 import Typography from '@mui/material/Typography';
-import { TokenConfig } from 'config/types';
-import config from 'config';
+import Link from '@mui/material/Link';
 import { useTheme } from '@mui/material';
+import OpenInNew from '@mui/icons-material/OpenInNew';
+import { makeStyles } from 'tss-react/mui';
+
+import TokenIcon from 'icons/TokenIcons';
+import { ChainConfig, TokenConfig } from 'config/types';
+import config from 'config';
 
 const useStyles = makeStyles()(() => ({
   tokenListItem: {
@@ -20,6 +23,11 @@ const useStyles = makeStyles()(() => ({
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  addressLink: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    marginLeft: 4,
   },
 }));
 
@@ -35,8 +43,13 @@ function TokenItem(props: TokenItemProps) {
   const { classes } = useStyles();
   const theme = useTheme();
 
-  const nativeChainConfig = config.chains[props.token.nativeChain];
-  const nativeChain = nativeChainConfig?.displayName || '';
+  const chainConfig: ChainConfig | undefined =
+    config.chains[props.token.tokenId?.chain ?? ''];
+  const address = props.token.tokenId?.address;
+  const explorerURL = `${chainConfig?.explorerUrl}address/${address}`;
+  const addressDisplay = `${address?.slice(0, 4)}...${address?.slice(-4)}`;
+
+  const displayName = props.token.displayName ?? props.token.symbol;
 
   return (
     <ListItemButton
@@ -52,7 +65,19 @@ function TokenItem(props: TokenItemProps) {
         <div>
           <Typography fontSize={16}>{props.token.symbol}</Typography>
           <Typography fontSize={10} color={theme.palette.text.secondary}>
-            {nativeChain}
+            {displayName}
+            {!!address && (
+              <Link
+                onClick={(e) => e.stopPropagation()}
+                className={classes.addressLink}
+                href={explorerURL}
+                rel="noreferrer noopener"
+                target="_blank"
+              >
+                {addressDisplay}
+                <OpenInNew sx={{ height: '8px', width: '12px' }} />
+              </Link>
+            )}
           </Typography>
         </div>
       </div>

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -11,9 +11,8 @@ import config from 'config';
 import useGetTokenBalances from 'hooks/useGetTokenBalances';
 import type { ChainConfig, TokenConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
-
-import SearchableList from './SearchableList';
-import TokenItem from './TokenItem';
+import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
+import TokenItem from 'views/v2/Bridge/AssetPicker/TokenItem';
 
 const useStyles = makeStyles()((theme) => ({
   card: {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -1,24 +1,19 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useTheme } from '@mui/material';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import CircularProgress from '@mui/material/CircularProgress';
-import InputAdornment from '@mui/material/InputAdornment';
-import List from '@mui/material/List';
-import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
 import Typography from '@mui/material/Typography';
-import TextField from '@mui/material/TextField';
-import SearchIcon from '@mui/icons-material/Search';
 import { makeStyles } from 'tss-react/mui';
 
 import config from 'config';
 import useGetTokenBalances from 'hooks/useGetTokenBalances';
-import TokenIcon from 'icons/TokenIcons';
-
 import type { ChainConfig, TokenConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
+
+import SearchableList from './SearchableList';
+import TokenItem from './TokenItem';
 
 const useStyles = makeStyles()((theme) => ({
   card: {
@@ -31,14 +26,12 @@ const useStyles = makeStyles()((theme) => ({
     fontSize: 14,
     marginBottom: '8px',
   },
-  tokenListItem: {
+  tokenLoader: {
     display: 'flex',
     justifyContent: 'space-between',
   },
-  tokenDetails: {
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'center',
+  tokenList: {
+    maxHeight: 340,
   },
 }));
 
@@ -48,16 +41,13 @@ type Props = {
   selectedChainConfig?: ChainConfig | undefined;
   selectedToken?: string | undefined;
   wallet: WalletData;
-  onClick?: (key: string) => void;
+  onSelectToken: (key: string) => void;
 };
 
 const SHORT_LIST_SIZE = 5;
 
 const TokenList = (props: Props) => {
-  const [tokenSearchQuery, setTokenSearchQuery] = useState('');
-
   const { classes } = useStyles();
-
   const theme = useTheme();
 
   const { isFetching: isFetchingTokenBalances, balances } = useGetTokenBalances(
@@ -118,103 +108,53 @@ const TokenList = (props: Props) => {
     return tokens;
   }, [balances, props.tokenList]);
 
-  const searchList = useMemo(() => {
-    const tokens = tokenSearchQuery
-      ? props.tokenList?.filter((t: TokenConfig) => {
-          const query = tokenSearchQuery.toLowerCase();
-          return (
-            t.symbol?.toLowerCase().includes(query) ||
-            t.displayName?.toLowerCase().includes(query)
-          );
-        })
-      : topTokens;
-
-    return (
-      <List>
-        <ListItem>
-          <TextField
-            autoFocus
-            fullWidth
-            inputProps={{
-              style: {
-                fontSize: 12,
-              },
-            }}
-            placeholder="Search for a token"
-            size="small"
-            variant="outlined"
-            onChange={(e) => setTokenSearchQuery(e.target.value)}
-            InputProps={{
-              startAdornment: (
-                <InputAdornment position="start">
-                  <SearchIcon />
-                </InputAdornment>
-              ),
-            }}
-          />
-        </ListItem>
-        {props.selectedChainConfig && (
-          <ListItem>
-            <Typography
-              fontSize={14}
-              color={theme.palette.text.secondary}
-            >{`Tokens on ${props.selectedChainConfig.displayName}`}</Typography>
-          </ListItem>
-        )}
-        {props.isFetching ? (
-          <ListItemButton className={classes.tokenListItem} dense>
+  const searchList = (
+    <SearchableList<TokenConfig>
+      searchPlaceholder="Search for a token"
+      className={classes.tokenList}
+      listTitle={
+        props.selectedChainConfig && (
+          <Typography fontSize={14} color={theme.palette.text.secondary}>
+            Tokens on {props.selectedChainConfig.displayName}
+          </Typography>
+        )
+      }
+      loading={
+        props.isFetching && (
+          <ListItemButton className={classes.tokenLoader} dense>
             <CircularProgress />
           </ListItemButton>
-        ) : (
-          tokens?.map((token: TokenConfig, i: number) => {
-            const nativeChainConfig = config.chains[token.nativeChain];
-            const nativeChain = nativeChainConfig?.displayName || '';
-            const balance = balances?.[token.key]?.balance;
+        )
+      }
+      initialItems={topTokens}
+      items={props.tokenList ?? []}
+      filterFn={(token, query) => {
+        if (query.length === 0) return true;
+        const queryLC = query.toLowerCase();
+        return Boolean(
+          token.symbol?.toLowerCase().includes(queryLC) ||
+            token.displayName?.toLowerCase().includes(queryLC),
+        );
+      }}
+      renderFn={(token: TokenConfig) => {
+        const balance = balances?.[token.key]?.balance;
+        const disabled = !!props.wallet?.address && !!balances && !balance;
 
-            return (
-              <ListItemButton
-                key={token.key}
-                className={classes.tokenListItem}
-                dense
-                disabled={!!props.wallet?.address && !!balances && !balance}
-                onClick={() => {
-                  props.onClick?.(token.key);
-                }}
-              >
-                <div className={classes.tokenDetails}>
-                  <ListItemIcon>
-                    <TokenIcon icon={token.icon} height={32} />
-                  </ListItemIcon>
-                  <div>
-                    <Typography fontSize={16}>{token.symbol}</Typography>
-                    <Typography
-                      fontSize={10}
-                      color={theme.palette.text.secondary}
-                    >
-                      {nativeChain}
-                    </Typography>
-                  </div>
-                </div>
-                <Typography fontSize={14}>
-                  {isFetchingTokenBalances ? (
-                    <CircularProgress size={24} />
-                  ) : (
-                    balance
-                  )}
-                </Typography>
-              </ListItemButton>
-            );
-          })
-        )}
-      </List>
-    );
-  }, [
-    isFetchingTokenBalances,
-    balances,
-    props.isFetching,
-    tokenSearchQuery,
-    topTokens,
-  ]);
+        return (
+          <TokenItem
+            key={token.key}
+            token={token}
+            disabled={disabled}
+            onClick={() => {
+              props.onSelectToken(token.key);
+            }}
+            balance={balance ?? ''}
+            isFetchingBalance={isFetchingTokenBalances}
+          />
+        );
+      }}
+    />
+  );
 
   return (
     <Card className={classes.card} variant="elevation">

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -165,8 +165,8 @@ const AssetPicker = (props: Props) => {
           showSearch={showChainSearch}
           setShowSearch={setShowChainSearch}
           wallet={props.wallet}
-          onClick={(key: string) => {
-            props.setChain(key as ChainName);
+          onChainSelect={(key) => {
+            props.setChain(key);
           }}
         />
         {!showChainSearch && chainConfig && (
@@ -176,7 +176,7 @@ const AssetPicker = (props: Props) => {
             selectedChainConfig={chainConfig}
             selectedToken={props.token}
             wallet={props.wallet}
-            onClick={(key: string) => {
+            onSelectToken={(key: string) => {
               props.setToken(key);
               popupState.close();
             }}

--- a/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import config from 'config';
+
 import { useDispatch, useSelector } from 'react-redux';
+import IconButton from '@mui/material/IconButton';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+import { makeStyles } from 'tss-react/mui';
+
+import config from 'config';
 import { RootState } from 'store';
 import { swapChains } from 'store/transferInput';
 import { swapWallets } from 'store/wallet';
-import { makeStyles } from 'tss-react/mui';
-import SwapVertIcon from '@mui/icons-material/SwapVert';
-
-import IconButton from '@mui/material/IconButton';
 
 const useStyles = makeStyles()(() => ({
   swapButton: {

--- a/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import config from 'config';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'store';
+import { swapChains } from 'store/transferInput';
+import { swapWallets } from 'store/wallet';
+import { makeStyles } from 'tss-react/mui';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+
+import IconButton from '@mui/material/IconButton';
+
+const useStyles = makeStyles()(() => ({
+  swapButton: {
+    display: 'block',
+    position: 'absolute',
+    bottom: -48,
+    left: 'calc(50% - 20px)',
+    width: 40,
+    height: 40,
+    zIndex: 1,
+  },
+}));
+
+function SwapChains() {
+  const dispatch = useDispatch();
+
+  const { isTransactionInProgress, fromChain, toChain } = useSelector(
+    (state: RootState) => state.transferInput,
+  );
+
+  const canSwap =
+    fromChain &&
+    !config.chains[fromChain]?.disabledAsDestination &&
+    toChain &&
+    !config.chains[toChain]?.disabledAsDestination;
+
+  const swap = () => {
+    if (!canSwap) return;
+    if (isTransactionInProgress) return;
+    dispatch(swapChains());
+    dispatch(swapWallets());
+  };
+
+  const { classes } = useStyles();
+
+  return (
+    <IconButton
+      className={classes.swapButton}
+      onClick={swap}
+      disabled={!canSwap}
+    >
+      <SwapVertIcon color="secondary" />
+    </IconButton>
+  );
+}
+
+export default SwapChains;

--- a/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/SwapChains/index.tsx
@@ -36,8 +36,7 @@ function SwapChains() {
     !config.chains[toChain]?.disabledAsDestination;
 
   const swap = () => {
-    if (!canSwap) return;
-    if (isTransactionInProgress) return;
+    if (!canSwap || isTransactionInProgress) return;
     dispatch(swapChains());
     dispatch(swapWallets());
   };

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -43,10 +43,12 @@ import WalletController from 'views/v2/Bridge/WalletConnector/Controller';
 import AmountInput from 'views/v2/Bridge/AmountInput';
 import Routes from 'views/v2/Bridge/Routes';
 import ReviewTransaction from 'views/v2/Bridge/ReviewTransaction';
+import SwapChains from 'views/v2/Bridge/SwapChains';
 
 const useStyles = makeStyles()((theme) => ({
   assetPickerContainer: {
     width: '100%',
+    position: 'relative',
   },
   assetPickerTitle: {
     color: theme.palette.text.secondary,
@@ -271,6 +273,7 @@ const Bridge = () => {
           }}
           wallet={sendingWallet}
         />
+        <SwapChains />
       </div>
     );
   }, [


### PR DESCRIPTION
Changes:
-  Restructure AssetPicker for UI v2
-  Improve AssetPickerv2 UI
-  Add swap chains button to redesign UI
-  Show all networks as scrollable in Asset Picker
-  Display Token names in asset picker and add Explorer URLs

Screenshots:
![Screenshot from 2024-08-14 04-35-29](https://github.com/user-attachments/assets/2d3a051e-0a03-4900-99f2-2c8a0ab15eb3)
![Screenshot from 2024-08-14 04-35-20](https://github.com/user-attachments/assets/9abee2d4-ea6f-492c-b0f8-3654cd0dcbd9)
![Screenshot from 2024-08-14 04-35-08](https://github.com/user-attachments/assets/8030fb65-6fd4-4227-b7c1-9d97e69029a4)


