### PR TITLE
bump evm wallet aggregator package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17015,9 +17015,9 @@
       }
     },
     "node_modules/@xlabs-libs/wallet-aggregator-core": {
-      "version": "0.0.1-alpha.19",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.19.tgz",
-      "integrity": "sha512-lCxkPVgrgT5LeuVx6o9DEWV0Bh3/TOcxp6BRBmqVV2Cy8are8tCMDSmLgHNatvWMSEwVMHzOih/3DIofVFF/7w==",
+      "version": "0.0.1-alpha.21",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.21.tgz",
+      "integrity": "sha512-sG2S9cgrzR8+nvAE4Q5PE/JwELk4G5liA4qYk8f5XD8lf4RTzeq7Hnxa+GUnC9Dkh3CI0SKfQpmDo+78/FJKBQ==",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
@@ -34285,7 +34285,7 @@
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18",
         "@xlabs-libs/wallet-aggregator-cosmos": "^0.0.1-alpha.16",
         "@xlabs-libs/wallet-aggregator-cosmos-evm": "^0.0.1-alpha.8",
-        "@xlabs-libs/wallet-aggregator-evm": "^0.0.1-alpha.42",
+        "@xlabs-libs/wallet-aggregator-evm": "^0.0.1-alpha.44",
         "@xlabs-libs/wallet-aggregator-sei": "^0.0.1-alpha.14",
         "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
         "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",
@@ -34737,14 +34737,6 @@
         "node-fetch": "^2.7.0",
         "rpc-websockets": "^9.0.2",
         "superstruct": "^2.0.2"
-      }
-    },
-    "wormhole-connect/node_modules/@xlabs-libs/wallet-aggregator-core": {
-      "version": "0.0.1-alpha.21",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.21.tgz",
-      "integrity": "sha512-sG2S9cgrzR8+nvAE4Q5PE/JwELk4G5liA4qYk8f5XD8lf4RTzeq7Hnxa+GUnC9Dkh3CI0SKfQpmDo+78/FJKBQ==",
-      "dependencies": {
-        "eventemitter3": "^5.0.0"
       }
     },
     "wormhole-connect/node_modules/@xlabs-libs/wallet-aggregator-cosmos": {

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -47,7 +47,7 @@
     "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18",
     "@xlabs-libs/wallet-aggregator-cosmos": "^0.0.1-alpha.16",
     "@xlabs-libs/wallet-aggregator-cosmos-evm": "^0.0.1-alpha.8",
-    "@xlabs-libs/wallet-aggregator-evm": "^0.0.1-alpha.42",
+    "@xlabs-libs/wallet-aggregator-evm": "^0.0.1-alpha.44",
     "@xlabs-libs/wallet-aggregator-sei": "^0.0.1-alpha.14",
     "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
     "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",


### PR DESCRIPTION
This new version of evm wallet aggregator detects when it is running into Binance Web3 Wallet to display the right name and icon
 
![image](https://github.com/user-attachments/assets/4edcad6c-4fec-4415-b4dd-e45bc2152b5a)
