### PR TITLE
Pet peeve: handle "." as a numeric input

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -42,7 +42,10 @@ const DebouncedTextField = memo(
 
     const onInnerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
       (e) => {
-        const numValue = Number(e.target.value);
+        let value = e.target.value;
+        if (value === '.') value = '0.';
+
+        const numValue = Number(value);
 
         if (isNaN(numValue) || numValue < 0) {
           // allows all but negative numbers


### PR DESCRIPTION
This change lets me type ".01" instead of having to type "0.01" in the amount field.