### PR TITLE
finalize transfers support

### DIFF
--- a/wormhole-connect/src/icons/TxWarning.tsx
+++ b/wormhole-connect/src/icons/TxWarning.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { createSvgIcon } from '@mui/material';
 
-const TxRefunded = createSvgIcon(
+const TxWarning = createSvgIcon(
   <svg
     width="107"
     height="107"
@@ -20,4 +20,4 @@ const TxRefunded = createSvgIcon(
   'Alert',
 );
 
-export default TxRefunded;
+export default TxWarning;

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -102,7 +102,7 @@ export const validateAmount = (
   if (isNaN(numAmount)) return 'Amount must be a number';
   if (numAmount <= 0) return 'Amount must be greater than 0';
   if (balance) {
-    const b = Number.parseFloat(balance);
+    const b = Number.parseFloat(balance.replace(',', ''));
     if (numAmount > b) return 'Amount exceeds available balance.';
   }
   if (isCctp && numAmount >= CCTP_MAX_TRANSFER_LIMIT)

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -6,7 +6,13 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { isRedeemed, routes, TransferState } from '@wormhole-foundation/sdk';
+import {
+  isCompleted,
+  isDestinationQueued,
+  isRedeemed,
+  routes,
+  TransferState,
+} from '@wormhole-foundation/sdk';
 import { getTokenDetails } from 'telemetry';
 import { makeStyles } from 'tss-react/mui';
 import { Context } from 'sdklegacy';
@@ -36,7 +42,7 @@ import WalletSidebar from 'views/v2/Bridge/WalletConnector/Sidebar';
 
 import type { RootState } from 'store';
 import TxCompleteIcon from 'icons/TxComplete';
-import TxRefundedIcon from 'icons/TxRefunded';
+import TxWarningIcon from 'icons/TxWarning';
 import TxFailedIcon from 'icons/TxFailed';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { PublicKey } from '@solana/web3.js';
@@ -84,6 +90,9 @@ const useStyles = makeStyles()((theme) => ({
     gap: '8px',
     marginTop: '24px',
   },
+  delayText: {
+    maxWidth: '420px',
+  },
 }));
 
 const Redeem = () => {
@@ -102,13 +111,6 @@ const Redeem = () => {
 
   const routeContext = React.useContext(RouteContext);
 
-  const isTxAttested = useMemo(
-    () =>
-      routeContext.receipt &&
-      routeContext.receipt.state >= TransferState.Attested,
-    [routeContext.receipt],
-  );
-
   const {
     transferComplete: isTxComplete,
     route: routeName,
@@ -118,8 +120,11 @@ const Redeem = () => {
 
   const { txData } = useSelector((state: RootState) => state.redeem);
 
-  const isTxRefunded = routeContext.receipt?.state === TransferState.Refunded;
-  const isTxFailed = routeContext.receipt?.state === TransferState.Failed;
+  const { state: receiptState } = routeContext.receipt || {};
+  const isTxAttested = receiptState && receiptState >= TransferState.Attested;
+  const isTxRefunded = receiptState === TransferState.Refunded;
+  const isTxFailed = receiptState === TransferState.Failed;
+  const isTxDestQueued = receiptState === TransferState.DestinationQueued;
 
   const {
     recipient,
@@ -197,6 +202,8 @@ const Redeem = () => {
       return <Stack>Transaction was refunded</Stack>;
     } else if (isTxFailed) {
       return <Stack>Transaction failed</Stack>;
+    } else if (isTxDestQueued) {
+      return <Stack>Transaction delayed</Stack>;
     } else if (isTxAttested) {
       return (
         <Stack>{`${receiveAmount} ${receivedTokenKey} received at ${displayAddress(
@@ -212,6 +219,7 @@ const Redeem = () => {
     isTxComplete,
     isTxRefunded,
     isTxFailed,
+    isTxDestQueued,
     receiveAmount,
     receivedTokenKey,
     recipient,
@@ -257,8 +265,8 @@ const Redeem = () => {
         <Box sx={{ position: 'relative', display: 'inline-flex' }}>
           {isTxComplete ? (
             <TxCompleteIcon className={classes.txStatusIcon} />
-          ) : isTxRefunded ? (
-            <TxRefundedIcon
+          ) : isTxRefunded || isTxDestQueued ? (
+            <TxWarningIcon
               className={classes.txStatusIcon}
               sx={{
                 color: theme.palette.warning.main,
@@ -299,7 +307,28 @@ const Redeem = () => {
         </Box>
       </>
     );
-  }, [etaDisplay, isTxComplete]);
+  }, [etaDisplay, isTxComplete, isTxRefunded, isTxFailed, isTxDestQueued]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | undefined;
+
+    if (routeContext.receipt && isDestinationQueued(routeContext.receipt)) {
+      setIsClaimInProgress(true);
+
+      const releaseTime = routeContext.receipt.queueReleaseTime.getTime();
+      const delay = releaseTime - Date.now();
+
+      timer = setTimeout(() => {
+        setIsClaimInProgress(false);
+      }, delay);
+    }
+
+    return () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  }, [routeContext.receipt]);
 
   // Checks whether the receiving wallet is currently connected
   const isConnectedToReceivingWallet = useMemo(() => {
@@ -364,6 +393,10 @@ const Redeem = () => {
       throw new Error('Unknown route, can not claim');
     }
 
+    if (!routeContext.receipt) {
+      throw new Error('No receipt found, can not claim');
+    }
+
     const transferDetails = {
       route: routeName,
       fromToken: getTokenDetails(tokenKey),
@@ -402,8 +435,8 @@ const Redeem = () => {
         await registerWalletSigner(toChain, TransferWallet.RECEIVING);
       }
 
-      if (!routes.isManual(route)) {
-        throw new Error('Route is not manual');
+      if (!routes.isManual(route) && !routes.isFinalizable(route)) {
+        throw new Error('Route is not manual or finalizable');
       }
 
       const signer = await SDKv2Signer.fromChain(
@@ -413,10 +446,16 @@ const Redeem = () => {
         TransferWallet.RECEIVING,
       );
 
-      const receipt = await route.complete(signer, routeContext.receipt!);
+      let receipt: routes.Receipt | undefined;
 
-      if (!isRedeemed(receipt)) {
-        throw new Error('Transfer not redeemed');
+      if (isTxDestQueued && routes.isFinalizable(route)) {
+        receipt = await route.finalize(signer, routeContext.receipt);
+      } else if (!isTxDestQueued && routes.isManual(route)) {
+        receipt = await route.complete(signer, routeContext.receipt);
+      }
+
+      if (!receipt || (!isRedeemed(receipt) && !isCompleted(receipt))) {
+        throw new Error('Transfer not completed');
       }
 
       if (receipt.destinationTxs && receipt.destinationTxs.length > 0) {
@@ -461,7 +500,12 @@ const Redeem = () => {
 
   // Main CTA button which has separate states for automatic and manual claims
   const actionButton = useMemo(() => {
-    if (!isTxComplete && !isTxRefunded && !isTxFailed && !isAutomaticRoute) {
+    if (
+      !isTxComplete &&
+      !isTxRefunded &&
+      !isTxFailed &&
+      (isTxDestQueued || !isAutomaticRoute)
+    ) {
       if (isTxAttested && !isConnectedToReceivingWallet) {
         return (
           <Button
@@ -513,8 +557,33 @@ const Redeem = () => {
     isClaimInProgress,
     isTxAttested,
     isTxComplete,
+    isTxRefunded,
+    isTxFailed,
+    isTxDestQueued,
     isConnectedToReceivingWallet,
   ]);
+
+  const txDelayedText = useMemo(() => {
+    if (!routeContext.receipt || !isDestinationQueued(routeContext.receipt)) {
+      return null;
+    }
+
+    const { to, queueReleaseTime } = routeContext.receipt;
+    const symbol = config.tokens[receivedTokenKey]?.symbol || '';
+    const releaseTime = queueReleaseTime.toLocaleString();
+
+    return (
+      <Typography
+        color={theme.palette.text.secondary}
+        fontSize={14}
+        className={classes.delayText}
+      >
+        {`Your transfer to ${to} is delayed due to rate limits configured by ${symbol}. After
+        the delay ends on ${releaseTime}, you will need to tap "Claim" to
+        complete your transfer.`}
+      </Typography>
+    );
+  }, [routeContext.receipt, config, receivedTokenKey]);
 
   return (
     <div className={joinClass([classes.container, classes.spacer])}>
@@ -523,6 +592,7 @@ const Redeem = () => {
       {etaCircle}
       <TransactionDetails />
       {actionButton}
+      {txDelayedText}
       <AlertBannerV2
         error
         content={claimError}


### PR DESCRIPTION
the redeem page allows transfers that are queued on the destination chain to be completed after the delay

currently only the ntt routes use this state