### PR TITLE
cache token addresses fix

### DIFF
--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -331,15 +331,15 @@ export class WrappedTokenAddressCache {
     this.caches = {};
 
     // Pre-populate cache with values from built-in config
-    for (const key in addresses) {
-      const token = tokens[key];
-      if (!token) continue;
-
+    for (const [key, token] of Object.entries(tokens)) {
+      // Cache any Wormhole-wrapped tokens
       const wrappedTokens = addresses[key];
-      for (const chain in wrappedTokens) {
-        const foreignAsset = wrappedTokens[chain];
-        const addr = WormholeV2.parseAddress(chain as Chain, foreignAsset);
-        this.set(key, chain as Chain, addr);
+      if (wrappedTokens) {
+        for (const chain in wrappedTokens) {
+          const foreignAsset = wrappedTokens[chain];
+          const addr = WormholeV2.parseAddress(chain as Chain, foreignAsset);
+          this.set(key, chain as Chain, addr);
+        }
       }
 
       // Cache it on its native chain too


### PR DESCRIPTION
tokens without wrapped assets defined were not getting cached on the native chain