### PR TITLE
memoize source token array

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -189,10 +189,14 @@ const Bridge = () => {
   // Fetch token prices
   useFetchTokenPrices();
 
+  const sourceTokenArray = useMemo(() => {
+    return sourceToken ? [config.tokens[sourceToken]] : [];
+  }, [sourceToken]);
+
   const { balances, isFetching: isFetchingBalances } = useGetTokenBalances(
     sendingWallet?.address || '',
     sourceChain,
-    sourceToken ? [config.tokens[sourceToken]] : [],
+    sourceTokenArray,
   );
 
   // Validate amount


### PR DESCRIPTION
This was causing the get balances hook to fire off in an infinite loop