### PR TITLE
Bug fix: Don't overwrite base theme

### DIFF
--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -302,7 +302,11 @@ export const dark: WormholeConnectTheme = {
 
 export const getDesignTokens = (customTheme: WormholeConnectPartialTheme) => {
   const baseTheme = customTheme?.mode === 'light' ? light : dark;
-  const theme = Object.assign(baseTheme, customTheme) as WormholeConnectTheme;
+  const theme = Object.assign(
+    {},
+    baseTheme,
+    customTheme,
+  ) as WormholeConnectTheme;
 
   return createTheme({
     components: {


### PR DESCRIPTION
Always `assign` on a fresh object to avoid mutating `baseTheme`. This causes bugs with dynamic theme updates when switching `mode`.