### PR TITLE
Show canonical tokens even when wallet is not connected

### DIFF
--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -408,6 +408,12 @@ export const isWrappedToken = (token: TokenConfig, chain: Chain) => {
   return token.nativeChain !== chain;
 };
 
+// Canonical tokens may be Wormhole-wrapped tokens that are canonical on the chain
+// e.g., Wormhole-wrapped Ethereum USDC is canonical on Sui
+export const isCanonicalToken = (token: TokenConfig, chain: Chain) => {
+  return token.key === 'USDCeth' && chain === 'Sui';
+};
+
 export const millisToHumanString = (ts: number): string => {
   if (ts > 60000) {
     const minutes = Math.ceil(ts / 60000);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -13,7 +13,12 @@ import type { ChainConfig, TokenConfig } from 'config/types';
 import type { WalletData } from 'store/wallet';
 import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
 import TokenItem from 'views/v2/Bridge/AssetPicker/TokenItem';
-import { getDisplayName, isFrankensteinToken, isWrappedToken } from 'utils';
+import {
+  getDisplayName,
+  isCanonicalToken,
+  isFrankensteinToken,
+  isWrappedToken,
+} from 'utils';
 import { getTokenBridgeWrappedTokenAddressSync } from 'utils/sdkv2';
 
 const useStyles = makeStyles()((theme) => ({
@@ -92,6 +97,7 @@ const TokenList = (props: Props) => {
       if (
         props.isSource &&
         isWrappedToken(tokenConfig, selectedChainConfig.key) &&
+        !isCanonicalToken(tokenConfig, selectedChainConfig.key) &&
         !balance
       ) {
         return;

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -94,6 +94,7 @@ const TokenList = (props: Props) => {
       }
 
       // Exclude wormhole-wrapped tokens with no balance
+      // unless it's canonical
       if (
         props.isSource &&
         isWrappedToken(tokenConfig, selectedChainConfig.key) &&
@@ -215,7 +216,13 @@ const TokenList = (props: Props) => {
         }
 
         // Exclude wormhole-wrapped tokens with no balance
-        if (props.isSource && isWrappedToken(token, chain) && !balance) {
+        // unless it's canonical
+        if (
+          props.isSource &&
+          isWrappedToken(token, chain) &&
+          !isCanonicalToken(token, chain) &&
+          !balance
+        ) {
           return false;
         }
 


### PR DESCRIPTION
Wormhole-wrapped Ethereum USDC was not showing with Sui as the source chain, because it's a Wormhole-wrapped token, and we only display those if the user has a balance. However, this token is canonical on Sui, so we want to display it even when the users's wallet isn't connected.

Added an `isCanonical` function that the `TokenList` uses.

Fixes #2690