### PR TITLE
[bug] USD equivalent of BONK is not displayed #845

### DIFF
--- a/wormhole-connect/src/hooks/useFetchTokenPrices.ts
+++ b/wormhole-connect/src/hooks/useFetchTokenPrices.ts
@@ -15,20 +15,21 @@ export const useFetchTokenPrices = (): void => {
     const controller = new AbortController();
     const signal = controller.signal;
 
-    const coingeckoIds = Object.values(config.tokens)
-      .filter((config) => !!config.coinGeckoId)
-      .map(({ coinGeckoId }) => coinGeckoId)
-      .join(',');
-
-    const headers = new Headers({
-      'Content-Type': 'application/json',
-      ...(config.coinGeckoApiKey
-        ? { 'x-cg-pro-api-key': config.coinGeckoApiKey }
-        : {}),
-    });
     const fetchTokenPrices = async () => {
       while (!cancelled) {
         try {
+          /** arbitrary delay to read from config mutable object after all sync and react's async processes affecting config have been queued  */
+          await sleep(10);
+          const headers = new Headers({
+            'Content-Type': 'application/json',
+            ...(config.coinGeckoApiKey
+              ? { 'x-cg-pro-api-key': config.coinGeckoApiKey }
+              : {}),
+          });
+          const coingeckoIds = Object.values(config.tokens)
+            .filter((config) => !!config.coinGeckoId)
+            .map(({ coinGeckoId }) => coinGeckoId)
+            .join(',');
           // Make API call to fetch token prices
           // In the case the user https://apiguide.coingecko.com/getting-started/getting-started#id-2.-making-api-request
           const res = await fetch(


### PR DESCRIPTION
[[bug] USD equivalent of BONK is not displayed #845](https://github.com/XLabs/portal-bridge-ui/issues/845)

* added arbitrary delay to read from config mutable object after all sync and react's async processes affecting config have been queued

before
![image](https://github.com/user-attachments/assets/c9ddf44b-8de5-4846-957b-637ec51488c9)
![image](https://github.com/user-attachments/assets/f51ef1cb-fcee-46e1-b373-ccf98e975251)


after
![image](https://github.com/user-attachments/assets/738094e5-45c3-4a54-b725-ea86f925313c)
![image](https://github.com/user-attachments/assets/8e2a174a-d839-496c-8743-14b154268862)

<img width="1187" alt="image" src="https://github.com/user-attachments/assets/58f0eb6a-eeb5-42bc-9c23-ce719edd9c4c">

<img width="513" alt="image" src="https://github.com/user-attachments/assets/192c59cc-ff5f-44e9-9380-a481315344db">

