### PR TITLE
[Redesign] Merging Mayan transactions into Transaction History view

### DIFF
--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -101,6 +101,7 @@ export function buildConfig(
       customConfig?.rest,
     ),
     graphql: Object.assign({}, networkData.graphql, customConfig?.graphql),
+    mayanApi: 'https://explorer-api.mayan.finance',
     wormholeApi: {
       Mainnet: 'https://api.wormholescan.io/',
       Testnet: 'https://api.testnet.wormholescan.io/',

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -165,6 +165,7 @@ export interface InternalConfig<N extends Network> {
   rpcs: ChainResourceMap;
   rest: ChainResourceMap;
   graphql: ChainResourceMap;
+  mayanApi: string;
   wormholeApi: string;
   wormholeRpcHosts: string[];
   coinGeckoApiKey?: string;
@@ -361,4 +362,36 @@ export class WrappedTokenAddressCache {
     const chainCache = this.caches[chain]!;
     chainCache[tokenKey] = foreignAsset;
   }
+}
+
+// Transactions in Transaction History view
+export interface Transaction {
+  // Transaction hash
+  txHash: string;
+
+  // Stringified addresses
+  sender?: string;
+  recipient: string;
+
+  amount: string;
+  amountUsd: number;
+
+  toChain: Chain;
+  fromChain: Chain;
+
+  // Source token address
+  tokenAddress: string;
+  tokenKey: string;
+  tokenDecimals?: number;
+
+  // Destination token
+  receivedTokenKey?: string;
+  receiveAmount?: string;
+
+  // Timestamps
+  senderTimestamp: string;
+  receiverTimestamp?: string;
+
+  // Explorer link
+  explorerLink?: string;
 }

--- a/wormhole-connect/src/hooks/useTransactionHistory.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistory.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+
+import useTransactionHistoryWHScan from 'hooks/useTransactionHistoryWHScan';
+import useTransactionHistoryMayan from 'hooks/useTransactionHistoryMayan';
+
+import type { Transaction } from 'config/types';
+import type { RootState } from 'store';
+
+type Props = {
+  page?: number;
+  pageSize?: number;
+};
+
+const useTransactionHistory = (
+  props: Props,
+): {
+  transactions: Array<Transaction> | undefined;
+  error: Array<string>;
+  isFetching: boolean;
+  hasMore: boolean;
+} => {
+  const { page = 0, pageSize = 30 } = props;
+
+  const [mayanIndex, setMayanIndex] = useState(0);
+  const [whScanIndex, setWHScanIndex] = useState(0);
+
+  const [mayanPage, setMayanPage] = useState(page);
+  const [whScanPage, setWHScanPage] = useState(page);
+
+  const [transactions, setTransactions] = useState<Array<Transaction>>();
+
+  const { address } = useSelector((state: RootState) => state.wallet.sending);
+
+  const {
+    transactions: whScanTxs,
+    isFetching: isFetchingWHScan,
+    hasMore: hasMoreWHScan,
+    error: errorWHScan,
+  } = useTransactionHistoryWHScan({
+    address,
+    page: whScanPage,
+    pageSize,
+  });
+
+  const {
+    transactions: mayanTxs,
+    isFetching: isFetchingMayan,
+    hasMore: hasMoreMayan,
+    error: errorMayan,
+  } = useTransactionHistoryMayan({
+    address,
+    page: mayanPage,
+    pageSize,
+  });
+
+  useEffect(() => {
+    if (hasMoreMayan && mayanPage !== page) {
+      setMayanPage(page);
+    }
+
+    if (hasMoreWHScan && whScanPage !== page) {
+      setWHScanPage(page);
+    }
+  }, [hasMoreMayan, hasMoreWHScan, page]);
+
+  useEffect(() => {
+    if (!whScanTxs || !mayanTxs) {
+      return;
+    }
+
+    const mergedTxs: Array<Transaction> = [];
+
+    let whScanLocalIdx = whScanIndex;
+    let mayanLocalIdx = mayanIndex;
+
+    for (let i = 0; i < pageSize; i++) {
+      if (
+        whScanLocalIdx === whScanTxs.length - 1 ||
+        mayanLocalIdx === mayanTxs.length - 1
+      ) {
+        setWHScanIndex(whScanLocalIdx + 1);
+        setMayanIndex(mayanLocalIdx + 1);
+        setTransactions((txs) => {
+          if (!txs) {
+            return mergedTxs;
+          }
+
+          return txs.concat(mergedTxs);
+        });
+        return;
+      }
+
+      const whScanItem = whScanTxs[whScanLocalIdx];
+      const mayanItem = mayanTxs[mayanLocalIdx];
+
+      const whScanTime = new Date(whScanItem.senderTimestamp);
+      const mayanTime = new Date(mayanItem.senderTimestamp);
+
+      if (whScanTime > mayanTime) {
+        mergedTxs.push(whScanItem);
+        if (whScanLocalIdx < whScanTxs.length - 1) {
+          whScanLocalIdx += 1;
+        }
+      } else {
+        mergedTxs.push(mayanItem);
+        if (mayanLocalIdx < mayanTxs.length - 1) {
+          mayanLocalIdx += 1;
+        }
+      }
+    }
+
+    setWHScanIndex(whScanLocalIdx + 1);
+    setMayanIndex(mayanLocalIdx + 1);
+    setTransactions(mergedTxs);
+  }, [whScanTxs, mayanTxs]);
+
+  return {
+    transactions,
+    error: [errorWHScan, errorMayan],
+    isFetching: isFetchingWHScan || isFetchingMayan,
+    hasMore: hasMoreWHScan || hasMoreMayan,
+  };
+};
+
+export default useTransactionHistory;

--- a/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useState } from 'react';
+import { ChainId, chainIdToChain } from '@wormhole-foundation/sdk';
+
+import config from 'config';
+import { getTokenById } from 'utils';
+
+import type { Transaction } from 'config/types';
+
+interface MayanTransaction {
+  trader: string;
+  sourceTxHash: string;
+  sourceChain: ChainId;
+  swapChain: string;
+  destChain: ChainId;
+  fromAmount: string;
+  fromTokenChain: ChainId;
+  fromTokenSymbol: string;
+  fromTokenPrice: number;
+  toTokenPrice: number;
+  toTokenAddress: string;
+  toTokenChain: ChainId;
+  toTokenSymbol: string;
+  status: string;
+  clientStatus: string;
+  initiatedAt: string;
+  toAmount: string;
+  statusUpdatedAt: string;
+}
+
+type Props = {
+  address: string;
+  page?: number;
+  pageSize?: number;
+};
+
+const useTransactionHistoryMayan = (
+  props: Props,
+): {
+  transactions: Array<Transaction> | undefined;
+  error: string;
+  isFetching: boolean;
+  hasMore: boolean;
+} => {
+  const [transactions, setTransactions] = useState<
+    Array<Transaction> | undefined
+  >();
+  const [error, setError] = useState('');
+  const [isFetching, setIsFetching] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { address, page = 0, pageSize = 30 } = props;
+
+  const parseSingleTx = (tx: MayanTransaction) => {
+    const {
+      fromAmount,
+      sourceChain,
+      destChain,
+      fromTokenPrice,
+      fromTokenSymbol,
+      initiatedAt,
+      toAmount,
+      toTokenAddress,
+      sourceTxHash,
+      trader,
+    } = tx;
+
+    const fromChain = chainIdToChain(sourceChain);
+    const toChain = chainIdToChain(destChain);
+
+    if (!fromChain || !toChain) {
+      return;
+    }
+
+    const fromTokenConfig = config.tokensArr.find(
+      (t) => t.nativeChain === fromChain && t.symbol === fromTokenSymbol,
+    );
+
+    const toTokenConfig = getTokenById({
+      chain: toChain,
+      address: toTokenAddress,
+    });
+
+    if (!fromTokenConfig || !toTokenConfig) {
+      return;
+    }
+
+    const txData: Transaction = {
+      txHash: sourceTxHash,
+      sender: trader,
+      amount: fromAmount,
+      amountUsd: Number(fromAmount) * fromTokenPrice,
+      recipient: '',
+      toChain,
+      fromChain,
+      tokenKey: fromTokenConfig?.key,
+      receivedTokenKey: toTokenConfig?.key,
+      receiveAmount: toAmount,
+      tokenAddress: toTokenAddress,
+      senderTimestamp: initiatedAt,
+      explorerLink: `https://explorer.mayan.finance/swap/${sourceTxHash}`,
+    };
+
+    return txData;
+  };
+
+  const parseTransactions = useCallback(
+    (allTxs: Array<MayanTransaction>) =>
+      allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx), // Filter out unsupported transactions
+    [],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const fetchTransactions = async () => {
+      setIsFetching(true);
+
+      const limit = pageSize;
+      const offset = limit * page;
+
+      try {
+        const res = await fetch(
+          `${config.mayanApi}/v3/swaps?trader=${address}&offset=${offset}&limit=${limit}`,
+        );
+
+        const payload = await res.json();
+
+        if (!cancelled) {
+          if (payload?.data?.length > 0) {
+            setTransactions((txs) => {
+              const parsedTxs = parseTransactions(payload.data);
+              if (txs && txs.length > 0) {
+                const uniqList = {};
+                txs.concat(parsedTxs).forEach((tx) => {
+                  if (tx?.txHash) {
+                    uniqList[tx.txHash] = tx;
+                  }
+                });
+
+                return Object.values(uniqList);
+              }
+              return parsedTxs;
+            });
+          }
+
+          if (payload?.data?.length < limit) {
+            setHasMore(false);
+          }
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setError(`Error fetching transaction history from Mayan: ${error}`);
+        }
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchTransactions();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [page, pageSize]);
+
+  return {
+    transactions,
+    error,
+    isFetching,
+    hasMore,
+  };
+};
+
+export default useTransactionHistoryMayan;

--- a/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { ChainId, chainIdToChain } from '@wormhole-foundation/sdk';
 
 import config from 'config';
-import { getTokenById } from 'utils';
 
 import type { Transaction } from 'config/types';
 
@@ -60,6 +59,7 @@ const useTransactionHistoryMayan = (
       initiatedAt,
       toAmount,
       toTokenAddress,
+      toTokenSymbol,
       sourceTxHash,
       trader,
     } = tx;
@@ -72,13 +72,16 @@ const useTransactionHistoryMayan = (
     }
 
     const fromTokenConfig = config.tokensArr.find(
-      (t) => t.nativeChain === fromChain && t.symbol === fromTokenSymbol,
+      (t) =>
+        t.symbol === fromTokenSymbol &&
+        (t.nativeChain === fromChain || t.tokenId?.chain === fromChain),
     );
 
-    const toTokenConfig = getTokenById({
-      chain: toChain,
-      address: toTokenAddress,
-    });
+    const toTokenConfig = config.tokensArr.find(
+      (t) =>
+        t.symbol === toTokenSymbol &&
+        (t.nativeChain === toChain || t.tokenId?.chain === toChain),
+    );
 
     if (!fromTokenConfig || !toTokenConfig) {
       return;

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -325,7 +325,15 @@ const ReviewTransaction = (props: Props) => {
         onClick={() => send()}
       >
         {isTransactionInProgress ? (
-          <CircularProgress color="secondary" size={24} />
+          <Typography
+            display="flex"
+            alignItems="center"
+            gap={1}
+            textTransform="none"
+          >
+            <CircularProgress color="secondary" size={16} />
+            {mobile ? 'Preparing' : 'Preparing transaction'}
+          </Typography>
         ) : (
           <Typography textTransform="none">
             {mobile ? 'Confirm' : 'Confirm transaction'}

--- a/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
@@ -1,30 +1,24 @@
-import React, { useMemo, useState } from 'react';
-import LaunchIcon from '@mui/icons-material/Launch';
+import React, { useMemo } from 'react';
 import { useTheme } from '@mui/material';
 import Badge from '@mui/material/Badge';
 import Card from '@mui/material/Card';
 import CardActionArea from '@mui/material/CardActionArea';
 import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
-import Collapse from '@mui/material/Collapse';
-import Divider from '@mui/material/Divider';
-import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import { makeStyles } from 'tss-react/mui';
 
 import config from 'config';
-import { WORMSCAN } from 'config/constants';
 import TokenIcon from 'icons/TokenIcons';
 import {
   calculateUSDPrice,
   getUSDFormat,
-  millisToHumanString,
   trimAddress,
   trimTxHash,
 } from 'utils';
 
-import type { Transaction } from 'hooks/useFetchTransactionHistory';
+import type { Transaction } from 'config/types';
 import type { TokenPrices } from 'store/tokenPrices';
 
 const useStyles = makeStyles()((theme: any) => ({
@@ -49,8 +43,6 @@ const TxHistoryItem = (props: Props) => {
   const { classes } = useStyles();
   const theme = useTheme();
 
-  const [collapsed, setCollapsed] = useState(true);
-
   const {
     txHash,
     sender,
@@ -62,9 +54,8 @@ const TxHistoryItem = (props: Props) => {
     tokenKey,
     receivedTokenKey,
     receiveAmount,
-    relayerFee,
     senderTimestamp,
-    receiverTimestamp,
+    explorerLink,
   } = props.data;
 
   // Render details for the sent amount
@@ -162,72 +153,6 @@ const TxHistoryItem = (props: Props) => {
     [],
   );
 
-  const bridgeFee = useMemo(() => {
-    if (!relayerFee) {
-      return <></>;
-    }
-
-    const sourceTokenConfig = config.tokens[tokenKey];
-
-    const feeAmountPrice = calculateUSDPrice(
-      relayerFee.fee,
-      props.tokenPrices,
-      sourceTokenConfig,
-      true,
-    );
-
-    return (
-      <Stack direction="row" justifyContent="space-between">
-        <Typography color={theme.palette.text.secondary} fontSize={14}>
-          Bridge fee
-        </Typography>
-        <Typography fontSize={14}>{feeAmountPrice}</Typography>
-      </Stack>
-    );
-  }, [props.tokenPrices, relayerFee, tokenKey]);
-
-  const timeToDestination = useMemo(() => {
-    if (!senderTimestamp || !receiverTimestamp) {
-      return null;
-    }
-
-    const senderDate = new Date(senderTimestamp);
-    const receiverDate = new Date(receiverTimestamp);
-    const timePassed = receiverDate.getTime() - senderDate.getTime();
-
-    return (
-      <Stack direction="row" justifyContent="space-between">
-        <Typography color={theme.palette.text.secondary} fontSize={14}>
-          Time to destination
-        </Typography>
-
-        <Typography fontSize={14}>{millisToHumanString(timePassed)}</Typography>
-      </Stack>
-    );
-  }, [senderTimestamp, receiverTimestamp]);
-
-  const wormscanLink = useMemo(() => {
-    const href = `${WORMSCAN}tx/${txHash}${
-      config.isMainnet ? '' : '?network=TESTNET'
-    }`;
-
-    return (
-      <Stack alignItems="center">
-        <Link
-          display="flex"
-          gap="8px"
-          href={href}
-          rel="noreferrer"
-          target="_blank"
-          underline="none"
-        >
-          <Typography>View on Wormholescan</Typography>
-          <LaunchIcon fontSize="small" sx={{ marginTop: '2px' }} />
-        </Link>
-      </Stack>
-    );
-  }, [txHash]);
-
   const transactionDateTime = useMemo(() => {
     if (!senderTimestamp) {
       return 'Unknown time';
@@ -244,7 +169,7 @@ const TxHistoryItem = (props: Props) => {
         <CardActionArea
           disableTouchRipple
           onClick={() => {
-            setCollapsed((collapsed) => !collapsed);
+            window.open(explorerLink, '_blank');
           }}
         >
           <CardHeader
@@ -264,19 +189,6 @@ const TxHistoryItem = (props: Props) => {
             {sentAmount}
             {verticalConnector}
             {receivedAmount}
-            <Collapse in={!collapsed}>
-              <Stack
-                direction="column"
-                gap="8px"
-                justifyContent="space-between"
-                marginTop="16px"
-              >
-                {bridgeFee}
-                {timeToDestination}
-              </Stack>
-              <Divider flexItem sx={{ margin: '16px 0', opacity: '50%' }} />
-              {wormscanLink}
-            </Collapse>
           </CardContent>
         </CardActionArea>
       </Card>

--- a/wormhole-connect/src/views/v2/TxHistory/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/index.tsx
@@ -13,7 +13,7 @@ import PageHeader from 'components/PageHeader';
 import Header, { Alignment } from 'components/Header';
 import config from 'config';
 import PoweredByIcon from 'icons/PoweredBy';
-import useFetchTransactionHistory from 'hooks/useFetchTransactionHistory';
+import useTransactionHistory from 'hooks/useTransactionHistory';
 import { setRoute as setAppRoute } from 'store/router';
 import { joinClass } from 'utils/style';
 import TxHistoryItem from 'views/v2/TxHistory/Item';
@@ -67,7 +67,7 @@ const TxHistory = () => {
 
   const [page, setPage] = useState(0);
 
-  const { transactions, isFetching, hasMore } = useFetchTransactionHistory({
+  const { transactions, isFetching, hasMore } = useTransactionHistory({
     page,
   });
 


### PR DESCRIPTION
This PR adds the hook to fetch and parse Mayan transactions as well as the logic to merge them with WHScan transactions into the Transaction History view.

Please see the loom here:
https://www.loom.com/share/3b849138a5e44adab4461a3add8fd2bb