### PR TITLE
[Redesign] Remove number type to avoid arrows and check type manually

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -42,7 +42,13 @@ const DebouncedTextField = memo(
 
     const onInnerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
       (e) => {
-        if (Number(e.target.value) < 0) return; // allows "everything" but negative numbers
+        const numValue = Number(e.target.value);
+
+        if (isNaN(numValue) || numValue < 0) {
+          // allows all but negative numbers
+          return;
+        }
+
         setInnerValue(e.target.value);
         defferedOnChange(e.target.value);
       },
@@ -78,15 +84,6 @@ const useStyles = makeStyles()((theme) => ({
   },
   balance: {
     color: theme.palette.text.secondary,
-  },
-  amountInput: {
-    '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {
-      webkitAppearance: 'none',
-      margin: 0,
-    },
-    '&[type="number"]': {
-      mozAppearance: 'textfield',
-    },
   },
 }));
 
@@ -226,8 +223,6 @@ const AmountInput = (props: Props) => {
                   </Stack>
                 </InputAdornment>
               ),
-              type: 'number',
-              classes: { input: classes.amountInput },
             }}
           />
         </CardContent>


### PR DESCRIPTION
Since the amount input TextField was moved into another layer of component for debouncing, it has become a bit tricky to remove the built-in up/down arrows. Therefore I've removed the number type and added the isNan check in the change handler.

<img width="510" alt="Screenshot 2024-09-26 at 7 54 44 PM" src="https://github.com/user-attachments/assets/488f1f82-c746-4ad7-8fa1-d1db7d12b1c1">
