### PR TITLE
Show the selected route when routes are collapsed

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -82,10 +82,17 @@ const Routes = ({ sortedSupportedRoutes, ...props }: Props) => {
     [sendingWallet.address, receivingWallet.address],
   );
 
-  const renderRoutes = useMemo(
-    () => (showAll ? sortedSupportedRoutes : sortedSupportedRoutes.slice(0, 1)),
-    [showAll, sortedSupportedRoutes],
-  );
+  const renderRoutes = useMemo(() => {
+    if (showAll) {
+      return sortedSupportedRoutes;
+    }
+
+    const selectedRoute = sortedSupportedRoutes.find(
+      (route) => route.name === props.selectedRoute,
+    );
+
+    return selectedRoute ? [selectedRoute] : sortedSupportedRoutes.slice(0, 1);
+  }, [showAll, sortedSupportedRoutes]);
 
   if (supportedRoutes.length === 0 || !walletsConnected) {
     return <></>;


### PR DESCRIPTION
[Ticket](https://www.notion.so/wormholelabs/UI-Bug-hiding-other-routes-with-an-active-selection-is-confusing-62b43d03a75f484c8d43e26a5771ad99?pvs=23)