### PR TITLE
Add eslint plugin for React hooks

### DIFF
--- a/wormhole-connect/.eslintrc.json
+++ b/wormhole-connect/.eslintrc.json
@@ -8,6 +8,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier"
   ],
   "rules": {

--- a/wormhole-connect/.eslintrc.strict.json
+++ b/wormhole-connect/.eslintrc.strict.json
@@ -8,6 +8,7 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react-hooks/recommended",
     "prettier"
   ],
   "rules": {

--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -81,6 +81,7 @@
         "env-cmd": "^10.1.0",
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
+        "eslint-plugin-react-hooks": "^5.0.0",
         "husky": "^8.0.3",
         "lint-staged": "^13.2.3",
         "prettier": "^2.8.8",
@@ -17630,6 +17631,18 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
+      "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -120,6 +120,7 @@
     "env-cmd": "^10.1.0",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-react-hooks": "^5.0.0",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.3",
     "prettier": "^2.8.8",

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -425,10 +425,6 @@ const SingleRoute = (props: Props) => {
     return 'pointer';
   }, [props.error, props.isSelected, props.onSelect]);
 
-  if (isEmptyObject(props.route)) {
-    return <></>;
-  }
-
   const routeCardBadge = useMemo(() => {
     if (props.isFastest) {
       return (
@@ -447,6 +443,10 @@ const SingleRoute = (props: Props) => {
       return null;
     }
   }, [props.isFastest, props.isCheapest]);
+
+  if (isEmptyObject(props.route)) {
+    return <></>;
+  }
 
   return (
     <div key={name} className={classes.container}>


### PR DESCRIPTION
Added a hook which looks out for mistakes using React hooks. For now the exhaustive dependencies check is a warning, not an error, but it does throw errors for conditional use of hooks (since that crashes React). It actually found one instance of this which I also fixed.

There are 91 warnings now when I run `npm run lint`. We can chip away at these and then make exhaustive deps an error:

```json
  "rules": {
    "react-hooks/exhaustive-deps": "error"
  }
```