### PR TITLE
[Redesign] UI polish for Redeem view

### DIFF
--- a/wormhole-connect/src/utils/sdkv2.ts
+++ b/wormhole-connect/src/utils/sdkv2.ts
@@ -121,14 +121,15 @@ export type ExplorerInfo = {
 
 // TODO SDKV2 add a way for the Route interface to offer this
 export function getExplorerInfo(
-  route: routes.Route<Network>,
+  route: string | routes.Route<Network>,
   txHash: string,
 ): ExplorerInfo {
-  if (
-    (route.constructor as routes.RouteConstructor).meta.name.startsWith(
-      'MayanSwap',
-    )
-  ) {
+  const routeName =
+    typeof route === 'string'
+      ? route
+      : (route.constructor as routes.RouteConstructor).meta.name;
+
+  if (routeName.startsWith('MayanSwap')) {
     return {
       url: `https://explorer.mayan.finance/swap/${txHash}`,
       name: 'Mayan Explorer',

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -207,7 +207,6 @@ const AmountInput = (props: Props) => {
                 e.currentTarget.blur();
               },
               step: '0.1',
-              pattern: '[0-9]+([.|,][0-9]{1,2})?',
             }}
             placeholder="0"
             variant="standard"

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -242,7 +242,7 @@ const SingleRoute = (props: Props) => {
 
     if (isManual) {
       messages.push(
-        <>
+        <div key="ManualTransactionWarning">
           <Divider flexItem sx={{ marginTop: '8px' }} />
           <Stack direction="row" alignItems="center">
             <WarningIcon htmlColor={theme.palette.warning.main} />
@@ -256,7 +256,7 @@ const SingleRoute = (props: Props) => {
               </Typography>
             </Stack>
           </Stack>
-        </>,
+        </div>,
       );
     }
 
@@ -268,7 +268,7 @@ const SingleRoute = (props: Props) => {
         const symbol = config.tokens[destToken].symbol;
         const duration = formatDuration(warning.delayDurationSec);
         messages.push(
-          <>
+          <div key={`${warning.type}-${warning.delayDurationSec}`}>
             <Divider flexItem sx={{ marginTop: '8px' }} />
             <Stack direction="row" alignItems="center">
               <WarningIcon htmlColor={theme.palette.warning.main} />
@@ -278,7 +278,7 @@ const SingleRoute = (props: Props) => {
                 </Typography>
               </Stack>
             </Stack>
-          </>,
+          </div>,
         );
       }
     }

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -127,15 +127,14 @@ const SingleRoute = (props: Props) => {
       return <></>;
     }
 
-    let feeValue = (
-      <Typography fontSize={14}>{`${toFixedDecimals(relayFee.toString(), 4)} ${
-        feeTokenConfig.symbol
-      } (${feePrice})`}</Typography>
-    );
+    let feeValue = `${toFixedDecimals(relayFee.toString(), 4)} ${
+      feeTokenConfig.symbol
+    } (${feePrice})`;
 
     // Wesley made me do it
+    // Them PMs :-/
     if (props.route.name.startsWith('MayanSwap')) {
-      feeValue = <Typography fontSize={14}>{`${feePrice}`}</Typography>;
+      feeValue = feePrice;
     }
 
     return (

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -160,7 +160,7 @@ const Routes = ({ ...props }: Props) => {
           Routes
         </Typography>
         {props.isLoading ? (
-          <CircularProgress sx={{ 'align-self': 'flex-end' }} size={20} />
+          <CircularProgress sx={{ alignSelf: 'flex-end' }} size={20} />
         ) : null}
       </Box>
 

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { makeStyles } from 'tss-react/mui';
-import CircularProgress from '@mui/material/CircularProgress';
-import Drawer from '@mui/material/Drawer';
 import { useDispatch, useSelector } from 'react-redux';
 
+import CircularProgress from '@mui/material/CircularProgress';
+import Drawer from '@mui/material/Drawer';
+import IconButton from '@mui/material/IconButton';
 import InputAdornment from '@mui/material/InputAdornment';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -19,10 +20,9 @@ import config from 'config';
 import { RootState } from 'store';
 import { TransferWallet, WalletData, connectWallet } from 'utils/wallet';
 
-import WalletIcon from 'icons/WalletIcons';
 import AlertBannerV2 from 'components/v2/AlertBanner';
 import { useAvailableWallets } from 'hooks/useAvailableWallets';
-import { IconButton } from '@mui/material';
+import WalletIcon from 'icons/WalletIcons';
 
 const useStyles = makeStyles()((theme) => ({
   drawer: {
@@ -131,7 +131,7 @@ const WalletSidebar = (props: Props) => {
                     height={32}
                   />
                 </ListItemIcon>
-                <Typography fontSize={14}>
+                <Typography component="div" fontSize={14}>
                   <div className={`${!wallet.isReady && classes.notInstalled}`}>
                     {!wallet.isReady && 'Install'} {wallet.name}
                   </div>

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -652,9 +652,7 @@ const Redeem = () => {
           {isClaimInProgress || !isTxAttested ? (
             <Stack direction="row" alignItems="center">
               <CircularProgress size={24} />
-              <Typography marginLeft="4px" textTransform="none">
-                Transfer in progress
-              </Typography>
+              <Typography textTransform="none">Transfer in progress</Typography>
             </Stack>
           ) : (
             <Typography textTransform="none">

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -50,7 +50,11 @@ import { getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { PublicKey } from '@solana/web3.js';
 import TxReadyForClaim from 'icons/TxReadyForClaim';
 
-const useStyles = makeStyles()((theme) => ({
+type StyleProps = {
+  transitionDuration?: string;
+};
+
+const useStyles = makeStyles<StyleProps>()((theme, { transitionDuration }) => ({
   spacer: {
     display: 'flex',
     flexDirection: 'column',
@@ -92,6 +96,8 @@ const useStyles = makeStyles()((theme) => ({
   },
   circularProgressCircleDeterminite: {
     strokeLinecap: 'round',
+    transitionDuration,
+    transitionProperty: 'all',
   },
   circularProgressRoot: {
     animationDuration: '1s',
@@ -118,7 +124,6 @@ const useStyles = makeStyles()((theme) => ({
 
 const Redeem = () => {
   const dispatch = useDispatch();
-  const { classes } = useStyles();
   const theme = useTheme();
 
   const [claimError, setClaimError] = useState('');
@@ -158,6 +163,8 @@ const Redeem = () => {
     receiveAmount,
     eta = 0,
   } = txData!;
+
+  const { classes } = useStyles({ transitionDuration: `${eta}ms` });
 
   const getUSDAmount = useUSDamountGetter();
 
@@ -307,15 +314,14 @@ const Redeem = () => {
 
   // Value for determinate circular progress bar
   const etaProgressValue = useMemo(() => {
-    const timePassed = Date.now() - txTimestamp;
-
-    // Check if eta has already
-    if (timePassed >= eta) {
+    if (eta && txTimestamp && isRunning) {
+      // We return the full bar value when the ETA timer is running
+      // and simulate the progress by setting transitionDuration the eta (see useStyles above)
       return 100;
     }
 
-    return (timePassed / eta) * 100;
-  }, [eta, txTimestamp, seconds]);
+    return 0;
+  }, [eta, txTimestamp, isRunning]);
 
   // In-progress circular progress bar
   const etaCircularProgress = useMemo(() => {
@@ -385,7 +391,7 @@ const Redeem = () => {
         </Box>
       </>
     );
-  }, [etaDisplay, etaProgressValue]);
+  }, [etaDisplay, etaExpired, etaProgressValue]);
 
   // Circular progress indicator component for ETA countdown
   const etaCircle = useMemo(() => {

--- a/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
@@ -221,7 +221,7 @@ const WidgetItem = (props: Props) => {
   }
 
   return (
-    <div key={txHash} className={classes.container}>
+    <div className={classes.container}>
       <Card className={classes.card}>
         <CardActionArea
           disableTouchRipple

--- a/wormhole-connect/src/views/v2/TxHistory/Widget/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Widget/index.tsx
@@ -57,7 +57,7 @@ const TxHistoryWidget = () => {
         </Typography>
       </div>
       {transactions.map((tx) => (
-        <WidgetItem data={tx} />
+        <WidgetItem key={tx.txHash} data={tx} />
       ))}
     </div>
   );


### PR DESCRIPTION
This PR addresses the UI polish requests which includes a redesign of the Circular Progress bar for both determinate and indeterminate cases (see below). It also cleans up a few more React warnings/errors.

You can see the update for smoother progress bar transition here:
https://www.loom.com/share/67634ad8fceb4d99a82804b39cefb3eb?sid=ba85d219-3077-4940-befc-6a48227d0af9


Screenshots for all UI states:

<img width="504" alt="Screenshot 2024-10-02 at 3 42 11 PM" src="https://github.com/user-attachments/assets/3a60acc9-d0a4-4724-8cb8-d610e37546e4">

<img width="504" alt="Screenshot 2024-10-02 at 3 49 46 PM" src="https://github.com/user-attachments/assets/07039669-6f51-4660-907a-eacead2e5f3e">

<img width="504" alt="Screenshot 2024-10-02 at 5 10 23 PM" src="https://github.com/user-attachments/assets/86e9befb-32c7-4693-b75d-d0bb3f256e7b">

<img width="504" alt="Screenshot 2024-10-02 at 5 15 23 PM" src="https://github.com/user-attachments/assets/a52803f4-5382-4855-bb90-5d921912d682">

