### PR TITLE
Always use a transparent background

### DIFF
--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -308,6 +308,8 @@ export const getDesignTokens = (customTheme: WormholeConnectPartialTheme) => {
     customTheme,
   ) as WormholeConnectTheme;
 
+  theme.background.default = 'transparent';
+
   return createTheme({
     components: {
       MuiPaper: {


### PR DESCRIPTION
This is almost always desired behavior. If an integrator wants to put Connect into an opaque box of a unique color, they can easily do that by styling its parent.

![image](https://github.com/user-attachments/assets/a5fddafa-4523-4e73-ae48-769026e142de)
