### PR TITLE
TokenPicker should show token addresses for selected chain

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -13,6 +13,9 @@ import TokenIcon from 'icons/TokenIcons';
 import { ChainConfig, TokenConfig } from 'config/types';
 import config from 'config';
 
+import type { Chain } from '@wormhole-foundation/sdk';
+import { getWrappedToken } from 'utils';
+
 const useStyles = makeStyles()(() => ({
   tokenListItem: {
     display: 'flex',
@@ -34,6 +37,7 @@ const useStyles = makeStyles()(() => ({
 
 type TokenItemProps = {
   token: TokenConfig;
+  chain: Chain;
   disabled?: boolean;
   onClick: () => void;
   balance?: string;
@@ -44,10 +48,17 @@ function TokenItem(props: TokenItemProps) {
   const { classes } = useStyles();
   const theme = useTheme();
 
-  const chainConfig: ChainConfig | undefined =
-    config.chains[props.token.tokenId?.chain ?? ''];
-  const address = props.token.tokenId?.address;
-  const explorerURL = `${chainConfig?.explorerUrl}address/${address}`;
+  const { chain, token } = props;
+  const chainConfig: ChainConfig | undefined = config.chains[chain];
+  // If the token is native to the chain, show the token's address.
+  // Otherwise, show the wrapped token's address.
+  const address =
+    chain === token.nativeChain
+      ? token.tokenId?.address
+      : getWrappedToken(token)?.foreignAssets?.[chain]?.address;
+  const explorerURL = address
+    ? `${chainConfig?.explorerUrl}address/${address}`
+    : undefined;
   const addressDisplay = `${address?.slice(0, 4)}...${address?.slice(-4)}`;
 
   const displayName = props.token.displayName ?? props.token.symbol;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -37,7 +37,7 @@ const useStyles = makeStyles()((theme) => ({
 type Props = {
   tokenList?: Array<TokenConfig> | undefined;
   isFetching?: boolean;
-  selectedChainConfig?: ChainConfig | undefined;
+  selectedChainConfig: ChainConfig;
   selectedToken?: string | undefined;
   wallet: WalletData;
   onSelectToken: (key: string) => void;
@@ -51,7 +51,7 @@ const TokenList = (props: Props) => {
 
   const { isFetching: isFetchingTokenBalances, balances } = useGetTokenBalances(
     props.wallet?.address || '',
-    props.selectedChainConfig?.key,
+    props.selectedChainConfig.key,
     props.tokenList || [],
   );
 
@@ -63,7 +63,7 @@ const TokenList = (props: Props) => {
       : undefined;
 
     const nativeTokenConfig = props.tokenList?.find(
-      (t) => t.key === selectedChainConfig?.gasToken,
+      (t) => t.key === selectedChainConfig.gasToken,
     );
 
     // First: Add previously selected token at the top of the list
@@ -112,11 +112,9 @@ const TokenList = (props: Props) => {
       searchPlaceholder="Search for a token"
       className={classes.tokenList}
       listTitle={
-        props.selectedChainConfig && (
-          <Typography fontSize={14} color={theme.palette.text.secondary}>
-            Tokens on {props.selectedChainConfig.displayName}
-          </Typography>
-        )
+        <Typography fontSize={14} color={theme.palette.text.secondary}>
+          Tokens on {props.selectedChainConfig.displayName}
+        </Typography>
       }
       loading={
         props.isFetching && (
@@ -143,6 +141,7 @@ const TokenList = (props: Props) => {
           <TokenItem
             key={token.key}
             token={token}
+            chain={props.selectedChainConfig.key}
             disabled={disabled}
             onClick={() => {
               props.onSelectToken(token.key);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -72,7 +72,7 @@ const AssetPicker = (props: Props) => {
 
   // Side-effect to reset chain search visibility.
   // Popover close has an animation, which requires to wait
-  // a tiny bit before reseting showChainSearch.
+  // a tiny bit before resetting showChainSearch.
   // 300 ms is the reference wait time in a double-click, that's why
   // we can use it as the min wait before user re-opens the popover.
   useEffect(() => {


### PR DESCRIPTION
Previously the TokenPicker would always display the address of the token for its native chain even when the native chain was not selected.

Now we show the foreign address when the selected chain != token.chain.