### PR TITLE
Push equivalent wrapped token to top of token list

### DIFF
--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -57,7 +57,9 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
         // If any of the tokens are native to the chain, only select those.
         // This is to avoid users inadvertently receiving wrapped versions of the token.
         const nativeTokens = supported.filter(
-          (t) => t.nativeChain === destChain,
+          (t) =>
+            t.nativeChain === destChain ||
+            config.tokens[sourceToken].wrappedAsset === t.key,
         );
         if (nativeTokens.length > 0) {
           supported = nativeTokens;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -72,15 +72,7 @@ const TokenList = (props: Props) => {
       ? [selectedTokenConfig]
       : [];
 
-    // Second: Add the native token, if not previously selected
-    if (
-      nativeTokenConfig &&
-      nativeTokenConfig.key !== selectedTokenConfig?.key
-    ) {
-      tokens.push(nativeTokenConfig);
-    }
-
-    // Third: Add the wrapped token of the source token, if sourceToken is defined (meaning
+    // Second: Add the wrapped token of the source token, if sourceToken is defined (meaning
     // this is being rendered with destination tokens).
     if (props.sourceToken) {
       const sourceToken = config.tokens[props.sourceToken];
@@ -95,6 +87,14 @@ const TokenList = (props: Props) => {
           }
         }
       }
+    }
+
+    // Third: Add the native gas token, if not previously selected
+    if (
+      nativeTokenConfig &&
+      nativeTokenConfig.key !== selectedTokenConfig?.key
+    ) {
+      tokens.push(nativeTokenConfig);
     }
 
     // Fourth: Add tokens with a balances in the connected wallet

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -35,10 +35,11 @@ const useStyles = makeStyles()((theme) => ({
 }));
 
 type Props = {
-  tokenList?: Array<TokenConfig> | undefined;
+  tokenList?: Array<TokenConfig>;
   isFetching?: boolean;
   selectedChainConfig: ChainConfig;
-  selectedToken?: string | undefined;
+  selectedToken?: string;
+  sourceToken?: string;
   wallet: WalletData;
   onSelectToken: (key: string) => void;
 };
@@ -79,7 +80,24 @@ const TokenList = (props: Props) => {
       tokens.push(nativeTokenConfig);
     }
 
-    // Third: Add tokens with a balances in the connected wallet
+    // Third: Add the wrapped token of the source token, if sourceToken is defined (meaning
+    // this is being rendered with destination tokens).
+    if (props.sourceToken) {
+      const sourceToken = config.tokens[props.sourceToken];
+      if (sourceToken) {
+        const destTokenKey = sourceToken.wrappedAsset;
+        if (destTokenKey) {
+          const destToken = props.tokenList?.find(
+            (t) => t.key === destTokenKey,
+          );
+          if (destToken) {
+            tokens.push(destToken);
+          }
+        }
+      }
+    }
+
+    // Fourth: Add tokens with a balances in the connected wallet
     Object.entries(balances).forEach(([key, val]) => {
       if (Number(val?.balance) > 0) {
         const tokenConfig = props.tokenList?.find((t) => t.key === key);
@@ -93,7 +111,7 @@ const TokenList = (props: Props) => {
       }
     });
 
-    // Fourth: Fill up any remaining space from supported tokens
+    // Finally: Fill up any remaining space from supported tokens
     props.tokenList?.forEach((t) => {
       const tokenNotAdded = !tokens.find(
         (addedToken) => addedToken.key === t.key,

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -54,6 +54,7 @@ type Props = {
   chain?: Chain | undefined;
   chainList: Array<ChainConfig>;
   token?: string;
+  sourceToken?: string;
   tokenList?: Array<TokenConfig> | undefined;
   isFetching?: boolean;
   setToken: (value: string) => void;
@@ -188,6 +189,7 @@ const AssetPicker = (props: Props) => {
             isFetching={props.isFetching}
             selectedChainConfig={chainConfig}
             selectedToken={props.token}
+            sourceToken={props.sourceToken}
             wallet={props.wallet}
             onSelectToken={(key: string) => {
               props.setToken(key);

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -279,6 +279,7 @@ const Bridge = () => {
           chain={destChain}
           chainList={supportedDestChains}
           token={destToken}
+          sourceToken={sourceToken}
           tokenList={supportedDestTokens}
           isFetching={isFetchingSupportedDestTokens}
           setChain={(value: Chain) => {


### PR DESCRIPTION
As observed by @tsadovska, adding the Mayan route causes wrapped assets to not show up in the destination token list. This PR makes two changes:

- still includes a wrapped destination token if it's the "equivalent token" for the source token (eg `wrappedAsset` key in `TokenConfig`)
- prioritizes this token to the top of the destination tokens list

On the first point, Mayan caused this bug because suddenly we had tokens native to the destination chain available (because Mayan supports several of them).

Before: 
<img width="590" alt="image" src="https://github.com/user-attachments/assets/3c899b98-2fab-431c-bc01-6c5ab8d943f9">

After (notice WAVAX at the top of the list):
<img width="590" alt="image" src="https://github.com/user-attachments/assets/db56911a-f030-4384-9654-cda9034878df">
