### PR TITLE
[Redesign] Prevent zoom on input fields for mobile

### DIFF
--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -75,8 +75,8 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Testnet vite",
-    "start:mainnet": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Mainnet vite",
+    "start": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Testnet vite --host",
+    "start:mainnet": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Mainnet vite --host",
     "build": "npm run build:lib; npm run build:hosted; npm run build:netlify",
     "build:lib": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
     "build:hosted": "VITE_BUILD_HOSTED=1 NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/SearchInput.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/SearchableList/SearchInput.tsx
@@ -39,7 +39,7 @@ export default function SearchInput(props: SearchInputProps) {
       fullWidth
       inputProps={{
         style: {
-          fontSize: 14,
+          fontSize: 16,
           height: 22,
           lineHeight: 22,
         },


### PR DESCRIPTION
It seems Safari and Chrome in mobile devices (tested for both iOS and Android) zooms in on an input field that has font size 15px or less. That's why bumping the Asset Picker input font size from 14 to 16 fixes the issue.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2737