### PR TITLE
Error display fixes & Hide tokens with 0 balances in Source Asset Picker

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -17,6 +17,7 @@ type Props = {
   quotesMap: Record<string, QuoteResult | undefined>;
   tokenSymbol: string;
   isLoading: boolean;
+  disabled?: boolean;
 };
 
 export const useAmountValidation = (props: Props): HookReturn => {
@@ -57,7 +58,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   const numAmount = Number.parseFloat(amount);
 
   // Don't show errors when no amount is set or it's loading
-  if (!amount || !numAmount || props.isLoading) {
+  if (!amount || !numAmount || props.isLoading || props.disabled) {
     return {};
   }
 

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -83,6 +83,11 @@ const TokenList = (props: Props) => {
         return;
       }
 
+      // Exclude tokens with no balance on source list
+      if (props.isSource && !balance && props.wallet?.address) {
+        return;
+      }
+
       // Exclude wormhole-wrapped tokens with no balance
       if (
         props.isSource &&
@@ -159,14 +164,30 @@ const TokenList = (props: Props) => {
     return tokens;
   }, [balances, props.tokenList, props.sourceToken]);
 
+  const noTokensMessage = useMemo(
+    () => (
+      <Typography variant="body2" color={theme.palette.grey.A400}>
+        No supported tokens found in wallet
+      </Typography>
+    ),
+    [],
+  );
+
+  const shouldShowEmptyMessage =
+    sortedTokens.length === 0 && !isFetchingTokenBalances && !props.isFetching;
+
   const searchList = (
     <SearchableList<TokenConfig>
       searchPlaceholder="Search for a token"
       className={classes.tokenList}
       listTitle={
-        <Typography fontSize={14} color={theme.palette.text.secondary}>
-          Tokens on {props.selectedChainConfig.displayName}
-        </Typography>
+        shouldShowEmptyMessage ? (
+          noTokensMessage
+        ) : (
+          <Typography fontSize={14} color={theme.palette.text.secondary}>
+            Tokens on {props.selectedChainConfig.displayName}
+          </Typography>
+        )
       }
       loading={
         props.isFetching && (

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -8,7 +8,6 @@ import { makeStyles } from 'tss-react/mui';
 import config from 'config';
 import { RoutesConfig } from 'config/routes';
 import SingleRoute from 'views/v2/Bridge/Routes/SingleRoute';
-import AlertBannerV2 from 'components/v2/AlertBanner';
 
 import type { RootState } from 'store';
 import { RouteState } from 'store/transferInput';
@@ -130,14 +129,8 @@ const Routes = ({ ...props }: Props) => {
   }, [routes, props.quotes]);
 
   if (walletsConnected && supportedRoutes.length === 0 && Number(amount) > 0) {
-    return (
-      <AlertBannerV2
-        error
-        show
-        content="No route found for this transaction"
-        style={{ justifyContent: 'center' }}
-      />
-    );
+    // Errors are displayed in AmountInput
+    return;
   }
 
   if (supportedRoutes.length === 0 || !walletsConnected || props.hasError) {

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -199,6 +199,14 @@ const Bridge = () => {
     sourceTokenArray,
   );
 
+  const disableValidation =
+    !sendingWallet.address ||
+    !receivingWallet.address ||
+    !sourceChain ||
+    !sourceToken ||
+    !destChain ||
+    !destToken;
+
   // Validate amount
   const amountValidation = useAmountValidation({
     balance: balances[sourceToken]?.balance,
@@ -206,6 +214,7 @@ const Bridge = () => {
     quotesMap,
     tokenSymbol: config.tokens[sourceToken]?.symbol ?? '',
     isLoading: isFetchingBalances || isFetchingQuotes,
+    disabled: disableValidation,
   });
 
   // Get input validation result


### PR DESCRIPTION
Tickets:
[Hide errors](https://www.notion.so/wormholelabs/Bug-don-t-show-error-message-when-fields-are-empty-1053029e88cb800cb55efe82b3f5cdf8?pvs=23)
[Double error](https://www.notion.so/wormholelabs/Bug-Double-route-not-found-error-1063029e88cb8084a6bdc3e24c9ca013?pvs=23)
[Hide 0 balance tokens] (https://www.notion.so/wormholelabs/Feature-For-source-wallet-network-input-hide-tokens-you-don-t-have-a-balance-of-1053029e88cb8077a6abc7c9b77b42be?pvs=23)

![Screenshot from 2024-09-19 21-45-00](https://github.com/user-attachments/assets/7812888b-c7ba-4517-bc38-ccde5171ab6d)
