### PR TITLE
Log commit hash in telemetry events

### DIFF
--- a/wormhole-connect/src/config/constants.ts
+++ b/wormhole-connect/src/config/constants.ts
@@ -8,6 +8,9 @@ export const AVAILABLE_MARKETS_URL =
 export const CONNECT_VERSION =
   import.meta.env.REACT_APP_CONNECT_VERSION || 'unknown';
 
+export const CONNECT_GIT_HASH =
+  import.meta.env.REACT_APP_CONNECT_GIT_HASH || 'unknown';
+
 export const CHAIN_ORDER: Chain[] = [
   'Ethereum',
   'Solana',

--- a/wormhole-connect/src/config/events.ts
+++ b/wormhole-connect/src/config/events.ts
@@ -1,4 +1,4 @@
-import { CONNECT_VERSION } from './constants';
+import { CONNECT_VERSION, CONNECT_GIT_HASH } from './constants';
 import {
   WormholeConnectEvent,
   WormholeConnectEventHandler,
@@ -12,6 +12,7 @@ export function wrapEventHandler(
     const eventWithMeta: WormholeConnectEventWithMeta = {
       meta: {
         version: CONNECT_VERSION,
+        hash: CONNECT_GIT_HASH,
         host: window?.location?.host,
       },
       ...event,

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -90,6 +90,7 @@ export type WormholeConnectEvent =
 export interface WormholeConnectEventMeta {
   meta: {
     version: string;
+    hash: string;
     host: string;
   };
 }

--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { execSync } from 'child_process';
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import checker from '@artursapek/vite-plugin-checker';
@@ -13,6 +14,18 @@ const packagePath = __dirname.endsWith('wormhole-connect')
   : './wormhole-connect/package.json';
 const { version } = require(packagePath);
 
+let gitHash = 'unknown';
+try {
+  gitHash = execSync("git log | head -n 1 | awk '{ print $2 }'").toString();
+} catch (e) {
+  console.error(`Failed to determine git hash! Will be missing from telemetry`);
+  console.error(e);
+}
+
+console.info(
+  `\nBuilding Wormhole Connect version=${version} hash=${gitHash}\n`,
+);
+
 // There are three configs this file can return.
 // 1. local dev server
 // 2. production build, for direct import
@@ -24,6 +37,7 @@ const envPrefix = 'REACT_APP_';
 const define = {
   'import.meta.env.REACT_APP_CONNECT_VERSION':
     process.env.CONNECT_VERSION ?? JSON.stringify(version),
+  'import.meta.env.REACT_APP_CONNECT_GIT_HASH': JSON.stringify(gitHash),
 };
 
 const resolve = {

--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -16,7 +16,7 @@ const { version } = require(packagePath);
 
 let gitHash = 'unknown';
 try {
-  gitHash = execSync("git log | head -n 1 | awk '{ print $2 }'").toString();
+  gitHash = execSync('git log -1 --format=%H').toString().replace('\n', '');
 } catch (e) {
   console.error(`Failed to determine git hash! Will be missing from telemetry`);
   console.error(e);


### PR DESCRIPTION
This adds a more specific build identifier (which git commit hash was used) to all Connect telemetry events.

This is generally useful, but particularly for immediately checking which commit hash a given build is from, using the `load` event that Connect fires when it first loads:

<img width="706" alt="image" src="https://github.com/user-attachments/assets/15ec87b4-7b44-45f3-b592-e04706ae0078">
