### PR TITLE
[Redesign] Display empty Tx history when we receive non-200 response from respective APIs

### DIFF
--- a/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
@@ -252,35 +252,41 @@ const useTransactionHistoryWHScan = (
           { headers },
         );
 
-        const resPayload = await res.json();
+        // If the fetch was unsuccessful, return an empty set
+        if (res.status !== 200) {
+          setIsFetching(false);
+          setTransactions([]);
+        } else {
+          const resPayload = await res.json();
 
-        if (!cancelled) {
-          const resData = resPayload?.operations;
-          if (resData.length > 0) {
-            setTransactions((txs) => {
-              const parsedTxs = parseTransactions(resData);
-              if (txs && txs.length > 0) {
-                // We need to keep track of existing tx hashes to prevent duplicates in the final list
-                const existingTxs = new Set<string>();
-                txs.forEach((tx: Transaction) => {
-                  if (tx?.txHash) {
-                    existingTxs.add(tx.txHash);
-                  }
-                });
+          if (!cancelled) {
+            const resData = resPayload?.operations;
+            if (resData) {
+              setTransactions((txs) => {
+                const parsedTxs = parseTransactions(resData);
+                if (txs && txs.length > 0) {
+                  // We need to keep track of existing tx hashes to prevent duplicates in the final list
+                  const existingTxs = new Set<string>();
+                  txs.forEach((tx: Transaction) => {
+                    if (tx?.txHash) {
+                      existingTxs.add(tx.txHash);
+                    }
+                  });
 
-                // Add the new set transactions while filtering out duplicates
-                return txs.concat(
-                  parsedTxs.filter(
-                    (tx: Transaction) => !existingTxs.has(tx.txHash),
-                  ),
-                );
-              }
-              return parsedTxs;
-            });
-          }
+                  // Add the new set transactions while filtering out duplicates
+                  return txs.concat(
+                    parsedTxs.filter(
+                      (tx: Transaction) => !existingTxs.has(tx.txHash),
+                    ),
+                  );
+                }
+                return parsedTxs;
+              });
+            }
 
-          if (resData?.length < pageSize) {
-            setHasMore(false);
+            if (resData?.length < pageSize) {
+              setHasMore(false);
+            }
           }
         }
       } catch (error) {

--- a/wormhole-connect/src/views/v2/TxHistory/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/index.tsx
@@ -15,6 +15,7 @@ import config from 'config';
 import PoweredByIcon from 'icons/PoweredBy';
 import useTransactionHistory from 'hooks/useTransactionHistory';
 import { setRoute as setAppRoute } from 'store/router';
+import { trimAddress } from 'utils';
 import { joinClass } from 'utils/style';
 import TxHistoryItem from 'views/v2/TxHistory/Item';
 
@@ -117,8 +118,10 @@ const TxHistory = () => {
       return <></>;
     } else if (transactions.length === 0) {
       return (
-        <Typography textAlign="center">
-          No transactions found for the address {sendingWallet.address}
+        <Typography color={theme.palette.text.secondary} textAlign="center">
+          {`No transactions found for the wallet ${trimAddress(
+            sendingWallet.address,
+          )}`}
         </Typography>
       );
     }


### PR DESCRIPTION
This PR fixes the case when receive non-200 responses from the APIs but it still thinks the fetching is not completed. In that case we need to set the transactions to empty arrays to display the empty list.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2677

<img width="532" alt="Screenshot 2024-09-23 at 12 46 52 PM" src="https://github.com/user-attachments/assets/5b6c94ea-dfd1-4076-a138-45c9eb0dbf8a">

<img width="527" alt="Screenshot 2024-09-23 at 12 46 59 PM" src="https://github.com/user-attachments/assets/7c0c26f8-952c-4219-8c4b-7da66d8c307d">
