### PR TITLE
wormhole-wrapped display name

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -61,7 +61,10 @@ function TokenItem(props: TokenItemProps) {
     : undefined;
   const addressDisplay = `${address?.slice(0, 4)}...${address?.slice(-4)}`;
 
-  const displayName = props.token.displayName ?? props.token.symbol;
+  let displayName = token.displayName ?? token.symbol;
+  if (chain !== token.nativeChain) {
+    displayName = `${'Wormhole-wrapped'} ${displayName}`;
+  }
 
   return (
     <ListItemButton


### PR DESCRIPTION
<img width="379" alt="image" src="https://github.com/user-attachments/assets/16732661-87f7-46a2-9736-b0c9ba75f811">

there is now an indication of a token being "Wormhole-wrapped"