### PR TITLE
[Redesign] Using token symbol isntead of token key in redeem view transaction details

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -74,7 +74,7 @@ const TransactionDetails = () => {
         <TokenIcon icon={sourceTokenConfig.icon} height={32} />
         <Stack direction="column" marginLeft="12px">
           <Typography fontSize={16}>
-            {amount} {tokenKey}
+            {amount} {sourceTokenConfig.symbol}
           </Typography>
           <Typography color={theme.palette.text.secondary} fontSize={14}>
             {isFetchingTokenPrices ? (
@@ -111,7 +111,7 @@ const TransactionDetails = () => {
         <TokenIcon icon={destTokenConfig.icon} height={32} />
         <Stack direction="column" marginLeft="12px">
           <Typography fontSize={16}>
-            {receiveAmount} {receivedTokenKey}
+            {receiveAmount} {destTokenConfig.symbol}
           </Typography>
           <Typography color={theme.palette.text.secondary} fontSize={14}>
             {isFetchingTokenPrices ? (


### PR DESCRIPTION
We need to use token symbol for better human readability.

<img width="710" alt="Screenshot 2024-08-28 at 12 34 23 PM" src="https://github.com/user-attachments/assets/3a3a927b-6158-4df0-af9d-3af48b2d07f8">
