### PR TITLE
Allow destination tokens selection before source token

### DIFF
--- a/wormhole-connect/src/hooks/useSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useSupportedRoutes.ts
@@ -21,6 +21,7 @@ const useAvailableRoutes = (): void => {
 
   useEffect(() => {
     if (!fromChain || !toChain || !token || !destToken) {
+      dispatch(setRoutes([]));
       return;
     }
 

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -204,7 +204,8 @@ const TokenList = (props: Props) => {
       }}
       renderFn={(token: TokenConfig) => {
         const balance = balances?.[token.key]?.balance;
-        const disabled = !!props.wallet?.address && !!balances && !balance;
+        const disabled =
+          props.isSource && !!props.wallet?.address && !!balances && !balance;
 
         return (
           <TokenItem

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -20,6 +20,7 @@ import type { RouteData } from 'config/routes';
 import type { RootState } from 'store';
 import { formatBalance } from 'store/transferInput';
 import { toFixedDecimals } from 'utils/balance';
+import { TokenConfig } from 'config/types';
 
 const useStyles = makeStyles()((theme: any) => ({
   container: {
@@ -61,7 +62,10 @@ const SingleRoute = (props: Props) => {
   const { name } = props.route;
   const { quote, isFetchingQuote } = props;
 
-  const destTokenConfig = useMemo(() => config.tokens[destToken], [destToken]);
+  const destTokenConfig = useMemo(
+    () => config.tokens[destToken] as TokenConfig | undefined,
+    [destToken],
+  );
 
   const relayerFee = useMemo(() => {
     if (!quote?.relayFee) {
@@ -271,7 +275,7 @@ const SingleRoute = (props: Props) => {
   }, [quote]);
 
   const receiveAmountTrunc = useMemo(() => {
-    return quote && destChain
+    return quote && destChain && destTokenConfig
       ? formatBalance(
           destChain,
           destTokenConfig,
@@ -289,7 +293,7 @@ const SingleRoute = (props: Props) => {
       return <CircularProgress size={18} />;
     }
 
-    if (receiveAmount === undefined) {
+    if (receiveAmount === undefined || !destTokenConfig) {
       return null;
     }
 
@@ -376,7 +380,7 @@ const SingleRoute = (props: Props) => {
           }}
         >
           <CardHeader
-            avatar={<TokenIcon icon={destTokenConfig.icon} height={36} />}
+            avatar={<TokenIcon icon={destTokenConfig?.icon} height={36} />}
             title={routeCardHeader}
             subheader={routeCardSubHeader}
           />

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -122,7 +122,7 @@ const Bridge = () => {
     destToken,
     route,
     routeStates,
-    supportedDestTokens,
+    supportedDestTokens: supportedDestTokensBase,
     supportedSourceTokens,
     amount,
     validations,
@@ -227,6 +227,19 @@ const Bridge = () => {
         supportedChains.includes(chain.key),
     );
   }, [config.chainsArr, sourceChain, supportedChains]);
+
+  // Supported tokens for destination chain
+  const supportedDestTokens = useMemo(() => {
+    if (sourceChain && sourceToken) {
+      return supportedDestTokensBase;
+    } else {
+      return config.tokensArr.filter(
+        (tokenConfig) =>
+          tokenConfig.nativeChain === destChain ||
+          tokenConfig.tokenId?.chain === destChain,
+      );
+    }
+  }, [destChain, sourceChain, sourceToken, supportedDestTokensBase]);
 
   // Connect bridge header, which renders any custom overrides for the header
   const header = useMemo(() => {


### PR DESCRIPTION
If no source Chain/Token is selected displaying all configured token for Destination chain.
Also resetting Routes when source/dest tokens are deselected.
Removed Disabling for destination tokens.