### PR TITLE
[bug] "Manual Bridge" route becomes available after user changes wallet to "Sui MetaMask Snap", but wallet has not been connected #991

### DIFF
--- a/wormhole-connect/src/views/WalletModal.tsx
+++ b/wormhole-connect/src/views/WalletModal.tsx
@@ -162,14 +162,17 @@ function WalletsModal(props: Props) {
   const connect = async (walletInfo: WalletData) => {
     const chain = type === TransferWallet.SENDING ? fromChain : toChain;
     dispatch(setWalletModal(false));
+    if (props.onClose) props.onClose();
+
+    await connectWallet(props.type, chain!, walletInfo, dispatch);
+
+    /** sets manual address to false only after successfully connecting a wallet */
     if (
       type === TransferWallet.RECEIVING &&
       walletInfo.name !== MANUAL_WALLET_NAME
     ) {
       dispatch(setManualAddressTarget(false));
     }
-    if (props.onClose) props.onClose();
-    await connectWallet(props.type, chain!, walletInfo, dispatch);
   };
 
   const displayWalletOptions = (wallets: WalletData[]): JSX.Element[] => {


### PR DESCRIPTION
[[bug] "Manual Bridge" route becomes available after user changes wallet to "Sui MetaMask Snap", but wallet has not been connected #99](https://github.com/XLabs/portal-bridge-ui/issues/991)

[[bug] "Manual Bridge" route becomes available after user closes "WalletConnect" pop-up #990](https://github.com/XLabs/portal-bridge-ui/issues/990)


https://github.com/user-attachments/assets/0416ee80-76bc-400e-8151-3e18149dbaa8

