### PR TITLE
Isolate chain badge background color so main background can be transparent

### DIFF
--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -33,6 +33,7 @@ export type WormholeConnectPartialTheme = {
   divider?: string;
   background?: {
     default: string;
+    badge: string;
   };
   text?: {
     primary: string;
@@ -99,6 +100,7 @@ export const light: WormholeConnectTheme = {
   divider: '#a0a2a9',
   background: {
     default: '#E5E8F2',
+    badge: '#E5E8F2',
   },
   text: {
     primary: grey[900],
@@ -198,6 +200,7 @@ export const dark: WormholeConnectTheme = {
   divider: '#ffffff' + OPACITY[20],
   background: {
     default: '#010101',
+    badge: '#010101',
   },
   text: {
     primary: '#ffffff',

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -56,7 +56,8 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   chainBadge: {
     padding: '2px',
-    background: theme.palette.background.badge,
+    background:
+      theme.palette.background.badge ?? theme.palette.background.default,
     borderRadius: '6px',
     border: `2px solid ${theme.palette.modal.background}`,
   },

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -56,7 +56,7 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   chainBadge: {
     padding: '2px',
-    background: theme.palette.background.default,
+    background: theme.palette.background.badge,
     borderRadius: '6px',
     border: `2px solid ${theme.palette.modal.background}`,
   },


### PR DESCRIPTION
Trying to avoid this:
![image](https://github.com/user-attachments/assets/b4462937-9ccd-457a-b14b-d6ea54f6f4af)
