### PR TITLE
[Redesign] Setting hasMore to false when the response is non-200

### DIFF
--- a/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryMayan.ts
@@ -132,8 +132,9 @@ const useTransactionHistoryMayan = (
 
         // If the fetch was unsuccessful, return an empty set
         if (res.status !== 200) {
-          setIsFetching(false);
           setTransactions([]);
+          setHasMore(false);
+          setIsFetching(false);
         } else {
           const resPayload = await res.json();
 
@@ -171,6 +172,7 @@ const useTransactionHistoryMayan = (
         }
       } catch (error) {
         if (!cancelled) {
+          setHasMore(false);
           setError(`Error fetching transaction history from Mayan: ${error}`);
         }
       } finally {

--- a/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
@@ -254,8 +254,9 @@ const useTransactionHistoryWHScan = (
 
         // If the fetch was unsuccessful, return an empty set
         if (res.status !== 200) {
-          setIsFetching(false);
           setTransactions([]);
+          setHasMore(false);
+          setIsFetching(false);
         } else {
           const resPayload = await res.json();
 
@@ -291,6 +292,7 @@ const useTransactionHistoryWHScan = (
         }
       } catch (error) {
         if (!cancelled) {
+          setHasMore(false);
           setError(
             `Error fetching transaction history from WormholeScan: ${error}`,
           );


### PR DESCRIPTION
We need to set hasMore to false to prevent the hook waiting for the non-existing data.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2742
Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2746