### PR TITLE
Pre-select network when asset picker is opened

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -19,6 +19,7 @@ import TokenIcon from 'icons/TokenIcons';
 
 import type { ChainConfig, TokenConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
+import { isDisabledChain } from 'store/transferInput';
 import ChainList from './ChainList';
 import TokenList from './TokenList';
 import { Chain } from '@wormhole-foundation/sdk';
@@ -51,7 +52,7 @@ const useStyles = makeStyles()((theme) => ({
 
 type Props = {
   chain?: Chain | undefined;
-  chainList?: Array<ChainConfig> | undefined;
+  chainList: Array<ChainConfig>;
   token?: string;
   tokenList?: Array<TokenConfig> | undefined;
   isFetching?: boolean;
@@ -79,6 +80,18 @@ const AssetPicker = (props: Props) => {
       setTimeout(() => {
         setShowChainSearch(false);
       }, 300);
+    }
+  }, [popupState.isOpen]);
+
+  // Pre-selecting first allowed chain, when asset picker is opened
+  useEffect(() => {
+    if (popupState.isOpen && !props.chain) {
+      const firstAllowedChain = props.chainList.find(
+        (chain) => !isDisabledChain(chain.key, props.wallet),
+      );
+      if (firstAllowedChain) {
+        props.setChain(firstAllowedChain.key);
+      }
     }
   }, [popupState.isOpen]);
 


### PR DESCRIPTION
Fixes: https://www.notion.so/wormholelabs/UI-BUG-tapping-on-select-chain-and-token-should-open-full-menu-8f363535e6e54acf8936524b663ec6ef
