### PR TITLE
[QA] [Improvement] Don't show "Fastest" label when only one route is available

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -57,21 +57,19 @@ const Routes = ({ ...props }: Props) => {
   const { classes } = useStyles();
   const [showAll, setShowAll] = useState(false);
 
-  const { amount, routeStates } = useSelector(
-    (state: RootState) => state.transferInput,
-  );
+  const { amount } = useSelector((state: RootState) => state.transferInput);
 
   const { sending: sendingWallet, receiving: receivingWallet } = useSelector(
     (state: RootState) => state.wallet,
   );
 
   const supportedRoutes = useMemo(() => {
-    if (!routeStates) {
+    if (!props.routes) {
       return [];
     }
 
-    return routeStates.filter((rs) => rs.supported);
-  }, [routeStates]);
+    return props.routes.filter((rs) => rs.supported);
+  }, [props.routes]);
 
   const walletsConnected = useMemo(
     () => !!sendingWallet.address && !!receivingWallet.address,


### PR DESCRIPTION
[[QA] [Improvement] Don't show "Fastest" label when only one route is available](https://github.com/wormhole-foundation/wormhole-connect/issues/2646)

<img width="506" alt="image" src="https://github.com/user-attachments/assets/592cc440-3d3e-4c29-ac04-1f68fca0a217">
