### PR TITLE
Export routes from index

### DIFF
--- a/wormhole-connect/src/components/DemoApp/index.tsx
+++ b/wormhole-connect/src/components/DemoApp/index.tsx
@@ -33,16 +33,15 @@ import { compressToBase64, decompressFromBase64 } from 'lz-string';
 import { routes } from '@wormhole-foundation/sdk';
 import { MayanRoute } from '@mayanfinance/wormhole-sdk-route';
 import { NTT_TEST_CONFIG_TESTNET, NTT_TEST_CONFIG_MAINNET } from './consts';
-
-// Using ts-ignore on these because TypeScript is confused and thinks they're unused
-// (They are meant to be used by the code passed into eval() below)
-/* @ts-ignore */
 import { DEFAULT_ROUTES, nttRoutes } from 'routes/operator';
+
 const MAX_URL_SIZE = 30_000; // 30kb (HTTP header limit is set to 32kb)
 
 const parseConfig = (config: string): WormholeConnectConfig => {
   if (config) {
     try {
+      // Using ts-ignore on these because TypeScript is confused
+      // (They are meant to be used by the code passed into eval() below)
       /* @ts-ignore */
       window.DEFAULT_ROUTES = DEFAULT_ROUTES;
       /* @ts-ignore */

--- a/wormhole-connect/src/index.ts
+++ b/wormhole-connect/src/index.ts
@@ -10,23 +10,47 @@ import { dark, light } from './theme';
 import MAINNET from './config/mainnet';
 import TESTNET from './config/testnet';
 
+// Routes
 import { DEFAULT_ROUTES, nttRoutes } from './routes/operator';
+import { routes } from '@wormhole-foundation/sdk';
+import { MayanRoute } from '@mayanfinance/wormhole-sdk-route';
+import {
+  nttAutomaticRoute,
+  nttManualRoute,
+} from '@wormhole-foundation/sdk-route-ntt';
 
 import type { WormholeConnectConfig } from './config/types';
-import type { Chain, routes } from '@wormhole-foundation/sdk';
+import type { Chain } from '@wormhole-foundation/sdk';
+
+const {
+  AutomaticTokenBridgeRoute,
+  TokenBridgeRoute,
+  AutomaticCCTPRoute,
+  CCTPRoute,
+} = routes;
 
 export default WormholeConnect;
 
 export {
   MAINNET,
   TESTNET,
+
+  // Types
   WormholeConnectConfig,
   Chain,
-  dark,
-  light,
-  DEFAULT_ROUTES,
-  nttRoutes,
-  routes,
   WormholeConnectPartialTheme,
   WormholeConnectTheme,
+  dark,
+  light,
+
+  // Routes
+  DEFAULT_ROUTES,
+  nttRoutes,
+  nttAutomaticRoute,
+  nttManualRoute,
+  AutomaticTokenBridgeRoute,
+  TokenBridgeRoute,
+  AutomaticCCTPRoute,
+  CCTPRoute,
+  MayanRoute,
 };


### PR DESCRIPTION
Adds exports to `index.ts` that make it easier for integrators to configure their own list of routes.