### PR TITLE
Fix transfer completion bug in manual transfer claims

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -446,11 +446,6 @@ const Redeem = () => {
 
       let receipt: routes.Receipt | undefined;
 
-      config.triggerEvent({
-        type: 'transfer.redeem.start',
-        details: transferDetails,
-      });
-
       if (isTxDestQueued && routes.isFinalizable(route)) {
         receipt = await route.finalize(signer, routeContext.receipt);
       } else if (!isTxDestQueued && routes.isManual(route)) {
@@ -464,6 +459,11 @@ const Redeem = () => {
       if (receipt.destinationTxs && receipt.destinationTxs.length > 0) {
         txId = receipt.destinationTxs[receipt.destinationTxs.length - 1].txid;
       }
+
+      config.triggerEvent({
+        type: 'transfer.redeem.start',
+        details: transferDetails,
+      });
 
       setIsClaimInProgress(false);
       setClaimError('');


### PR DESCRIPTION
When claiming a manual transfer, the useTrackTransfer hook sometimes marked the transfer as complete before the async function triggered by the claim button finished. This allowed users to start a new transfer prematurely, causing the new transfer to be erroneously marked as complete. We should rely solely on the useTrackTransfer hook to set the transfer as complete and handle the redeem transaction. This change prevents the bug and moves the transfer.redeem.start event trigger to before the routes redeem function call.