### PR TITLE
UI config fixes

### DIFF
--- a/wormhole-connect/src/components/FooterNavBar.tsx
+++ b/wormhole-connect/src/components/FooterNavBar.tsx
@@ -59,7 +59,7 @@ export default function FooterNavBar() {
     [dispatch],
   );
 
-  const entries = config.ui.menu.reduce(
+  const entries = (config.ui?.menu ?? []).reduce(
     itemAppender,
     defaultMenuItems(navigate),
   );

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -53,22 +53,11 @@ export interface MenuEntry {
   order?: number;
 }
 
-export function createUiConfig(customConfig: Partial<UiConfig>): UiConfig {
+export function createUiConfig(customConfig: UiConfig): UiConfig {
   return {
-    title: customConfig?.title ?? 'Wormhole Connect',
-    cta: customConfig?.cta,
-    explorer: customConfig?.explorer,
-    defaultInputs: customConfig?.defaultInputs,
-    pageHeader: customConfig?.pageHeader,
-    menu: customConfig?.menu ?? [],
-    getHelpUrl: customConfig?.getHelpUrl,
-    searchTx: customConfig?.searchTx,
-    partnerLogo: customConfig?.partnerLogo,
+    ...customConfig,
     walletConnectProjectId:
       customConfig?.walletConnectProjectId ??
       import.meta.env.REACT_APP_WALLET_CONNECT_PROJECT_ID,
-    showHamburgerMenu: customConfig?.showHamburgerMenu ?? false,
-    previewMode: !!customConfig?.previewMode,
-    showInProgressWidget: !!customConfig?.showInProgressWidget,
   };
 }

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -2,7 +2,7 @@ import { Chain } from '@wormhole-foundation/sdk';
 import { Alignment } from 'components/Header';
 
 export type UiConfig = {
-  title: string;
+  title?: string;
   cta?: {
     text: string;
     link: string;
@@ -10,11 +10,11 @@ export type UiConfig = {
   explorer?: ExplorerConfig;
   defaultInputs?: DefaultInputs;
   pageHeader?: string | PageHeader;
-  menu: MenuEntry[];
+  menu?: MenuEntry[];
   searchTx?: SearchTxConfig;
   partnerLogo?: string;
   walletConnectProjectId?: string;
-  showHamburgerMenu: boolean;
+  showHamburgerMenu?: boolean;
   previewMode?: boolean; // Disables making transfers
 
   getHelpUrl?: string;

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -120,6 +120,11 @@ const ReviewTransaction = (props: Props) => {
   const send = async () => {
     setSendError(undefined);
 
+    if (config.ui.previewMode) {
+      setSendError('Connect is in preview mode');
+      return;
+    }
+
     // Pre-check of required values
     if (
       !sourceChain ||

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -365,7 +365,11 @@ const Bridge = () => {
     const isTxHistoryDisabled = !sendingWallet?.address;
     return (
       <div className={classes.bridgeHeader}>
-        <Header align="left" text={config.ui.title} size={18} />
+        <Header
+          align="left"
+          text={config.ui.title ?? 'Wormhole Connect'}
+          size={18}
+        />
         <Tooltip
           title={isTxHistoryDisabled ? 'No connected wallets found' : ''}
         >


### PR DESCRIPTION
- re-enables the `ui.previewMode` config setting, which essentially bricks Connect. This was present in the v1 UI code
- makes all properties inside `config.ui` optional for the integrator (making these mandatory was an oversight)

<img width="560" alt="image" src="https://github.com/user-attachments/assets/28e9e0ee-b60f-4952-a1de-7c6c2023fdef">
