### PR TITLE
Simpler custom theme type

### DIFF
--- a/wormhole-connect/src/WormholeConnect.tsx
+++ b/wormhole-connect/src/WormholeConnect.tsx
@@ -8,12 +8,12 @@ import AppRouter from './AppRouter';
 import { generateTheme } from './theme';
 import ErrorBoundary from './components/ErrorBoundary';
 import { WormholeConnectConfig } from './config/types';
-import { WormholeConnectCustomTheme } from 'theme';
+import { WormholeConnectTheme } from 'theme';
 import { RouteProvider } from './contexts/RouteContext';
 
 export interface WormholeConnectProps {
   // theme can be updated at any time to change the colors of Connect
-  theme?: WormholeConnectCustomTheme;
+  theme?: WormholeConnectTheme;
   // config is only used once, when Connect first mounts, to initialize the global config
   config?: WormholeConnectConfig;
 }

--- a/wormhole-connect/src/WormholeConnect.tsx
+++ b/wormhole-connect/src/WormholeConnect.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import ScopedCssBaseline from '@mui/material/ScopedCssBaseline';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material/styles';
 import './App.css';
 import { store } from './store';
 import AppRouter from './AppRouter';
-import { getDesignTokens, dark } from './theme';
+import { generateTheme } from './theme';
 import ErrorBoundary from './components/ErrorBoundary';
 import { WormholeConnectConfig } from './config/types';
-import { WormholeConnectPartialTheme } from 'theme';
+import { WormholeConnectCustomTheme } from 'theme';
 import { RouteProvider } from './contexts/RouteContext';
 
 export interface WormholeConnectProps {
   // theme can be updated at any time to change the colors of Connect
-  theme?: WormholeConnectPartialTheme;
+  theme?: WormholeConnectCustomTheme;
   // config is only used once, when Connect first mounts, to initialize the global config
   config?: WormholeConnectConfig;
 }
@@ -24,7 +24,7 @@ export default function WormholeConnect({
 }: WormholeConnectProps) {
   // Handle theme changes at any time
   const muiTheme = React.useMemo(
-    () => createTheme(getDesignTokens(theme ?? dark)),
+    () => generateTheme(theme ?? { mode: 'dark' }),
     [theme],
   );
 

--- a/wormhole-connect/src/hosted.ts
+++ b/wormhole-connect/src/hosted.ts
@@ -1,11 +1,11 @@
 // This file exports a utility function used to add the hosted version of Connect to a webpage
 import { CONNECT_VERSION } from 'config/constants';
 import { WormholeConnectConfig } from 'config/types';
-import { WormholeConnectCustomTheme } from 'theme';
+import { WormholeConnectTheme } from 'theme';
 
 export interface HostedParameters {
   config?: WormholeConnectConfig;
-  theme?: WormholeConnectCustomTheme;
+  theme?: WormholeConnectTheme;
   version?: string;
   cdnBaseUrl?: string;
 }

--- a/wormhole-connect/src/hosted.ts
+++ b/wormhole-connect/src/hosted.ts
@@ -1,11 +1,11 @@
 // This file exports a utility function used to add the hosted version of Connect to a webpage
 import { CONNECT_VERSION } from 'config/constants';
 import { WormholeConnectConfig } from 'config/types';
-import { WormholeConnectPartialTheme } from 'theme';
+import { WormholeConnectCustomTheme } from 'theme';
 
 export interface HostedParameters {
   config?: WormholeConnectConfig;
-  theme?: WormholeConnectPartialTheme;
+  theme?: WormholeConnectCustomTheme;
   version?: string;
   cdnBaseUrl?: string;
 }

--- a/wormhole-connect/src/index.ts
+++ b/wormhole-connect/src/index.ts
@@ -1,9 +1,6 @@
 import WormholeConnect from './WormholeConnect';
 
-import type {
-  WormholeConnectPartialTheme,
-  WormholeConnectTheme,
-} from './theme';
+import type { WormholeConnectCustomTheme, WormholeConnectTheme } from './theme';
 
 import { dark, light } from './theme';
 
@@ -49,7 +46,7 @@ export {
   // Types
   WormholeConnectConfig,
   Chain,
-  WormholeConnectPartialTheme,
+  WormholeConnectCustomTheme,
   WormholeConnectTheme,
   dark,
   light,

--- a/wormhole-connect/src/index.ts
+++ b/wormhole-connect/src/index.ts
@@ -1,6 +1,6 @@
 import WormholeConnect from './WormholeConnect';
 
-import type { WormholeConnectCustomTheme, WormholeConnectTheme } from './theme';
+import type { WormholeConnectTheme } from './theme';
 
 import { dark, light } from './theme';
 
@@ -46,7 +46,6 @@ export {
   // Types
   WormholeConnectConfig,
   Chain,
-  WormholeConnectCustomTheme,
   WormholeConnectTheme,
   dark,
   light,

--- a/wormhole-connect/src/index.ts
+++ b/wormhole-connect/src/index.ts
@@ -2,8 +2,6 @@ import WormholeConnect from './WormholeConnect';
 
 import type { WormholeConnectTheme } from './theme';
 
-import { dark, light } from './theme';
-
 import MAINNET from './config/mainnet';
 import TESTNET from './config/testnet';
 import { buildConfig } from './config';
@@ -47,8 +45,6 @@ export {
   WormholeConnectConfig,
   Chain,
   WormholeConnectTheme,
-  dark,
-  light,
 
   // Routes
   DEFAULT_ROUTES,

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -4,7 +4,7 @@ import green from '@mui/material/colors/green';
 import orange from '@mui/material/colors/orange';
 import purple from '@mui/material/colors/purple';
 import red from '@mui/material/colors/red';
-import { PaletteMode } from '@mui/material';
+import { PaletteMode, PaletteColorOptions, Theme } from '@mui/material';
 import { OPACITY } from './utils/style';
 
 export type PaletteColor = {
@@ -26,24 +26,45 @@ export type PaletteColor = {
   A700?: string;
 };
 
-export type WormholeConnectPartialTheme = {
-  mode?: PaletteMode;
-  primary?: PaletteColor;
-  secondary?: PaletteColor;
-  divider?: string;
-  background?: {
+export type WormholeConnectCustomTheme = {
+  mode: PaletteMode;
+  // Color of input fields, like asset picker and dropdowns
+  input?: string;
+  // Primary brand color
+  primary?: string;
+  // Secondary brand color
+  secondary?: string;
+  // Primary text color
+  text?: string;
+  // Secondary text color
+  textSecondary?: string;
+  // Error message color
+  error?: string;
+  success?: string;
+  badge?: string;
+  font?: string;
+};
+
+type Color = PaletteColor | PaletteColorOptions;
+
+export type WormholeConnectTheme = {
+  mode: PaletteMode;
+  primary: Color;
+  secondary: Color;
+  divider: string;
+  background: {
     default: string;
     badge: string;
   };
-  text?: {
+  text: {
     primary: string;
     secondary: string;
   };
-  error?: PaletteColor;
-  info?: PaletteColor;
-  success?: PaletteColor;
-  warning?: PaletteColor;
-  button?: {
+  error: Color;
+  info: Color;
+  success: Color;
+  warning: Color;
+  button: {
     primary: string;
     primaryText: string;
     disabled: string;
@@ -52,28 +73,26 @@ export type WormholeConnectPartialTheme = {
     actionText: string;
     hover: string;
   };
-  options?: {
+  options: {
     hover: string;
     select: string;
   };
-  card?: {
+  card: {
     background: string;
     elevation: string;
     secondary: string;
   };
-  popover?: {
+  popover: {
     background: string;
     elevation: string;
     secondary: string;
   };
-  modal?: {
+  modal: {
     background: string;
   };
-  font?: string;
-  logo?: string;
+  font: string;
+  logo: string;
 };
-
-export type WormholeConnectTheme = Required<WormholeConnectPartialTheme>;
 
 export const light: WormholeConnectTheme = {
   mode: 'light',
@@ -300,13 +319,49 @@ export const dark: WormholeConnectTheme = {
   logo: '#ffffff',
 };
 
-export const getDesignTokens = (customTheme: WormholeConnectPartialTheme) => {
-  const baseTheme = customTheme?.mode === 'light' ? light : dark;
-  const theme = Object.assign(
-    {},
-    baseTheme,
-    customTheme,
-  ) as WormholeConnectTheme;
+export const generateTheme = (
+  customTheme: WormholeConnectCustomTheme,
+): Theme => {
+  const baseTheme = customTheme.mode === 'light' ? light : dark;
+  const theme = Object.assign({}, baseTheme) as WormholeConnectTheme;
+
+  // Override built-in theme with whichever custom values we've been provided
+  if (customTheme) {
+    if (customTheme.input) {
+      theme.modal = {
+        background: customTheme.input,
+      };
+    }
+    if (customTheme.primary) {
+      theme.primary = {
+        main: customTheme.primary,
+      };
+    }
+    if (customTheme.secondary) {
+      theme.secondary = {
+        main: customTheme.secondary,
+      };
+    }
+    if (customTheme.text) {
+      theme.text.primary = customTheme.text;
+    }
+    if (customTheme.textSecondary) {
+      theme.text.secondary = customTheme.textSecondary;
+    }
+    if (customTheme.error) {
+      theme.error = {
+        main: customTheme.error,
+      };
+    }
+    if (customTheme.success) {
+      theme.success = {
+        main: customTheme.success,
+      };
+    }
+    if (customTheme.badge) {
+      theme.background.badge = customTheme.badge;
+    }
+  }
 
   theme.background.default = 'transparent';
 

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -365,8 +365,6 @@ export const generateTheme = (customTheme: WormholeConnectTheme): Theme => {
     }
   }
 
-  theme.background.default = 'transparent';
-
   return createTheme({
     components: {
       MuiPaper: {

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -26,7 +26,7 @@ export type PaletteColor = {
   A700?: string;
 };
 
-export type WormholeConnectCustomTheme = {
+export type WormholeConnectTheme = {
   mode: PaletteMode;
   // Color of input fields, like asset picker and dropdowns
   input?: string;
@@ -47,7 +47,7 @@ export type WormholeConnectCustomTheme = {
 
 type Color = PaletteColor | PaletteColorOptions;
 
-export type WormholeConnectTheme = {
+export type InternalTheme = {
   mode: PaletteMode;
   primary: Color;
   secondary: Color;
@@ -94,7 +94,7 @@ export type WormholeConnectTheme = {
   logo: string;
 };
 
-export const light: WormholeConnectTheme = {
+export const light: InternalTheme = {
   mode: 'light',
   primary: {
     50: '#161718',
@@ -172,7 +172,7 @@ export const light: WormholeConnectTheme = {
 };
 
 // wormhole styled theme
-export const dark: WormholeConnectTheme = {
+export const dark: InternalTheme = {
   mode: 'dark',
   primary: {
     25: '#FCFAFF',
@@ -319,11 +319,9 @@ export const dark: WormholeConnectTheme = {
   logo: '#ffffff',
 };
 
-export const generateTheme = (
-  customTheme: WormholeConnectCustomTheme,
-): Theme => {
+export const generateTheme = (customTheme: WormholeConnectTheme): Theme => {
   const baseTheme = customTheme.mode === 'light' ? light : dark;
-  const theme = Object.assign({}, baseTheme) as WormholeConnectTheme;
+  const theme = Object.assign({}, baseTheme) as InternalTheme;
 
   // Override built-in theme with whichever custom values we've been provided
   if (customTheme) {

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -27,6 +27,7 @@ export type PaletteColor = {
 };
 
 export type WormholeConnectTheme = {
+  // "dark" or "light"
   mode: PaletteMode;
   // Color of input fields, like asset picker and dropdowns
   input?: string;

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -41,8 +41,11 @@ export type WormholeConnectTheme = {
   textSecondary?: string;
   // Error message color
   error?: string;
+  // Success message color
   success?: string;
+  // Background color for badges in asset picker
   badge?: string;
+  // Font family
   font?: string;
 };
 
@@ -116,7 +119,7 @@ export const light: InternalTheme = {
   secondary: grey,
   divider: '#a0a2a9',
   background: {
-    default: '#E5E8F2',
+    default: 'transparent',
     badge: '#E5E8F2',
   },
   text: {
@@ -213,7 +216,7 @@ export const dark: InternalTheme = {
   },
   divider: '#ffffff' + OPACITY[20],
   background: {
-    default: '#010101',
+    default: 'transparent',
     badge: '#010101',
   },
   text: {


### PR DESCRIPTION
This introduces a new type `WormholeConnectTheme` which is a more integrator-friendly way of creating custom themes. It allows integrators to provide a simple mapping of whichever colors they want to modify in our default themes, and uses MUI's color derivation to do the rest.

```ts
export type WormholeConnectTheme = {
  // "dark" or "light"
  mode: PaletteMode;
  // Color of input fields, like asset picker and dropdowns
  input?: string;
  // Primary brand color
  primary?: string;
  // Secondary brand color
  secondary?: string;
  // Primary text color
  text?: string;
  // Secondary text color
  textSecondary?: string;
  // Error message color
  error?: string;
  // Success message color
  success?: string;
  // Background color for badges in asset picker
  badge?: string;
  // Font family
  font?: string;
};


```

This mirrors our approach to configs: there is an external-facing `WormholeConnectConfig` type for integrators to provide, and an `InternalConfig` type that we create from that and use for all of the code internally.

|        | External type for integrators | Internal Type  |
|--------|-------------------------------|----------------|
| Config | `WormholeConnectConfig`         | `InternalConfig` |
| Theme  | `WormholeConnectTheme`          | `InternalTheme`  |