### PR TITLE
Log the provided config in `load` event

### DIFF
--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -62,6 +62,7 @@ function AppRouter(props: Props) {
 
     config.triggerEvent({
       type: 'load',
+      config: props.config,
     });
   }, []);
 

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -1,8 +1,10 @@
 import { Chain } from '@wormhole-foundation/sdk';
+import { WormholeConnectConfig } from 'config/types';
 import { TransferWallet } from 'utils/wallet';
 
 export interface LoadEvent {
   type: 'load';
+  config?: WormholeConnectConfig;
 }
 
 export interface TransferDetails {


### PR DESCRIPTION
For diagnostics purposes