### PR TITLE
[Redesign] Fix vertical connector's height

### DIFF
--- a/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
@@ -141,7 +141,7 @@ const TxHistoryItem = (props: Props) => {
   const verticalConnector = useMemo(
     () => (
       <Stack
-        height="32px"
+        height="24px"
         borderLeft="1px solid #8B919D"
         marginLeft="16px"
       ></Stack>


### PR DESCRIPTION
The space between source and destination token symbols should be 24px instead of 32px according to the UX mocks.
