### PR TITLE
tokens with large balances not selectable fix

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -71,7 +71,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
 
   // Balance errors
   if (props.balance) {
-    const balanceNum = Number.parseFloat(props.balance.replace(',', ''));
+    const balanceNum = Number.parseFloat(props.balance.replaceAll(',', ''));
     if (numAmount > balanceNum) {
       return {
         error: 'Amount exceeds available balance.',

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -100,7 +100,7 @@ export const validateAmount = (
   if (isNaN(numAmount)) return 'Amount must be a number';
   if (numAmount <= 0) return 'Amount must be greater than 0';
   if (balance) {
-    const b = Number.parseFloat(balance.replace(',', ''));
+    const b = Number.parseFloat(balance.replaceAll(',', ''));
     if (numAmount > b) return 'Amount exceeds available balance.';
   }
   if (numAmount > maxAmount) {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -123,7 +123,7 @@ const TokenList = (props: Props) => {
 
     // Fourth: Add tokens with a balances in the connected wallet
     Object.entries(balances).forEach(([key, val]) => {
-      if (val?.balance && Number(val.balance) > 0) {
+      if (val?.balance && Number(val.balance.replaceAll(',', '')) > 0) {
         const tokenConfig = props.tokenList?.find((t) => t.key === key);
 
         if (tokenConfig && !tokenSet.has(tokenConfig.key)) {


### PR DESCRIPTION
Calling `Number(s)` where `s` is an amount string with commas returns NaN and was preventing tokens from large balances from being selected. Also we should be using relaceAll instead of relace when replacing commas.