### PR TITLE
Tx complete page icon change

### DIFF
--- a/wormhole-connect/src/icons/TxComplete.tsx
+++ b/wormhole-connect/src/icons/TxComplete.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createSvgIcon } from '@mui/material';
+
+const TxCompleteIcon = createSvgIcon(
+  <svg
+    width="107"
+    height="106"
+    viewBox="0 0 107 106"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M53.2079 105.5C82.2486 105.5 105.791 81.9949 105.791 53C105.791 24.0051 82.2486 0.5 53.2079 0.5C24.1672 0.5 0.625 24.0051 0.625 53C0.625 81.9949 24.1672 105.5 53.2079 105.5ZM53.207 102.097C80.3654 102.097 102.382 80.1157 102.382 53.0001C102.382 25.8844 80.3654 3.90283 53.207 3.90283C26.0485 3.90283 4.03223 25.8844 4.03223 53.0001C4.03223 80.1157 26.0485 102.097 53.207 102.097Z"
+      fill="#C1BBF6"
+    />
+    <path
+      d="M46.8789 68L32.628906 53.75L36.19141 50.1875L46.8789 60.875L69.8164 37.9375L73.3789 41.5L46.8789 68Z"
+      fill="#C1BBF6"
+    />
+  </svg>,
+  'Alert',
+);
+
+export default TxCompleteIcon;

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -6,7 +6,6 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import { isRedeemed, routes, TransferState } from '@wormhole-foundation/sdk';
 import { getTokenDetails } from 'telemetry';
 import { makeStyles } from 'tss-react/mui';
@@ -39,6 +38,7 @@ import TransactionDetails from 'views/v2/Redeem/TransactionDetails';
 import WalletSidebar from 'views/v2/Bridge/WalletConnector/Sidebar';
 
 import type { RootState } from 'store';
+import TxCompleteIcon from 'icons/TxComplete';
 
 const useStyles = makeStyles()((_theme) => ({
   spacer: {
@@ -235,9 +235,13 @@ const Redeem = () => {
       <>
         <Box sx={{ position: 'relative', display: 'inline-flex' }}>
           {isTxComplete ? (
-            <CheckCircleOutlineIcon
-              htmlColor="#C1BBF6"
-              sx={{ width: '120px', height: '120px' }}
+            <TxCompleteIcon
+              sx={{
+                width: 105,
+                height: 105,
+                marginTop: 1,
+                marginBottom: 2,
+              }}
             />
           ) : (
             <>


### PR DESCRIPTION
[Ticket](https://www.notion.so/wormholelabs/FEEDBACK-Transaction-complete-icon-looks-very-sloppy-bb220b27c3f94f6fade4644a93906bc5)

UI:
![Screenshot from 2024-09-05 19-01-53](https://github.com/user-attachments/assets/e8a79e20-6f61-4610-8e0e-e7adbaa1163d)

