### PR TITLE
[Redesign] Custom config feature flag for in-progress widget

### DIFF
--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -18,6 +18,9 @@ export type UiConfig = {
   previewMode?: boolean; // Disables making transfers
 
   getHelpUrl?: string;
+
+  // Shows in-progress widgets
+  showInProgressWidget?: boolean;
 };
 
 export interface DefaultInputs {
@@ -66,5 +69,6 @@ export function createUiConfig(customConfig: Partial<UiConfig>): UiConfig {
       import.meta.env.REACT_APP_WALLET_CONNECT_PROJECT_ID,
     showHamburgerMenu: customConfig?.showHamburgerMenu ?? false,
     previewMode: !!customConfig?.previewMode,
+    showInProgressWidget: !!customConfig?.showInProgressWidget,
   };
 }

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -458,7 +458,7 @@ const Bridge = () => {
   return (
     <div className={joinClass([classes.bridgeContent, classes.spacer])}>
       {header}
-      <TxHistoryWidget />
+      {config.ui.showInProgressWidget && <TxHistoryWidget />}
       {bridgeHeader}
       {sourceAssetPicker}
       {destAssetPicker}


### PR DESCRIPTION
Adds the prop showInProgressWidget under UI custom props to hide in-progress widgets when not set to true.

```
{
  network: 'mainnet',
  ui: { showInProgressWidget: true },
  ...
}
```