### PR TITLE
Improve Redeem view error handling & small fixes

### DIFF
--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -22,6 +22,7 @@ export type TransferEventType =
   | 'transfer.initiate'
   | 'transfer.start'
   | 'transfer.success'
+  | 'transfer.refunded'
   | 'transfer.redeem.initiate'
   | 'transfer.redeem.start'
   | 'transfer.redeem.success';
@@ -60,6 +61,7 @@ export const ERR_SOURCE_CONTRACT_PAUSED = 'source_contract_paused';
 export const ERR_DESTINATION_CONTRACT_PAUSED = 'destination_contract_paused';
 export const ERR_UNSUPPORTED_ABI_VERSION = 'unsupported_abi_version';
 export const ERR_INSUFFICIENT_GAS = 'insufficient_gas';
+export const ERR_AMOUNT_TOO_LARGE = 'amount_too_large';
 
 export const ERR_USER_REJECTED = 'user_rejected';
 export const ERR_TIMEOUT = 'user_timeout';
@@ -73,6 +75,7 @@ export type TransferErrorType =
   | typeof ERR_DESTINATION_CONTRACT_PAUSED
   | typeof ERR_UNSUPPORTED_ABI_VERSION
   | typeof ERR_INSUFFICIENT_GAS
+  | typeof ERR_AMOUNT_TOO_LARGE
   | typeof ERR_USER_REJECTED
   | typeof ERR_TIMEOUT
   | typeof ERR_UNKNOWN;

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -1,4 +1,8 @@
-import type { TransferErrorType, TransferError } from 'telemetry/types';
+import type {
+  TransferErrorType,
+  TransferError,
+  TransferDetails,
+} from 'telemetry/types';
 import {
   ERR_INSUFFICIENT_ALLOWANCE,
   //ERR_SWAP_FAILED,
@@ -6,10 +10,9 @@ import {
   ERR_TIMEOUT,
   ERR_UNKNOWN,
   ERR_USER_REJECTED,
+  ERR_AMOUNT_TOO_LARGE,
 } from 'telemetry/types';
 import { InsufficientFundsForGasError } from 'sdklegacy';
-import { Chain } from '@wormhole-foundation/sdk';
-//import { SWAP_ERROR } from 'routes/porticoBridge/consts';
 
 // TODO SDKV2
 // attempt to capture errors using regex
@@ -21,7 +24,7 @@ export const USER_REJECTED_REGEX = new RegExp(
 
 export function interpretTransferError(
   e: any,
-  chain: Chain,
+  transferDetails: TransferDetails,
 ): [string, TransferError] {
   // Fall-back values
   let uiErrorMessage = 'Error with transfer, please try again';
@@ -41,11 +44,22 @@ export function interpretTransferError(
     } else if (USER_REJECTED_REGEX.test(e?.message)) {
       uiErrorMessage = 'Transfer rejected in wallet, please try again';
       internalErrorCode = ERR_USER_REJECTED;
-      /* TODO SDKV2
-    } else if (e.message === SWAP_ERROR) {
-      uiErrorMessage = SWAP_ERROR;
-      internalErrorCode = ERR_SWAP_FAILED;
-      */
+    } else if (
+      transferDetails.route.includes('CCTP') &&
+      /burn.*exceed/i.test(e?.toString())
+    ) {
+      // As of this code being written the CCTP limit is 1,000,000 USDC in a single transfer
+      // It's possible Circle could change this in the future and we're not reading the limit
+      // from their contracts dynamically for now so we assume it's 1M and tell users that if
+      // their amount exceeded 1M
+      const assumedCircleLimit = 1_000_000;
+      const { amount } = transferDetails;
+      const limitString =
+        amount !== undefined && amount > assumedCircleLimit
+          ? ` of 1,000,000`
+          : '';
+      uiErrorMessage = `Amount exceeds Circle limit${limitString}. Please reduce transfer amount.`;
+      internalErrorCode = ERR_AMOUNT_TOO_LARGE;
     }
   }
 

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -298,7 +298,10 @@ const ReviewTransaction = (props: Props) => {
       dispatch(setAppRoute('redeem'));
       setSendError(undefined);
     } catch (e: any) {
-      const [uiError, transferError] = interpretTransferError(e, sourceChain);
+      const [uiError, transferError] = interpretTransferError(
+        e,
+        transferDetails,
+      );
 
       if (transferError.type === ERR_USER_REJECTED) {
         // User intentionally rejected in their wallet. This is not an error in the sense

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -744,6 +744,22 @@ const Redeem = () => {
       );
     }
 
+    if (!isTxAttested || isClaimInProgress) {
+      return (
+        <Button disabled variant="primary" className={classes.actionButton}>
+          <Typography
+            display="flex"
+            alignItems="center"
+            gap={1}
+            textTransform="none"
+          >
+            <CircularProgress color="secondary" size={16} />
+            Transfer in progress
+          </Typography>
+        </Button>
+      );
+    }
+
     const canBeManuallyClaimed =
       isTxDestQueued || (!isAutomaticRoute && isTxAttested);
 

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -248,7 +248,6 @@ const Redeem = () => {
         if (txData?.sendTx) {
           removeTxFromLocalStorage(txData?.sendTx);
         }
-
       }
     } else if (isTxRefunded) {
       config.triggerEvent({
@@ -273,11 +272,6 @@ const Redeem = () => {
       );
 
       setIsClaimInProgress(false);
-    } else if (isTxAttested && !isAutomaticRoute && txData?.sendTx) {
-      // If this is a manual transaction in attested state,
-      // we will mark the local storage item as readyToClaim
-      updateTxInLocalStorage(txData?.sendTx, 'isReadyToClaim', true);
-
     } else if (unhandledManualClaimError) {
       const [uiError, transferError] = interpretTransferError(
         unhandledManualClaimError,
@@ -297,6 +291,10 @@ const Redeem = () => {
       );
 
       setIsClaimInProgress(false);
+    } else if (isTxAttested && !isAutomaticRoute && txData?.sendTx) {
+      // If this is a manual transaction in attested state,
+      // we will mark the local storage item as readyToClaim
+      updateTxInLocalStorage(txData?.sendTx, 'isReadyToClaim', true);
     }
   }, [
     receipt?.state,
@@ -773,7 +771,7 @@ const Redeem = () => {
               Claim tokens to complete transfer
             </Typography>
           </Button>
-        )
+        );
       }
     }
   }, [

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -9,11 +9,11 @@ import IconButton from '@mui/material/IconButton';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import {
-  isCompleted,
+  isAttested,
   isDestinationQueued,
-  isRedeemed,
+  isRefunded,
+  isFailed,
   routes,
-  TransferState,
 } from '@wormhole-foundation/sdk';
 import { getTokenDetails, getTransferDetails } from 'telemetry';
 import { makeStyles } from 'tss-react/mui';
@@ -47,6 +47,7 @@ import {
 } from 'utils/wallet';
 import TransactionDetails from 'views/v2/Redeem/TransactionDetails';
 import WalletSidebar from 'views/v2/Bridge/WalletConnector/Sidebar';
+import { useConnectToLastUsedWallet } from 'utils/wallet';
 
 import type { RootState } from 'store';
 import TxCompleteIcon from 'icons/TxComplete';
@@ -118,7 +119,6 @@ const useStyles = makeStyles<StyleProps>()((theme, { transitionDuration }) => ({
     maxWidth: '420px',
   },
   txStatusIcon: {
-    color: theme.palette.primary.light,
     width: '105px',
     height: '105px',
   },
@@ -151,6 +151,8 @@ const Redeem = () => {
 
   const routeContext = React.useContext(RouteContext);
 
+  useConnectToLastUsedWallet();
+
   const {
     transferComplete: isTxComplete,
     route: routeName,
@@ -159,11 +161,15 @@ const Redeem = () => {
     txData,
   } = useSelector((state: RootState) => state.redeem);
 
-  const { state: receiptState } = routeContext.receipt || {};
-  const isTxAttested = receiptState && receiptState >= TransferState.Attested;
-  const isTxRefunded = receiptState === TransferState.Refunded;
-  const isTxFailed = receiptState === TransferState.Failed;
-  const isTxDestQueued = receiptState === TransferState.DestinationQueued;
+  const [unhandledManualClaimError, setUnhandledManualClaimError] =
+    useState<any>(undefined);
+
+  const { receipt } = routeContext;
+  const isTxAttested = receipt && isAttested(receipt);
+  const isTxRefunded = receipt && isRefunded(receipt);
+  const isTxFailed =
+    (receipt && isFailed(receipt)) || !!unhandledManualClaimError;
+  const isTxDestQueued = receipt && isDestinationQueued(receipt);
 
   const {
     recipient,
@@ -192,37 +198,114 @@ const Redeem = () => {
     return route.AUTOMATIC_DEPOSIT;
   }, [routeName]);
 
+  const details = getTransferDetails(
+    routeName!,
+    tokenKey,
+    receivedTokenKey,
+    fromChain,
+    toChain,
+    amount,
+    getUSDAmount,
+  );
+
+  // Handle changes to receiptState as well as uncaught errors when initiating manual redeems
+  // There are four cases this handles, in this order:
+  //
+  // - receipt.state === DestinationFinalized
+  // - receipt.state === Refunded
+  // - receipt.state === Failed
+  // - Unhandled error when manually redeeming
+  //
+  // Because the unhandled manual redeem error is at the end, we ignore it if
+  // we already saw one of the first three cases.
   useEffect(() => {
-    // When we see the transfer was complete for the first time,
-    // fire a transfer.success telemetry event
+    const { receipt } = routeContext;
+
+    if (!receipt) return;
+
     if (isTxComplete) {
       if (!transferSuccessEventFired) {
+        // When we see the transfer was complete for the first time,
+        // fire a transfer.success telemetry event.
         setTransferSuccessEventFired(true);
 
         config.triggerEvent({
           type: 'transfer.success',
-          details: getTransferDetails(
-            routeName!,
-            tokenKey,
-            receivedTokenKey,
-            fromChain,
-            toChain,
-            amount,
-            getUSDAmount,
-          ),
+          details,
         });
-      }
 
-      // Remove the in-progress tx from local storage
-      if (txData?.sendTx) {
-        removeTxFromLocalStorage(txData?.sendTx);
+        if (!isAutomaticRoute) {
+          // Manual routes also fire a second success event specific to manual redeems
+          config.triggerEvent({
+            type: 'transfer.redeem.success',
+            details,
+          });
+        }
+
+        setIsClaimInProgress(false);
+        setClaimError('');
+
+        if (txData?.sendTx) {
+          removeTxFromLocalStorage(txData?.sendTx);
+        }
+
       }
+    } else if (isTxRefunded) {
+      config.triggerEvent({
+        type: 'transfer.refunded',
+        details,
+      });
+    } else if (isFailed(receipt)) {
+      const [uiError, transferError] = interpretTransferError(
+        receipt.error,
+        details,
+      );
+      setClaimError(uiError);
+
+      config.triggerEvent({
+        type: 'transfer.error',
+        details,
+        error: transferError,
+      });
+
+      console.error(
+        `Transfer failed with error ${transferError}: ${receipt.error}`,
+      );
+
+      setIsClaimInProgress(false);
     } else if (isTxAttested && !isAutomaticRoute && txData?.sendTx) {
       // If this is a manual transaction in attested state,
       // we will mark the local storage item as readyToClaim
       updateTxInLocalStorage(txData?.sendTx, 'isReadyToClaim', true);
+
+    } else if (unhandledManualClaimError) {
+      const [uiError, transferError] = interpretTransferError(
+        unhandledManualClaimError,
+        details,
+      );
+
+      setClaimError(uiError);
+
+      config.triggerEvent({
+        type: 'transfer.redeem.error',
+        details,
+        error: transferError,
+      });
+
+      console.error(
+        `Error while manually redeeming: ${transferError.type} - ${unhandledManualClaimError}`,
+      );
+
+      setIsClaimInProgress(false);
     }
-  }, [isAutomaticRoute, isTxAttested, isTxComplete]);
+  }, [
+    receipt?.state,
+    isTxComplete,
+    isTxRefunded,
+    isTxAttested,
+    unhandledManualClaimError,
+    transferSuccessEventFired,
+  ]);
 
   const receivingWallet = useSelector(
     (state: RootState) => state.wallet.receiving,
@@ -442,23 +525,24 @@ const Redeem = () => {
   // Circular progress indicator component for ETA countdown
   const etaCircle = useMemo(() => {
     if (isTxComplete) {
-      return <TxCompleteIcon className={classes.txStatusIcon} />;
+      return (
+        <TxCompleteIcon
+          className={classes.txStatusIcon}
+          sx={{ color: theme.palette.primary.light }}
+        />
+      );
     } else if (isTxRefunded || isTxDestQueued) {
       return (
         <TxWarningIcon
           className={classes.txStatusIcon}
-          sx={{
-            color: theme.palette.warning.main,
-          }}
+          sx={{ color: theme.palette.warning.main }}
         />
       );
     } else if (isTxFailed) {
       return (
         <TxFailedIcon
           className={classes.txStatusIcon}
-          sx={{
-            color: theme.palette.error.light,
-          }}
+          sx={{ color: theme.palette.error.light }}
         />
       );
     } else if (!isAutomaticRoute && isTxAttested) {
@@ -466,9 +550,7 @@ const Redeem = () => {
       return (
         <TxReadyForClaim
           className={classes.txStatusIcon}
-          sx={{
-            color: theme.palette.warning.light,
-          }}
+          sx={{ color: theme.palette.warning.light }}
         />
       );
     } else {
@@ -561,6 +643,7 @@ const Redeem = () => {
 
   // Callback for claim action in Manual route transactions
   const handleManualClaim = async () => {
+    // This will be set back to false by a hook above which looks out for isTxComplete=true
     setIsClaimInProgress(true);
     setClaimError('');
 
@@ -599,8 +682,6 @@ const Redeem = () => {
 
     const route = routeContext.route!;
 
-    let txId: string | undefined;
-
     try {
       if (
         chainConfig!.context === Context.ETH &&
@@ -621,71 +702,56 @@ const Redeem = () => {
         TransferWallet.RECEIVING,
       );
 
-      let receipt: routes.Receipt | undefined;
+      const finishPromise = (() => {
+        if (isTxDestQueued && routes.isFinalizable(route)) {
+          return route.finalize(signer, routeContext.receipt);
+        } else if (!isTxDestQueued && routes.isManual(route)) {
+          return route.complete(signer, routeContext.receipt);
+        } else {
+          // Should be unreachable
+          return undefined;
+        }
+      })();
 
-      if (isTxDestQueued && routes.isFinalizable(route)) {
-        receipt = await route.finalize(signer, routeContext.receipt);
-      } else if (!isTxDestQueued && routes.isManual(route)) {
-        receipt = await route.complete(signer, routeContext.receipt);
+      if (finishPromise) {
+        config.triggerEvent({
+          type: 'transfer.redeem.start',
+          details,
+        });
+
+        // Await this promise just so that we catch any errors thrown by it and handle them below
+        await finishPromise;
       }
-
-      if (!receipt || (!isRedeemed(receipt) && !isCompleted(receipt))) {
-        throw new Error('Transfer not completed');
-      }
-
-      if (receipt.destinationTxs && receipt.destinationTxs.length > 0) {
-        txId = receipt.destinationTxs[receipt.destinationTxs.length - 1].txid;
-      }
-
-      config.triggerEvent({
-        type: 'transfer.redeem.start',
-        details: transferDetails,
-      });
-
-      setIsClaimInProgress(false);
-      setClaimError('');
     } catch (e: any) {
-      const [uiError, transferError] = interpretTransferError(e, toChain);
-
-      setClaimError(uiError);
-
-      config.triggerEvent({
-        type: 'transfer.redeem.error',
-        details: transferDetails,
-        error: transferError,
-      });
-
+      // This could be all kinds of unexpected errors
+      // Kick it up to the main useEffect where we handle receipt state changes
+      setUnhandledManualClaimError(e);
       setIsClaimInProgress(false);
-      console.error(e);
-    }
-    if (txId !== undefined) {
-      config.triggerEvent({
-        type: 'transfer.redeem.success',
-        details: transferDetails,
-      });
     }
   };
 
   // Main CTA button which has separate states for automatic and manual claims
   const actionButton = useMemo(() => {
-    if (
-      !isTxComplete &&
-      !isTxRefunded &&
-      !isTxFailed &&
-      (isTxDestQueued || !isAutomaticRoute)
-    ) {
-      if (isTxAttested) {
-        return isConnectedToReceivingWallet ? (
-          <Button
-            className={joinClass([classes.actionButton, classes.claimButton])}
-            variant={claimError ? 'error' : 'primary'}
-            onClick={handleManualClaim}
-          >
-            <Typography textTransform="none">
-              Claim tokens to complete transfer
-            </Typography>
-          </Button>
-        ) : (
+    if (isTxComplete || isTxRefunded) {
+      return (
+        <Button
+          variant="primary"
+          className={classes.actionButton}
+          onClick={() => {
+            dispatch(setRoute('bridge'));
+          }}
+        >
+          <Typography textTransform="none">Start a new transaction</Typography>
+        </Button>
+      );
+    }
+
+    const canBeManuallyClaimed =
+      isTxDestQueued || (!isAutomaticRoute && isTxAttested);
+
+    if (canBeManuallyClaimed) {
+      if (!isConnectedToReceivingWallet) {
+        return (
           <Button
             variant="primary"
             className={classes.actionButton}
@@ -696,20 +762,20 @@ const Redeem = () => {
             </Typography>
           </Button>
         );
+      } else {
+        return (
+          <Button
+            className={joinClass([classes.actionButton, classes.claimButton])}
+            variant={claimError ? 'error' : 'primary'}
+            onClick={handleManualClaim}
+          >
+            <Typography textTransform="none">
+              Claim tokens to complete transfer
+            </Typography>
+          </Button>
+        )
       }
     }
-
-    return (
-      <Button
-        variant="primary"
-        className={classes.actionButton}
-        onClick={() => {
-          dispatch(setRoute('bridge'));
-        }}
-      >
-        <Typography textTransform="none">Start a new transaction</Typography>
-      </Button>
-    );
   }, [
     isAutomaticRoute,
     isClaimInProgress,


### PR DESCRIPTION
## Error handling

This fixes #2857 and generally cleans things up. We now do all transfer telemetry events and UI error handling in a single `useEffect`. This means we're only relying on the `track` method now to tell us about the progress of a transaction.

The only exception to that is if `handleManualClaim` throws an error _before we've seen any other kind of final status on the receipt_ (complete, refunded, or failed).

## Icon colors

This fixes a recently introduced bug that made all of the status icons purple

## Auto-connect wallet for manual claims

Added this behavior using `useConnectToLastUsedWallet()` :)

## Call-to-action button

If a manual claim fails, we now show the redeem button again so they can try again. Before, it was showing the "Start a new transaction" button.