### PR TITLE
[Redesign] Fix gas top up token config

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/GasSlider.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/GasSlider.tsx
@@ -19,7 +19,6 @@ import { RootState } from 'store';
 import { setToNativeToken } from 'store/relay';
 
 import { toFixedDecimals } from 'utils/balance';
-import { TokenConfig } from 'config/types';
 
 const useStyles = makeStyles()(() => ({
   card: {
@@ -91,7 +90,7 @@ const GasSlider = (props: {
   const dispatch = useDispatch();
   const theme = useTheme();
 
-  const { token: sourceToken, toChain: destChain } = useSelector(
+  const { toChain: destChain } = useSelector(
     (state: RootState) => state.transferInput,
   );
 
@@ -100,8 +99,7 @@ const GasSlider = (props: {
   );
 
   const destChainConfig = config.chains[destChain!];
-  const sourceTokenConfig = config.tokens[sourceToken];
-  const nativeGasToken = config.tokens[destChainConfig!.gasToken];
+  const nativeGasTokenConfig = config.tokens[destChainConfig!.gasToken];
 
   const [isGasSliderOpen, setIsGasSliderOpen] = useState(!props.disabled);
   const [percentage, setPercentage] = useState(0);
@@ -113,36 +111,33 @@ const GasSlider = (props: {
   }, [debouncedPercentage]);
 
   const nativeGasPrice = useMemo(() => {
+    if (!destChain) {
+      return null;
+    }
+
     const tokenAmount = toFixedDecimals(
       props.destinationGasDrop?.toString() || '0',
       6,
     );
+
     const tokenPrice = calculateUSDPrice(
       props.destinationGasDrop,
       tokenPrices.data,
-      nativeGasToken,
+      nativeGasTokenConfig,
     );
-
-    if (!destChain) return null;
 
     return (
       <Typography fontSize={14}>
         {`${tokenAmount} ${getDisplayName(
-          sourceTokenConfig as TokenConfig,
+          nativeGasTokenConfig,
           destChain,
         )} ${tokenPrice}`}
       </Typography>
     );
-  }, [
-    nativeGasToken,
-    tokenPrices,
-    props.destinationGasDrop,
-    sourceTokenConfig,
-    destChain,
-  ]);
+  }, [nativeGasTokenConfig, tokenPrices, props.destinationGasDrop, destChain]);
 
   // Checking required values
-  if (!sourceTokenConfig || !destChainConfig || !nativeGasToken) {
+  if (!destChainConfig || !nativeGasTokenConfig) {
     return <></>;
   }
 


### PR DESCRIPTION
This PR fixes the token config for gas top up, which was previously set to source token. It should be the destination chain's native gas token.

![Screenshot 2024-09-13 at 4 32 08 PM](https://github.com/user-attachments/assets/3fe5b3d8-b463-46c6-8d27-47917a175dc9)
