### PR TITLE
Export buildConfig function

### DIFF
--- a/wormhole-connect/src/index.ts
+++ b/wormhole-connect/src/index.ts
@@ -9,6 +9,8 @@ import { dark, light } from './theme';
 
 import MAINNET from './config/mainnet';
 import TESTNET from './config/testnet';
+import { buildConfig } from './config';
+import type { WormholeConnectConfig } from './config/types';
 
 // Routes
 import { DEFAULT_ROUTES, nttRoutes } from './routes/operator';
@@ -24,7 +26,6 @@ import {
   nttManualRoute,
 } from '@wormhole-foundation/sdk-route-ntt';
 
-import type { WormholeConnectConfig } from './config/types';
 import type { Chain } from '@wormhole-foundation/sdk';
 
 const {
@@ -37,8 +38,10 @@ const {
 export default WormholeConnect;
 
 export {
+  // Config related exports
   MAINNET,
   TESTNET,
+  buildConfig,
 
   // Types
   WormholeConnectConfig,


### PR DESCRIPTION
`buildConfig` throws errors in some places if the custom config passed in is invalid. It could honestly be doing a lot more of that than it is. Having access to this function externally would be useful for validating arbitrary configs. I want to use this in connect-in-style to show any validation errors thrown by a user's custom config, directly in that UI.