### PR TITLE
Approximate fee for Mayan Swift quotes

### DIFF
--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -24,7 +24,7 @@
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@ledgerhq/logs": "6.12.0",
         "@manahippo/aptos-wallet-adapter": "^1.0.8",
-        "@mayanfinance/wormhole-sdk-route": "^0.4.0",
+        "@mayanfinance/wormhole-sdk-route": "^0.4.1",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.4",
         "@mysten/sui.js": "^0.32.2",
@@ -4952,9 +4952,9 @@
       }
     },
     "node_modules/@mayanfinance/wormhole-sdk-route": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mayanfinance/wormhole-sdk-route/-/wormhole-sdk-route-0.4.0.tgz",
-      "integrity": "sha512-SGzp0rLnJvQ6/F0CQkElqG2wpovjS6+2klMWDf0NexZbBpkAcAuZcqREpThe+LKEUjUIEOHBxx0CMr46atl13w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mayanfinance/wormhole-sdk-route/-/wormhole-sdk-route-0.4.1.tgz",
+      "integrity": "sha512-Qb/DMYesDOgFFjmNAxrn1bmN48nRuFSSMqTkDznu8MVeCwe0cf64u1Hr67/XUvJAqjsOVW08NwnSgpLuUAlQnA==",
       "dependencies": {
         "@mayanfinance/swap-sdk": "9.0.0",
         "@wormhole-foundation/sdk-connect": "^0.10.0",

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -33,7 +33,7 @@
     "@ledgerhq/hw-transport-webhid": "6.27.1",
     "@ledgerhq/logs": "6.12.0",
     "@manahippo/aptos-wallet-adapter": "^1.0.8",
-    "@mayanfinance/wormhole-sdk-route": "^0.4.0",
+    "@mayanfinance/wormhole-sdk-route": "^0.4.1",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.4",
     "@mysten/sui.js": "^0.32.2",

--- a/wormhole-connect/src/components/DemoApp/index.tsx
+++ b/wormhole-connect/src/components/DemoApp/index.tsx
@@ -53,7 +53,7 @@ const parseConfig = (config: string): WormholeConnectConfig => {
       /* @ts-ignore */
       window.TokenBridgeRoute = routes.TokenBridgeRoute;
       /* @ts-ignore */
-      window.ManualCCTPRoute = routes.ManualCCTPRoute;
+      window.CCTPRoute = routes.CCTPRoute;
       /* @ts-ignore */
       window.MayanRoute = MayanRoute;
       /* @ts-ignore */
@@ -191,7 +191,7 @@ function DemoApp() {
                 <i>{'RouteConstructor'}</i>
               </li>
               <li>
-                <pre>ManualCCTPRoute</pre>
+                <pre>CCTPRoute</pre>
                 <i>{'RouteConstructor'}</i>
               </li>
               <li>

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -134,7 +134,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
               chain: 'Solana' as Chain,
               address: Wormhole.parseAddress(
                 'Solana',
-                circle.usdcContract.get('Mainnet', 'Solana'),
+                circle.usdcContract.get('Mainnet', 'Solana') as string,
               ),
             },
             amount: amount.parse(amount.denoise(approxUsdNetworkCost, 6), 6),

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -129,12 +129,12 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
         const approxUsdNetworkCost = approxInputUsdValue - approxOutputUsdValue;
 
         if (!isNaN(approxUsdNetworkCost) && approxUsdNetworkCost > 0) {
-          (quotesMap['MayanSwap']! as routes.Quote<Network>).relayFee = {
+          (quotesMap['MayanSwap'] as routes.Quote<Network>).relayFee = {
             token: {
               chain: 'Solana' as Chain,
               address: Wormhole.parseAddress(
                 'Solana',
-                circle.usdcContract.get('Mainnet', 'Solana')!,
+                circle.usdcContract.get('Mainnet', 'Solana'),
               ),
             },
             amount: amount.parse(amount.denoise(approxUsdNetworkCost, 6), 6),

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -128,16 +128,18 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       if (approxInputUsdValue && approxOutputUsdValue) {
         const approxUsdNetworkCost = approxInputUsdValue - approxOutputUsdValue;
 
-        (quotesMap['MayanSwap']! as routes.Quote<Network>).relayFee = {
-          token: {
-            chain: 'Solana' as Chain,
-            address: Wormhole.parseAddress(
-              'Solana',
-              circle.usdcContract.get('Mainnet', 'Solana')!,
-            ),
-          },
-          amount: amount.parse(amount.denoise(approxUsdNetworkCost, 6), 6),
-        };
+        if (!isNaN(approxUsdNetworkCost) && approxInputUsdValue > 0) {
+          (quotesMap['MayanSwap']! as routes.Quote<Network>).relayFee = {
+            token: {
+              chain: 'Solana' as Chain,
+              address: Wormhole.parseAddress(
+                'Solana',
+                circle.usdcContract.get('Mainnet', 'Solana')!,
+              ),
+            },
+            amount: amount.parse(amount.denoise(approxUsdNetworkCost, 6), 6),
+          };
+        }
       }
     }
   }

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -128,7 +128,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       if (approxInputUsdValue && approxOutputUsdValue) {
         const approxUsdNetworkCost = approxInputUsdValue - approxOutputUsdValue;
 
-        if (!isNaN(approxUsdNetworkCost) && approxInputUsdValue > 0) {
+        if (!isNaN(approxUsdNetworkCost) && approxUsdNetworkCost > 0) {
           (quotesMap['MayanSwap']! as routes.Quote<Network>).relayFee = {
             token: {
               chain: 'Solana' as Chain,

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -105,10 +105,7 @@ const SingleRoute = (props: Props) => {
     );
 
     // Wesley made me do it
-    if (
-      props.route.name === 'MayanSwap' &&
-      quote.details?.type?.toLowerCase() === 'swift'
-    ) {
+    if (props.route.name === 'MayanSwap') {
       feeValue = <Typography fontSize={14}>{`${feePrice}`}</Typography>;
     }
 

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -46,6 +46,7 @@ type Props = {
 const SingleRoute = (props: Props) => {
   const { classes } = useStyles();
   const theme = useTheme();
+  const routeConfig = config.routes.get(props.route.name);
 
   const {
     toChain: destChain,
@@ -64,6 +65,10 @@ const SingleRoute = (props: Props) => {
   const destTokenConfig = useMemo(() => config.tokens[destToken], [destToken]);
 
   const relayerFee = useMemo(() => {
+    if (!routeConfig.AUTOMATIC_DEPOSIT) {
+      return <>You pay gas on {destChain}</>;
+    }
+
     if (!quote?.relayFee) {
       return <></>;
     }
@@ -163,8 +168,6 @@ const SingleRoute = (props: Props) => {
     if (!props.route) {
       return false;
     }
-
-    const routeConfig = config.routes.get(props.route.name);
 
     return !routeConfig.AUTOMATIC_DEPOSIT;
   }, [props.route.name]);

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -109,7 +109,7 @@ const SingleRoute = (props: Props) => {
       props.route.name === 'MayanSwap' &&
       quote.details?.type?.toLowerCase() === 'swift'
     ) {
-      feeValue = <Typography>{`$(${feePrice})`}</Typography>;
+      feeValue = <Typography>{`${feePrice}`}</Typography>;
     }
 
     return (

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -94,7 +94,7 @@ const SingleRoute = (props: Props) => {
     return (
       <Stack direction="row" justifyContent="space-between">
         <Typography color={theme.palette.text.secondary} fontSize={14}>
-          Relayer fee
+          Relayer gas fee
         </Typography>
         {isFetchingQuote ? (
           <CircularProgress size={14} />

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -94,7 +94,7 @@ const SingleRoute = (props: Props) => {
     return (
       <Stack direction="row" justifyContent="space-between">
         <Typography color={theme.palette.text.secondary} fontSize={14}>
-          Relayer gas fee
+          Network cost
         </Typography>
         {isFetchingQuote ? (
           <CircularProgress size={14} />

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -96,19 +96,28 @@ const SingleRoute = (props: Props) => {
       return <></>;
     }
 
+    let feeValue = isFetchingQuote ? (
+      <CircularProgress size={14} />
+    ) : (
+      <Typography fontSize={14}>{`${toFixedDecimals(relayFee.toString(), 4)} ${
+        feeTokenConfig.symbol
+      } (${feePrice})`}</Typography>
+    );
+
+    // Wesley made me do it
+    if (
+      props.route.name === 'MayanSwap' &&
+      quote.details?.type?.toLowerCase() === 'swift'
+    ) {
+      feeValue = <Typography>{`$(${feePrice})`}</Typography>;
+    }
+
     return (
       <Stack direction="row" justifyContent="space-between">
         <Typography color={theme.palette.text.secondary} fontSize={14}>
           Network cost
         </Typography>
-        {isFetchingQuote ? (
-          <CircularProgress size={14} />
-        ) : (
-          <Typography fontSize={14}>{`${toFixedDecimals(
-            relayFee.toString(),
-            4,
-          )} ${feeTokenConfig.symbol} (${feePrice})`}</Typography>
-        )}
+        {feeValue}
       </Stack>
     );
   }, [destToken, isFetchingQuote, quote?.relayFee, tokenPrices]);

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -109,7 +109,7 @@ const SingleRoute = (props: Props) => {
       props.route.name === 'MayanSwap' &&
       quote.details?.type?.toLowerCase() === 'swift'
     ) {
-      feeValue = <Typography>{`${feePrice}`}</Typography>;
+      feeValue = <Typography fontSize={14}>{`${feePrice}`}</Typography>;
     }
 
     return (


### PR DESCRIPTION
Adds special logic for Mayan Swift xfers that calculates a USD-denominated fee. Also hides the token symbol for Mayan quotes' network cost, because we're using USDC to represent dollars.

<img width="527" alt="image" src="https://github.com/user-attachments/assets/2604786c-80d8-4a45-9608-c3d58645f024">

Depends on https://github.com/mayan-finance/wormhole-sdk-route/pull/40