### PR TITLE
Fix relayer fee display value

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -65,6 +65,7 @@ const SingleRoute = (props: Props) => {
     eta: estimatedTime,
     receiveAmount,
     relayerFee,
+    relayerFeeTokenKey,
     isFetching: isFetchingQuote,
   } = useComputeQuoteV2({
     sourceChain,
@@ -82,7 +83,7 @@ const SingleRoute = (props: Props) => {
     const bridgePrice = calculateUSDPrice(
       relayerFee,
       tokenPrices,
-      config.tokens[destToken],
+      config.tokens[relayerFeeTokenKey],
       true,
     );
 
@@ -102,7 +103,7 @@ const SingleRoute = (props: Props) => {
         )}
       </Stack>
     );
-  }, [destToken, isFetchingQuote, relayerFee, tokenPrices]);
+  }, [destToken, isFetchingQuote, relayerFee, relayerFeeTokenKey, tokenPrices]);
 
   const destinationGas = useMemo(() => {
     if (!destChain || !props.destinationGasDrop) {

--- a/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -170,14 +170,14 @@ const TransactionDetails = () => {
   );
 
   const bridgeFee = useMemo(() => {
-    if (!relayerFee || !receivedTokenKey) {
+    if (!relayerFee) {
       return <></>;
     }
 
     const bridgePrice = calculateUSDPrice(
-      relayerFee?.fee,
+      relayerFee.fee,
       tokenPrices,
-      config.tokens[receivedTokenKey],
+      config.tokens[relayerFee.tokenKey],
       true,
     );
 
@@ -197,7 +197,7 @@ const TransactionDetails = () => {
         )}
       </Stack>
     );
-  }, [isFetchingTokenPrices, receivedTokenKey, relayerFee, tokenPrices]);
+  }, [isFetchingTokenPrices, relayerFee, tokenPrices]);
 
   const destinationGas = useMemo(() => {
     if (!receivedTokenKey || !receiveNativeAmount) {


### PR DESCRIPTION
The relayer fee was not being scaled correctly.

Also, the relayer fee token may not always be the received token. Use the token returned by the SDK.

Fixes #2455