### PR TITLE
Don't disable chains; Connect already handles wallet switching

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -11,7 +11,6 @@ import Typography from '@mui/material/Typography';
 import AddIcon from '@mui/icons-material/Add';
 import TokenIcon from 'icons/TokenIcons';
 
-import { isDisabledChain } from 'store/transferInput';
 import type { ChainConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
 import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
@@ -91,7 +90,6 @@ const ChainList = (props: Props) => {
         {topChains.map((chain: ChainConfig) => (
           <ListItemButton
             key={chain.key}
-            disabled={isDisabledChain(chain.key, props.wallet)}
             selected={props.selectedChainConfig?.key === chain.key}
             className={classes.chainButton}
             onClick={() => props.onChainSelect(chain.key)}
@@ -132,7 +130,6 @@ const ChainList = (props: Props) => {
           <ListItemButton
             key={chain.key}
             dense
-            disabled={isDisabledChain(chain.key, props.wallet)}
             className={classes.chainItem}
             onClick={() => {
               props.onChainSelect(chain.key);


### PR DESCRIPTION
This removes the behavior that a chain is disabled if you have a wallet connected for a different platform. Connect already can disconnect the wallet (and reconnect to the right wallet if you have previously connected one).

This was frustrating/confusing because the new design menu auto-selects Ethereum when I open it, which then immediately made Solana and other non-EVM chains disabled right away.

https://github.com/user-attachments/assets/00133467-fbf9-44c4-b8c5-cd2282d71b1d

