### PR TITLE
pre select destination and preferred route

### DIFF
--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -29,6 +29,7 @@ export interface DefaultInputs {
   tokenKey?: string;
   toTokenKey?: string;
   requiredChain?: Chain;
+  preferredRouteName?: string;
 }
 
 export type ExplorerConfig = {

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -27,6 +27,7 @@ export interface DefaultInputs {
   fromChain?: Chain;
   toChain?: Chain;
   tokenKey?: string;
+  toTokenKey?: string;
   requiredChain?: Chain;
 }
 

--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -11,6 +11,7 @@ import { Chain } from '@wormhole-foundation/sdk';
 type Props = {
   sourceChain: Chain | undefined;
   sourceToken: string;
+  destToken: string;
   destChain: Chain | undefined;
   route?: string;
 };
@@ -20,7 +21,7 @@ type ReturnProps = {
 };
 
 const useComputeDestinationTokens = (props: Props): ReturnProps => {
-  const { sourceChain, destChain, sourceToken } = props;
+  const { sourceChain, destChain, sourceToken, destToken } = props;
 
   const dispatch = useDispatch();
 
@@ -54,7 +55,14 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
       // Done fetching and setting all supported tokens
       setIsFetching(false);
 
-      if (destChain && supported.length === 1) {
+      if (!canceled && destChain && destToken !== '') {
+        // check if the pre selected destToken is supported
+        const isTokenSupported = supported.some((t) => t.key == destToken);
+        if (!isTokenSupported) {
+          // if not, clear the destToken
+          dispatch(setDestToken(''));
+        }
+      } else if (destChain && supported.length === 1) {
         if (!canceled) {
           dispatch(setDestToken(supported[0].key));
         }

--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -32,7 +32,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
       return;
     }
 
-    let canceled = false;
+    let active = true;
 
     const computeDestTokens = async () => {
       let supported: Array<TokenConfig> = [];
@@ -55,7 +55,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
       // Done fetching and setting all supported tokens
       setIsFetching(false);
 
-      if (!canceled && destChain && destToken !== '') {
+      if (active && destChain && destToken !== '') {
         // check if the pre selected destToken is supported
         const isTokenSupported = supported.some((t) => t.key == destToken);
         if (!isTokenSupported) {
@@ -63,7 +63,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
           dispatch(setDestToken(''));
         }
       } else if (destChain && supported.length === 1) {
-        if (!canceled) {
+        if (active) {
           dispatch(setDestToken(supported[0].key));
         }
       }
@@ -82,7 +82,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
             t.nativeChain === t.tokenId?.chain &&
             t.nativeChain === destChain,
         )?.key;
-        if (!canceled && key) {
+        if (active && key) {
           dispatch(setDestToken(key));
         }
       }
@@ -91,7 +91,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
     computeDestTokens();
 
     return () => {
-      canceled = true;
+      active = false;
     };
   }, [sourceToken, sourceChain, destChain, dispatch]);
 

--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -11,7 +11,6 @@ import { Chain } from '@wormhole-foundation/sdk';
 type Props = {
   sourceChain: Chain | undefined;
   sourceToken: string;
-  destToken: string;
   destChain: Chain | undefined;
   route?: string;
 };
@@ -21,7 +20,7 @@ type ReturnProps = {
 };
 
 const useComputeDestinationTokens = (props: Props): ReturnProps => {
-  const { sourceChain, destChain, sourceToken, destToken } = props;
+  const { sourceChain, destChain, sourceToken } = props;
 
   const dispatch = useDispatch();
 
@@ -55,14 +54,7 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
       // Done fetching and setting all supported tokens
       setIsFetching(false);
 
-      if (active && destChain && destToken !== '') {
-        // check if the pre selected destToken is supported
-        const isTokenSupported = supported.some((t) => t.key == destToken);
-        if (!isTokenSupported) {
-          // if not, clear the destToken
-          dispatch(setDestToken(''));
-        }
-      } else if (destChain && supported.length === 1) {
+      if (destChain && supported.length === 1) {
         if (active) {
           dispatch(setDestToken(supported[0].key));
         }

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -25,8 +25,15 @@ type HookReturn = {
 };
 
 export const useSortedRoutesWithQuotes = (): HookReturn => {
-  const { amount, routeStates, fromChain, token, toChain, destToken } =
-    useSelector((state: RootState) => state.transferInput);
+  const {
+    amount,
+    routeStates,
+    fromChain,
+    token,
+    toChain,
+    destToken,
+    preferredRouteName,
+  } = useSelector((state: RootState) => state.transferInput);
   const { toNativeToken } = useSelector((state: RootState) => state.relay);
 
   const supportedRoutes = useMemo(
@@ -78,6 +85,16 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
     return [...routesWithQuotes].sort((routeA, routeB) => {
       const routeConfigA = config.routes.get(routeA.route.name);
       const routeConfigB = config.routes.get(routeB.route.name);
+
+      // Prioritize preferred route to avoid flickering the UI
+      // when the preferred route gets autoselected
+      if (preferredRouteName) {
+        if (routeA.route.name === preferredRouteName) {
+          return -1;
+        } else if (routeB.route.name === preferredRouteName) {
+          return 1;
+        }
+      }
 
       // 1. Prioritize automatic routes
       if (routeConfigA.AUTOMATIC_DEPOSIT && !routeConfigB.AUTOMATIC_DEPOSIT) {

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -124,6 +124,7 @@ export interface TransferInputState {
   amount: string;
   receiveAmount: DataWrapper<string>;
   route?: string;
+  preferredRouteName?: string | undefined;
   balances: WalletBalances;
   foreignAsset: string;
   associatedTokenAddress: string;
@@ -160,6 +161,7 @@ function getInitialState(): TransferInputState {
     destToken: config.ui.defaultInputs?.tokenKey || '',
     amount: '',
     receiveAmount: getEmptyDataWrapper(),
+    preferredRouteName: undefined,
     route: undefined,
     balances: {},
     foreignAsset: '',

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -161,7 +161,7 @@ function getInitialState(): TransferInputState {
     destToken: config.ui.defaultInputs?.toTokenKey || '',
     amount: '',
     receiveAmount: getEmptyDataWrapper(),
-    preferredRouteName: undefined,
+    preferredRouteName: config.ui.defaultInputs?.preferredRouteName,
     route: undefined,
     balances: {},
     foreignAsset: '',

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -158,7 +158,7 @@ function getInitialState(): TransferInputState {
     fromChain: config.ui.defaultInputs?.fromChain || undefined,
     toChain: config.ui.defaultInputs?.toChain || undefined,
     token: config.ui.defaultInputs?.tokenKey || '',
-    destToken: config.ui.defaultInputs?.tokenKey || '',
+    destToken: config.ui.defaultInputs?.toTokenKey || '',
     amount: '',
     receiveAmount: getEmptyDataWrapper(),
     preferredRouteName: undefined,

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -157,7 +157,7 @@ function getInitialState(): TransferInputState {
     fromChain: config.ui.defaultInputs?.fromChain || undefined,
     toChain: config.ui.defaultInputs?.toChain || undefined,
     token: config.ui.defaultInputs?.tokenKey || '',
-    destToken: '',
+    destToken: config.ui.defaultInputs?.tokenKey || '',
     amount: '',
     receiveAmount: getEmptyDataWrapper(),
     route: undefined,

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -153,7 +153,6 @@ const Bridge = () => {
       sourceChain,
       destChain,
       sourceToken,
-      destToken,
       route: selectedRoute,
     });
 
@@ -171,7 +170,7 @@ const Bridge = () => {
         (route) => route.route.name === preferredRouteName,
       );
       const autoselectedRoute =
-        route ?? validRoutes[0].route.name ?? preferredRoute?.route.name;
+        route ?? preferredRoute?.route.name ?? validRoutes[0].route.name;
       const isSelectedRouteValid =
         validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -121,6 +121,7 @@ const Bridge = () => {
     token: sourceToken,
     destToken,
     route,
+    preferredRouteName,
     routeStates,
     supportedDestTokens: supportedDestTokensBase,
     supportedSourceTokens,
@@ -166,7 +167,11 @@ const Bridge = () => {
     if (validRoutes.length === 0) {
       setSelectedRoute('');
     } else {
-      const autoselectedRoute = route || validRoutes[0].route.name;
+      const preferredRoute = validRoutes.find(
+        (route) => route.route.name === preferredRouteName,
+      );
+      const autoselectedRoute =
+        preferredRoute?.route.name ?? route ?? validRoutes[0].route.name;
       const isSelectedRouteValid =
         validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -152,6 +152,7 @@ const Bridge = () => {
       sourceChain,
       destChain,
       sourceToken,
+      destToken,
       route: selectedRoute,
     });
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -171,7 +171,7 @@ const Bridge = () => {
         (route) => route.route.name === preferredRouteName,
       );
       const autoselectedRoute =
-        preferredRoute?.route.name ?? route ?? validRoutes[0].route.name;
+        route ?? validRoutes[0].route.name ?? preferredRoute?.route.name;
       const isSelectedRouteValid =
         validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
 


### PR DESCRIPTION
Added `toTokenKey` and `preferredRouteName` params to `ui` object config to allow integrators to pre-select target token and mark a configured route as preferred

If the toTokenKey does not exist or is invalid, it will fail silent
If the preferred route does not exist or is invalid, it will fail silent

Sample config piece

```json
"defaultInputs": {
  "fromChain": "Ethereum",
  "toChain": "Arbitrum",
  "tokenKey": "USDCeth",
  "toTokenKey": "USDCarbitrum",
  "preferredRouteName": "ManualCCTP"
}
```

https://github.com/user-attachments/assets/9fb444f8-b4da-4868-9435-ec8f34b38634

