### PR TITLE
[QA] Amount displayed in "More routes available" message should have more decimal places

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -83,7 +83,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   if (allRoutesFailed) {
     if (minAmount) {
       const formattedAmount = sdkAmount.whole(minAmount).toLocaleString('en', {
-        maximumFractionDigits: 4,
+        maximumFractionDigits: 6,
       });
       return {
         error: `Amount too small (min ~${formattedAmount} ${props.tokenSymbol})`,

--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -98,7 +98,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   // MinQuote warnings information
   if (minAmount) {
     const formattedAmount = sdkAmount.whole(minAmount).toLocaleString('en', {
-      maximumFractionDigits: 4,
+      maximumFractionDigits: 6,
     });
     return {
       warning: `More routes available for amounts exceeding ${formattedAmount} ${props.tokenSymbol}`,

--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -82,9 +82,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   // All quotes fail.
   if (allRoutesFailed) {
     if (minAmount) {
-      const formattedAmount = sdkAmount.whole(minAmount).toLocaleString('en', {
-        maximumFractionDigits: 6,
-      });
+      const formattedAmount = sdkAmount.display(minAmount);
       return {
         error: `Amount too small (min ~${formattedAmount} ${props.tokenSymbol})`,
       };
@@ -97,9 +95,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
 
   // MinQuote warnings information
   if (minAmount) {
-    const formattedAmount = sdkAmount.whole(minAmount).toLocaleString('en', {
-      maximumFractionDigits: 6,
-    });
+    const formattedAmount = sdkAmount.display(minAmount);
     return {
       warning: `More routes available for amounts exceeding ${formattedAmount} ${props.tokenSymbol}`,
     };


### PR DESCRIPTION
[[QA] Amount displayed in "More routes available" message should have more decimal places](https://github.com/wormhole-foundation/wormhole-connect/issues/2740)

<img width="559" alt="image" src="https://github.com/user-attachments/assets/1fa18f27-a22e-4236-bf5c-4115c4bc4b12">
