### PR TITLE
Fix Claim button text when background default is transparent

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -77,7 +77,8 @@ const useStyles = makeStyles()((theme) => ({
   },
   claimButton: {
     backgroundColor: theme.palette.warning.light,
-    color: theme.palette.background.default,
+    color:
+      theme.palette.warning.contrastText ?? theme.palette.background.default,
     '&:hover': {
       backgroundColor: theme.palette.warning.main,
     },


### PR DESCRIPTION
Issue: https://github.com/XLabs/portal-bridge-ui/issues/1112

Connect:

<img width="602" alt="Captura de pantalla 2024-09-26 a las 2 31 12 p m" src="https://github.com/user-attachments/assets/60a84c6c-741e-464c-ba0b-332a25ef022f">

Portal:

<img width="846" alt="Captura de pantalla 2024-09-26 a las 2 38 38 p m" src="https://github.com/user-attachments/assets/0bc9866f-318c-4303-9079-9e6f36a5f920">

