### PR TITLE
xlabs/portal-bridge-ui#1026 - block ui while the routes gets resolved to avoid bad state

### DIFF
--- a/wormhole-connect/src/components/AlertBanner.tsx
+++ b/wormhole-connect/src/components/AlertBanner.tsx
@@ -2,6 +2,7 @@ import { Collapse } from '@mui/material';
 import React from 'react';
 import { makeStyles } from 'tss-react/mui';
 import AlertIcon from 'icons/Alert';
+import InfoIcon from 'icons/Info';
 import { OPACITY, joinClass } from 'utils/style';
 
 const useStyles = makeStyles()((theme: any) => ({
@@ -21,6 +22,9 @@ const useStyles = makeStyles()((theme: any) => ({
   warning: {
     backgroundColor: theme.palette.warning[500] + OPACITY[25],
   },
+  info: {
+    backgroundColor: theme.palette.info[500] + OPACITY[25],
+  },
 }));
 
 type Props = {
@@ -28,6 +32,7 @@ type Props = {
   content: React.ReactNode | undefined;
   warning?: boolean;
   error?: boolean;
+  info?: boolean;
   margin?: string;
   testId?: string;
 };
@@ -42,11 +47,12 @@ function AlertBanner(props: Props) {
           classes.base,
           !!props.warning && classes.warning,
           !!props.error && classes.error,
+          !!props.info && classes.info,
         ])}
         style={{ margin: props.margin || 0 }}
         data-testid={props.testId}
       >
-        <AlertIcon />
+        {props.info ? <InfoIcon /> : <AlertIcon />}
         {props.content}
       </div>
     </Collapse>

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -132,6 +132,7 @@ export interface TransferInputState {
   supportedDestTokens: TokenConfig[];
   manualAddressTarget: boolean;
   showManualAddressInput: boolean;
+  resolvingRoutes: boolean;
 }
 
 // This is a function because config might have changed since we last cleared this store
@@ -174,6 +175,7 @@ function getInitialState(): TransferInputState {
     supportedDestTokens: [],
     manualAddressTarget: false,
     showManualAddressInput: config.manualTargetAddress || false,
+    resolvingRoutes: false,
   };
 }
 
@@ -297,6 +299,12 @@ export const transferInputSlice = createSlice({
   name: 'transfer',
   initialState: getInitialState(),
   reducers: {
+    setResolvingRoutes(
+      state: TransferInputState,
+      { payload }: PayloadAction<boolean>,
+    ) {
+      state.resolvingRoutes = payload;
+    },
     // validations
     setValidations: (
       state: TransferInputState,
@@ -574,6 +582,7 @@ export const {
   swapChains,
   setManualAddressTarget,
   showManualAddressInput,
+  setResolvingRoutes,
 } = transferInputSlice.actions;
 
 export default transferInputSlice.reducer;

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -183,7 +183,9 @@ export const validateToNativeAmt = (
 export const validateRoute = (
   route: Route | undefined,
   availableRoutes: string[] | undefined,
+  resolvingRoutes = false,
 ): ValidationErr => {
+  if (resolvingRoutes) return '';
   if (!route || !availableRoutes || !availableRoutes.includes(route)) {
     return 'No bridge or swap route available for selected tokens';
   }
@@ -295,6 +297,7 @@ export const validateAll = async (
     routeStates,
     receiveAmount,
     manualAddressTarget,
+    resolvingRoutes,
   } = transferData;
   const { maxSwapAmt, toNativeToken } = relayData;
   const { sending, receiving } = walletData;
@@ -326,7 +329,7 @@ export const validateAll = async (
       maxSendAmount,
       isCctpTx,
     ),
-    route: validateRoute(route, availableRoutes),
+    route: validateRoute(route, availableRoutes, resolvingRoutes),
     toNativeToken: '',
     foreignAsset: validateForeignAsset(foreignAsset),
     relayerFee: '',

--- a/wormhole-connect/src/views/Bridge/Bridge.tsx
+++ b/wormhole-connect/src/views/Bridge/Bridge.tsx
@@ -53,6 +53,7 @@ import { isNttRoute } from 'routes/utils';
 import { useConnectToLastUsedWallet } from 'utils/wallet';
 import { USDTBridge } from 'routes/porticoBridge/usdtBridge';
 import { isAutomatic } from 'utils/route';
+import AlertBanner from 'components/AlertBanner';
 
 const useStyles = makeStyles()((_theme) => ({
   spacer: {
@@ -105,6 +106,7 @@ function Bridge() {
     isTransactionInProgress,
     amount,
     manualAddressTarget,
+    resolvingRoutes,
   }: TransferInputState = useSelector(
     (state: RootState) => state.transferInput,
   );
@@ -351,6 +353,13 @@ function Bridge() {
       <SwapChains />
       <ToInputs />
 
+      <AlertBanner
+        show={resolvingRoutes}
+        content="Resolving available routes..."
+        info
+        margin="0 0 16px 0"
+        testId="resolving-routes-message"
+      />
       <ValidationError
         forceShow={showRouteValidation}
         validations={[validations.route]}


### PR DESCRIPTION
Current Behavior:
- If the widget already has routes resolved and the user changes the chain while the network is slow, it re-renders using the routes from the current state without waiting for the new routes array to be resolved.

New Behavior:
- On network selection change, we reset the routes, display a banner to inform the user of what’s happening, and update the resolved routes once the computation and network calls has finished.

https://github.com/user-attachments/assets/80d79fc5-5b25-45a1-9967-26dfbab62c1f

