### PR TITLE
Powered by responsive

### DIFF
--- a/wormhole-connect/src/icons/PoweredBy.tsx
+++ b/wormhole-connect/src/icons/PoweredBy.tsx
@@ -10,6 +10,9 @@ const useStyles = makeStyles()((theme) => ({
     alignContent: 'center',
     alignItems: 'center',
     flexDirection: 'row',
+    maxWidth: '100%',
+    flexWrap: 'wrap',
+    gap: '20px 4px',
   },
   partnerLogo: {
     maxHeight: theme.spacing(3),


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/723f7e4e-c263-4917-95c9-938cd6cac20e)


After:

<img width="401" alt="Captura de pantalla 2024-09-20 a las 3 00 07 p m" src="https://github.com/user-attachments/assets/c5c1e36b-86ed-4a10-8817-1f8cddc36dc7">
