### PR TITLE
Hide terrible quotes; warn about mediocre ones

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -58,7 +58,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   const numAmount = Number.parseFloat(amount);
 
   // Don't show errors when no amount is set or it's loading
-  if (!amount || !numAmount || props.isLoading || props.disabled) {
+  if (!amount || !numAmount || props.disabled) {
     return {};
   }
 

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -124,7 +124,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
   // Filter out quotes that would result in a large instant loss
   // (Transfers >=$1000 with >=10% value loss)
   for (const name in quotesMap) {
-    const quote = quotesMap[name]!;
+    const quote = quotesMap[name];
     if (quote !== undefined && quote.success) {
       const usdValueOut = calculateUSDPriceRaw(
         amount.whole(quote.destinationToken.amount),

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -121,9 +121,8 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     [routes.join(), quotes],
   );
 
-  // Here we filter out bad quotes (price protection)
-  // For transfers >=$1000, we hide quotes with >=10% value loss
-  // For <=$1000, we hide quotes with >=$100 loss
+  // Filter out quotes that would result in a large instant loss
+  // (Transfers >=$1000 with >=10% value loss)
   for (const name in quotesMap) {
     const quote = quotesMap[name]!;
     if (quote !== undefined && quote.success) {
@@ -136,7 +135,6 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       if (usdValue && usdValueOut) {
         const valueRatio = usdValueOut / usdValue;
         if (usdValue >= 1000 && valueRatio <= 0.9) {
-          // Don't offer quotes where the user would get 90% or less of the input amount
           delete quotesMap[name];
         }
       }

--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -289,17 +289,12 @@ export const getTokenPrice = (
   return undefined;
 };
 
-export const getUSDFormat = (
-  price: number | undefined,
-  noParanthesis?: boolean | undefined,
-): string => {
+export const getUSDFormat = (price: number | undefined): string => {
   if (typeof price !== 'undefined') {
-    return `${noParanthesis ? '' : '('}${
-      price > 0 ? '~' : ''
-    }${Intl.NumberFormat('en-EN', {
+    return `${price > 0 ? '~' : ''}${Intl.NumberFormat('en-EN', {
       style: 'currency',
       currency: 'USD',
-    }).format(price)}${noParanthesis ? '' : ')'}`;
+    }).format(price)}`;
   }
   return '';
 };
@@ -328,12 +323,8 @@ export const calculateUSDPrice = (
   amount?: number | string,
   tokenPrices?: TokenPrices | null,
   token?: TokenConfig,
-  noParanthesis?: boolean | undefined,
 ): string => {
-  return getUSDFormat(
-    calculateUSDPriceRaw(amount, tokenPrices, token),
-    noParanthesis,
-  );
+  return getUSDFormat(calculateUSDPriceRaw(amount, tokenPrices, token));
 };
 
 /**

--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -290,13 +290,21 @@ export const getTokenPrice = (
 };
 
 export const getUSDFormat = (price: number | undefined): string => {
-  if (typeof price !== 'undefined') {
-    return `${price > 0 ? '~' : ''}${Intl.NumberFormat('en-EN', {
+  if (typeof price === 'undefined') {
+    return '';
+  }
+
+  if (price === 0) {
+    return '$0';
+  }
+
+  return (
+    '~' +
+    Intl.NumberFormat('en-EN', {
       style: 'currency',
       currency: 'USD',
-    }).format(price)}`;
-  }
-  return '';
+    }).format(price)
+  );
 };
 
 export const calculateUSDPriceRaw = (

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -393,17 +393,19 @@ const SingleRoute = (props: Props) => {
       return null;
     }
 
-    const receiveAmountPrice = calculateUSDPrice(
+    let usdValue = calculateUSDPrice(
       receiveAmount,
       tokenPrices.data,
       destTokenConfig,
     );
 
+    if (usdValue !== '') usdValue = `(${usdValue})`;
+
     return (
       <Typography
         fontSize={14}
         color={theme.palette.text.secondary}
-      >{`(${receiveAmountPrice}) ${providerText}`}</Typography>
+      >{`${usdValue} ${providerText}`}</Typography>
     );
   }, [destTokenConfig, providerText, receiveAmount, tokenPrices]);
 

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -17,6 +17,8 @@ import TokenIcon from 'icons/TokenIcons';
 import {
   isEmptyObject,
   calculateUSDPrice,
+  calculateUSDPriceRaw,
+  getUSDFormat,
   millisToHumanString,
   formatDuration,
 } from 'utils';
@@ -28,6 +30,8 @@ import { toFixedDecimals } from 'utils/balance';
 import { TokenConfig } from 'config/types';
 import FastestRoute from 'icons/FastestRoute';
 import CheapestRoute from 'icons/CheapestRoute';
+
+const HIGH_FEE_THRESHOLD = 20; // dollhairs
 
 const useStyles = makeStyles()((theme: any) => ({
   container: {
@@ -97,46 +101,53 @@ const SingleRoute = (props: Props) => {
     [destToken],
   );
 
+  const [feePrice, isHighFee, feeTokenConfig]: [
+    number | undefined,
+    boolean,
+    TokenConfig | undefined,
+  ] = useMemo(() => {
+    if (!quote?.relayFee) {
+      return [undefined, false, undefined];
+    }
+
+    const relayFee = amount.whole(quote.relayFee.amount);
+    const feeToken = quote.relayFee.token;
+    const feeTokenConfig = config.sdkConverter.findTokenConfigV1(
+      feeToken,
+      Object.values(config.tokens),
+    );
+    const feePrice = calculateUSDPriceRaw(
+      relayFee,
+      tokenPrices.data,
+      feeTokenConfig,
+    );
+
+    if (feePrice === undefined) {
+      return [undefined, false, undefined];
+    }
+
+    return [feePrice, feePrice > HIGH_FEE_THRESHOLD, feeTokenConfig];
+  }, [quote]);
+
   const relayerFee = useMemo(() => {
     if (!routeConfig.AUTOMATIC_DEPOSIT) {
       return <>You pay gas on {destChain}</>;
     }
 
-    if (!quote?.relayFee) {
+    if (!quote || !feePrice || !feeTokenConfig) {
       return <></>;
     }
 
-    const relayFee = amount.whole(quote.relayFee.amount);
-    const feeToken = quote.relayFee.token;
+    const feePriceFormatted = getUSDFormat(feePrice);
 
-    const feeTokenConfig = config.sdkConverter.findTokenConfigV1(
-      feeToken,
-      Object.values(config.tokens),
-    );
-
-    if (!feeTokenConfig) {
-      return <></>;
-    }
-
-    const feePrice = calculateUSDPrice(
-      relayFee,
-      tokenPrices.data,
-      feeTokenConfig,
-      true,
-    );
-
-    if (!feePrice) {
-      return <></>;
-    }
-
-    let feeValue = `${toFixedDecimals(relayFee.toString(), 4)} ${
+    let feeValue = `${toFixedDecimals(quote!.relayFee!.toString(), 4)} ${
       feeTokenConfig.symbol
-    } (${feePrice})`;
+    } (${feePriceFormatted})`;
 
     // Wesley made me do it
     // Them PMs :-/
     if (props.route.name.startsWith('MayanSwap')) {
-      feeValue = feePrice;
+      feeValue = feePriceFormatted;
     }
 
     return (
@@ -183,7 +194,7 @@ const SingleRoute = (props: Props) => {
         <Typography
           color={theme.palette.text.secondary}
           fontSize={14}
-        >{`${gasTokenAmount} ${gasTokenConfig.symbol} ${gasTokenPrice}`}</Typography>
+        >{`${gasTokenAmount} ${gasTokenConfig.symbol} (${gasTokenPrice})`}</Typography>
       </Stack>
     );
   }, [destChain, props.destinationGasDrop]);
@@ -274,7 +285,7 @@ const SingleRoute = (props: Props) => {
             <Divider flexItem sx={{ marginTop: '8px' }} />
             <Stack direction="row" alignItems="center">
               <WarningIcon htmlColor={theme.palette.warning.main} />
-              <Stack sx={{ padding: '16px' }}>
+              <Stack sx={{ padding: '16px 16px 0 16px' }}>
                 <Typography color={theme.palette.warning.main} fontSize={14}>
                   {`Your transfer to ${destChain} may be delayed due to rate limits set by ${symbol}. If your transfer is delayed, you will need to return after ${duration} to complete the transfer. Please consider this before proceeding.`}
                 </Typography>
@@ -283,6 +294,23 @@ const SingleRoute = (props: Props) => {
           </div>,
         );
       }
+    }
+
+    if (isHighFee) {
+      messages.push(
+        <div key="HighFee">
+          <Divider flexItem sx={{ marginTop: '8px' }} />
+          <Stack direction="row" alignItems="center">
+            <WarningIcon htmlColor={theme.palette.warning.main} />
+            <Stack sx={{ padding: '16px 16px 0 16px' }}>
+              <Typography color={theme.palette.warning.main} fontSize={14}>
+                Output amount is much lower than input amount. Double check
+                before proceeding.
+              </Typography>
+            </Stack>
+          </Stack>
+        </div>,
+      );
     }
 
     return messages;
@@ -345,8 +373,12 @@ const SingleRoute = (props: Props) => {
       return null;
     }
 
+    const color = isHighFee
+      ? theme.palette.warning.main
+      : theme.palette.text.primary;
+
     return (
-      <Typography fontSize={18}>
+      <Typography fontSize={18} color={color}>
         {receiveAmountTrunc} {destTokenConfig.symbol}
       </Typography>
     );
@@ -371,7 +403,7 @@ const SingleRoute = (props: Props) => {
       <Typography
         fontSize={14}
         color={theme.palette.text.secondary}
-      >{`${receiveAmountPrice} ${providerText}`}</Typography>
+      >{`(${receiveAmountPrice}) ${providerText}`}</Typography>
     );
   }, [destTokenConfig, providerText, receiveAmount, tokenPrices]);
 

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -63,13 +63,13 @@ const Routes = ({ ...props }: Props) => {
     (state: RootState) => state.wallet,
   );
 
-  const supportedRoutes = useMemo(() => {
-    if (!props.routes) {
-      return [];
-    }
+  const routes = useMemo(() => {
+    return props.routes.filter((rs) => props.quotes[rs.name] !== undefined);
+  }, [props.routes, props.quotes]);
 
-    return props.routes.filter((rs) => rs.supported);
-  }, [props.routes]);
+  const supportedRoutes = useMemo(() => {
+    return routes.filter((rs) => rs.supported);
+  }, [routes]);
 
   const walletsConnected = useMemo(
     () => !!sendingWallet.address && !!receivingWallet.address,
@@ -78,18 +78,18 @@ const Routes = ({ ...props }: Props) => {
 
   const renderRoutes = useMemo(() => {
     if (showAll) {
-      return props.routes;
+      return routes;
     }
 
-    const selectedRoute = props.routes.find(
+    const selectedRoute = routes.find(
       (route) => route.name === props.selectedRoute,
     );
 
-    return selectedRoute ? [selectedRoute] : props.routes.slice(0, 1);
-  }, [showAll, props.routes]);
+    return selectedRoute ? [selectedRoute] : routes.slice(0, 1);
+  }, [showAll, routes]);
 
   const fastestRoute = useMemo(() => {
-    return props.routes.reduce(
+    return routes.reduce(
       (fastest, route) => {
         const quote = props.quotes[route.name];
         if (!quote || !quote.success) return fastest;
@@ -109,7 +109,7 @@ const Routes = ({ ...props }: Props) => {
   }, [routes, props.quotes]);
 
   const cheapestRoute = useMemo(() => {
-    return props.routes.reduce(
+    return routes.reduce(
       (cheapest, route) => {
         const quote = props.quotes[route.name];
         const rc = config.routes.get(route.name);
@@ -127,15 +127,6 @@ const Routes = ({ ...props }: Props) => {
     );
   }, [routes, props.quotes]);
 
-  if (walletsConnected && supportedRoutes.length === 0 && Number(amount) > 0) {
-    // Errors are displayed in AmountInput
-    return;
-  }
-
-  if (supportedRoutes.length === 0 || !walletsConnected || props.hasError) {
-    return null;
-  }
-
   if (walletsConnected && !(Number(amount) > 0)) {
     return (
       <Tooltip title="Please enter the amount to view available routes">
@@ -144,6 +135,10 @@ const Routes = ({ ...props }: Props) => {
         </div>
       </Tooltip>
     );
+  }
+
+  if (props.hasError) {
+    return null;
   }
 
   return (
@@ -195,7 +190,7 @@ const Routes = ({ ...props }: Props) => {
         })
       )}
 
-      {props.routes.length > 1 && (
+      {routes.length > 1 && (
         <Link
           onClick={() => setShowAll((prev) => !prev)}
           className={classes.otherRoutesToggle}

--- a/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -75,7 +75,6 @@ const TransactionDetails = () => {
       amount,
       tokenPrices.data,
       sourceTokenConfig,
-      true,
     );
 
     const senderAddress = sender ? trimAddress(sender) : '';
@@ -127,7 +126,6 @@ const TransactionDetails = () => {
       receiveAmount,
       tokenPrices.data,
       destTokenConfig,
-      true,
     );
 
     const recipientAddress = recipient ? trimAddress(recipient) : '';
@@ -190,7 +188,6 @@ const TransactionDetails = () => {
       relayerFee.fee,
       tokenPrices.data,
       feeTokenConfig,
-      true,
     );
 
     if (!feePrice) {
@@ -234,7 +231,6 @@ const TransactionDetails = () => {
       receiveNativeAmount,
       tokenPrices.data,
       config.tokens[destChainConfig.gasToken],
-      true,
     );
 
     return (

--- a/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
@@ -84,7 +84,7 @@ const TxHistoryItem = (props: Props) => {
             {amount} {sourceTokenConfig?.symbol}
           </Typography>
           <Typography color={theme.palette.text.secondary} fontSize={14}>
-            {`${getUSDFormat(amountUsd, true)} \u2022 ${
+            {`${getUSDFormat(amountUsd)} \u2022 ${
               sourceChainConfig?.displayName
             }`}
           </Typography>
@@ -104,7 +104,6 @@ const TxHistoryItem = (props: Props) => {
       receiveAmount,
       props.tokenPrices,
       destTokenConfig,
-      true,
     );
 
     const receiveAmountDisplay = receiveAmountPrice


### PR DESCRIPTION
This PR makes two changes:

- Never show a quote that returns <=90% of the input amount, for transfers over $1000 USD
- Show a warning for any other quotes that return a USD value that's >=$20 _less_ than the input amount:

![image](https://github.com/user-attachments/assets/71713ea9-d29f-47f8-8f17-081bac7bbc30)

(Screenshot was taken with a threshold of $2 instead, for testing purposes)

I also un-broke the loading UI for `Routes`... which was broken recently by someone in a different change.

TODO:

- add % to warning