### PR TITLE
Sort chains by usage

### DIFF
--- a/wormhole-connect/src/config/constants.ts
+++ b/wormhole-connect/src/config/constants.ts
@@ -1,3 +1,5 @@
+import { type Chain } from '@wormhole-foundation/sdk';
+
 export const WORMSCAN = 'https://wormholescan.io/#/';
 
 export const AVAILABLE_MARKETS_URL =
@@ -5,3 +7,25 @@ export const AVAILABLE_MARKETS_URL =
 
 export const CONNECT_VERSION =
   import.meta.env.REACT_APP_CONNECT_VERSION || 'unknown';
+
+export const CHAIN_ORDER: Chain[] = [
+  'Solana',
+  'Ethereum',
+  'Arbitrum',
+  'Base',
+  'Sui',
+  'Bsc',
+  'Optimism',
+  'Fantom',
+  'Polygon',
+  'Avalanche',
+  'Osmosis',
+  'Celo',
+  'Moonbeam',
+  'Klaytn',
+  'Injective',
+  'Kujira',
+  'Scroll',
+  'Evmos',
+  'Mantle',
+];

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -28,6 +28,7 @@ import cosmwasm from '@wormhole-foundation/sdk/cosmwasm';
 import algorand from '@wormhole-foundation/sdk/algorand';
 import RouteOperator from 'routes/operator';
 import { getTokenDecimals, getWrappedTokenId } from 'utils';
+import { CHAIN_ORDER } from './constants';
 
 export function buildConfig(
   customConfig?: WormholeConnectConfig,
@@ -111,11 +112,20 @@ export function buildConfig(
 
     // White lists
     chains: networkData.chains,
-    chainsArr: Object.values(networkData.chains).filter((chain) => {
-      return customConfig?.chains
-        ? customConfig.chains.includes(chain.key)
-        : true;
-    }),
+    chainsArr: Object.values(networkData.chains)
+      .filter((chain) => {
+        return customConfig?.chains
+          ? customConfig.chains.includes(chain.key)
+          : true;
+      })
+      .sort((a, b) => {
+        const ai = CHAIN_ORDER.indexOf(a.key);
+        const bi = CHAIN_ORDER.indexOf(b.key);
+        if (ai >= 0 && bi >= 0) return ai - bi;
+        if (ai === -1) return 1;
+        if (bi === -1) return -1;
+        return 0;
+      }),
     tokens,
     tokensArr: Object.values(tokens).filter((token) => {
       return customConfig?.tokens


### PR DESCRIPTION
Right now the UI displays the chains in whatever order `Object.values` gave us when creating the internal config. This adds an explicit ordering so that the most popular chains are shown first.

<img width="610" alt="image" src="https://github.com/user-attachments/assets/ac91924c-0565-481e-9538-d056ef2393e4">
