### PR TITLE
Only display dest wormhole-wrapped token if it actually exists

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -91,7 +91,10 @@ const TokenList = (props: Props) => {
         const destTokenKey = sourceToken.wrappedAsset;
         if (destTokenKey) {
           const destToken = props.tokenList?.find(
-            (t) => t.key === destTokenKey,
+            (t) =>
+              t.key === destTokenKey &&
+              // Only add the wrapped token if it actually exists on the destination chain
+              !!t.foreignAssets?.[selectedChainConfig.key],
           );
           if (destToken) {
             addToken(destToken);


### PR DESCRIPTION
Connect doesn't look up the foreign asset on-chain, so we check that it's defined in the token's foreignAssets map.