### PR TITLE
fix: event handler config overrides by parsedConfig

### DIFF
--- a/wormhole-connect/src/main.tsx
+++ b/wormhole-connect/src/main.tsx
@@ -54,7 +54,7 @@ try {
 
   if (configAttr) {
     const parsedConfig = JSON.parse(configAttr);
-    config = parsedConfig;
+    config = { ...config, ...parsedConfig };
 
     // Handle legacy method of including theme in config JSON
     if (config?.customTheme) {


### PR DESCRIPTION
Fix issue where event handler configurations were being overridden by parsedConfig when users supplied configurations in the hosted build