### PR TITLE
Add graceful error handling for failed route quotes

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -268,8 +268,12 @@ const SingleRoute = (props: Props) => {
       return <Typography color="error">Route is unavailable</Typography>;
     }
 
-    if (typeof receiveAmount === 'undefined') {
+    if (props.isFetchingQuote) {
       return <CircularProgress size={18} />;
+    }
+
+    if (receiveAmount === undefined) {
+      return null;
     }
 
     return (
@@ -284,8 +288,12 @@ const SingleRoute = (props: Props) => {
       return null;
     }
 
-    if (typeof receiveAmount === 'undefined') {
+    if (props.isFetchingQuote) {
       return <CircularProgress size={18} />;
+    }
+
+    if (receiveAmount === undefined) {
+      return null;
     }
 
     const receiveAmountPrice = calculateUSDPrice(

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -264,9 +264,15 @@ const SingleRoute = (props: Props) => {
   }, [quote]);
 
   const routeCardHeader = useMemo(() => {
-    return typeof receiveAmount === 'undefined' ? (
-      <CircularProgress size={18} />
-    ) : (
+    if (props.error) {
+      return <Typography color="error">Route is unavailable</Typography>;
+    }
+
+    if (typeof receiveAmount === 'undefined') {
+      return <CircularProgress size={18} />;
+    }
+
+    return (
       <Typography>
         {receiveAmount} {destTokenConfig.symbol}
       </Typography>
@@ -274,12 +280,12 @@ const SingleRoute = (props: Props) => {
   }, [destToken, receiveAmount]);
 
   const routeCardSubHeader = useMemo(() => {
-    if (typeof receiveAmount === 'undefined') {
-      return <CircularProgress size={18} />;
+    if (props.error || !destChain) {
+      return null;
     }
 
-    if (!destChain) {
-      return <></>;
+    if (typeof receiveAmount === 'undefined') {
+      return <CircularProgress size={18} />;
     }
 
     const receiveAmountPrice = calculateUSDPrice(

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -108,12 +108,17 @@ const Routes = ({ sortedSupportedRoutes, ...props }: Props) => {
         const isSelected = routeConfig.name === props.selectedRoute;
         const quoteResult = quotesMap[name];
         const quote = quoteResult?.success ? quoteResult : undefined;
+        // Default message added as precaution, as 'Error' type cannot be trusted
+        const quoteError =
+          quoteResult?.success === false
+            ? quoteResult?.error?.message ?? 'Error while getting a quote.'
+            : undefined;
         return (
           <SingleRoute
             key={name}
             route={routeConfig}
             available={available}
-            error={availabilityError}
+            error={availabilityError || quoteError}
             isSelected={isSelected}
             onSelect={props.onRouteChange}
             quote={quote}

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -111,7 +111,8 @@ const Routes = ({ sortedSupportedRoutes, ...props }: Props) => {
         // Default message added as precaution, as 'Error' type cannot be trusted
         const quoteError =
           quoteResult?.success === false
-            ? quoteResult?.error?.message ?? 'Error while getting a quote.'
+            ? quoteResult?.error?.message ??
+              `Error while getting a quote for ${name}.`
             : undefined;
         return (
           <SingleRoute


### PR DESCRIPTION
Tickets:
[Route Errors](https://www.notion.so/wormholelabs/BUG-Mayan-quote-requests-are-failing-with-406-Errors-3d1fac6d5b614a858f11c65491c3de91?pvs=23)

UI:
![Screenshot from 2024-09-05 01-39-41](https://github.com/user-attachments/assets/68b861d5-4e89-4813-9d30-88430c5fa52d)
