### PR TITLE
[Redesign] Fixing which tokens to display whether a wallet is connected

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -83,7 +83,7 @@ const TokenList = (props: Props) => {
     }
 
     // Second: Add the wrapped token of the source token, if sourceToken is defined (meaning
-    // this is being rendered with destination tokens).
+    // this is being rendered with destination tokens) and the wrapped is not a Frankenstein token
     if (props.sourceToken) {
       const sourceTokenConfig = config.tokens[props.sourceToken];
       if (sourceTokenConfig) {
@@ -98,7 +98,12 @@ const TokenList = (props: Props) => {
                 selectedChainConfig.key,
               ),
           );
-          if (destTokenConfig && !tokenSet.has(destTokenConfig.key)) {
+
+          if (
+            destTokenConfig &&
+            !tokenSet.has(destTokenConfig.key) &&
+            !isFrankensteinToken(destTokenConfig, selectedChainConfig.key)
+          ) {
             tokenSet.add(destTokenConfig.key);
             tokens.push(destTokenConfig);
           }

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -91,11 +91,6 @@ const TokenList = (props: Props) => {
         return;
       }
 
-      // Exclude tokens with no balance on source list
-      if (props.isSource && noBalance && props.wallet?.address) {
-        return;
-      }
-
       // Exclude wormhole-wrapped tokens with no balance
       // unless it's canonical
       if (
@@ -163,11 +158,14 @@ const TokenList = (props: Props) => {
       }
     });
 
-    // Finally: If no wallet is connected, fill up any remaining space from supported tokens
-    if (!props.wallet?.address) {
+    // Finally: If this is destination token or no wallet is connected,
+    // fill up any remaining space from supported and non-Frankenstein tokens
+    if (!props.isSource || !props.wallet?.address) {
       props.tokenList?.forEach((t) => {
-        // Adding remaining tokens
-        if (!tokenSet.has(t.key)) {
+        if (
+          !tokenSet.has(t.key) &&
+          !isFrankensteinToken(t, selectedChainConfig.key)
+        ) {
           addToken(t);
         }
       });


### PR DESCRIPTION
This PR displays all tokens supported when no wallet is connected; and the ones with a balance when a wallet is connected. Please see the loom below for details.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2674

https://www.loom.com/share/8c78bd459de442b58193e6c2ff93dc03?sid=5cd50d11-a606-4914-99f6-aa92712e3221