### PR TITLE
[Redesign] Fix the cursor for selected route

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -377,15 +377,16 @@ const SingleRoute = (props: Props) => {
   // 1- If no action handler provided, fall back to default
   // 2- Otherwise there is an action handler, "pointer"
   const cursor = useMemo(() => {
-    if (typeof props.onSelect !== 'function') {
-      return 'auto';
+    if (props.isSelected || typeof props.onSelect !== 'function') {
+      return 'default';
     }
+
     if (props.error) {
       return 'not-allowed';
     }
 
     return 'pointer';
-  }, [props.onSelect, props.error]);
+  }, [props.error, props.isSelected, props.onSelect]);
 
   if (isEmptyObject(props.route)) {
     return <></>;
@@ -419,7 +420,6 @@ const SingleRoute = (props: Props) => {
           borderColor: props.isSelected
             ? theme.palette.primary.main
             : 'transparent',
-          cursor,
           opacity: 1,
         }}
       >
@@ -428,6 +428,7 @@ const SingleRoute = (props: Props) => {
             typeof props.onSelect !== 'function' || props.error !== undefined
           }
           disableTouchRipple
+          sx={{ cursor }}
           onClick={() => {
             props.onSelect?.(props.route.name);
           }}


### PR DESCRIPTION
Fixes the cursor for selected item in Routes.

Please see the loom for details:
https://www.loom.com/share/aef89926cb224f66a623894717eb8065?sid=995d850a-e0d6-4ccc-8762-9328813f6b4b

Fixes https://www.notion.so/wormholelabs/BUG-Automatic-route-button-appears-clickable-but-it-isn-t-ccc46b690d9c473cbaab93279117b63e?pvs=4