### PR TITLE
[Redesign] Automatic route selection should overwrite invalid routes

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -165,9 +165,14 @@ const Bridge = () => {
       setSelectedRoute('');
     } else {
       const autoselectedRoute = route || validRoutes[0].route.name;
+      const isSelectedRouteValid =
+        validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
 
-      // avoids overwriting selected route
-      if (!autoselectedRoute || !!selectedRoute) return;
+      // If no route is autoselected or we already have a valid selected route,
+      // we should avoid to overwrite it
+      if (!autoselectedRoute || (selectedRoute && isSelectedRouteValid)) {
+        return;
+      }
 
       const routeData = validRoutes?.find(
         (rs) => rs.route.name === autoselectedRoute,


### PR DESCRIPTION
I've been seeing this case where a previous source/dest token selection's route might be invalid for a new token pair. In that case we should auto-select a new valid route.