### PR TITLE
Refactor supported routes fetching

### DIFF
--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { QuoteResult } from 'routes/operator';
 import { RootState } from 'store';
-import { RouteState } from 'store/transferInput';
 import { isMinAmountError } from 'utils/sdkv2';
 
 type HookReturn = {
@@ -13,7 +12,7 @@ type HookReturn = {
 
 type Props = {
   balance?: string | null;
-  routes: RouteState[];
+  routes: string[];
   quotesMap: Record<string, QuoteResult | undefined>;
   tokenSymbol: string;
   isLoading: boolean;
@@ -51,7 +50,7 @@ export const useAmountValidation = (props: Props): HookReturn => {
   );
 
   const allRoutesFailed = useMemo(
-    () => props.routes.every((route) => !props.quotesMap[route.name]?.success),
+    () => props.routes.every((route) => !props.quotesMap[route]?.success),
     [props.routes, props.quotesMap],
   );
 

--- a/wormhole-connect/src/hooks/useAmountValidation.ts
+++ b/wormhole-connect/src/hooks/useAmountValidation.ts
@@ -50,7 +50,8 @@ export const useAmountValidation = (props: Props): HookReturn => {
   );
 
   const allRoutesFailed = useMemo(
-    () => props.routes.every((route) => !props.quotesMap[route]?.success),
+    () =>
+      props.routes.every((route) => props.quotesMap[route]?.success === false),
     [props.routes, props.quotesMap],
   );
 

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import type { RootState } from 'store';

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -59,9 +59,8 @@ const useFetchSupportedRoutes = (): HookReturn => {
         _routes.push(name);
       });
 
-      setIsFetching(false);
-
       if (isActive) {
+        setIsFetching(false);
         setRoutes(_routes);
       }
     };

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -72,12 +72,10 @@ const useFetchSupportedRoutes = (): HookReturn => {
     };
   }, [token, destToken, amount, fromChain, toChain, toNativeToken]);
 
-  return useMemo(() => {
-    return {
-      supportedRoutes: routes,
-      isFetching,
-    };
-  }, [routes, isFetching]);
+  return {
+    supportedRoutes: routes,
+    isFetching,
+  };
 };
 
 export default useFetchSupportedRoutes;

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -67,6 +67,10 @@ const useFetchSupportedRoutes = (): HookReturn => {
     };
 
     getSupportedRoutes();
+
+    return () => {
+      isActive = false;
+    };
   }, [token, destToken, amount, fromChain, toChain, toNativeToken]);
 
   return useMemo(() => {

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -63,7 +63,8 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       !params.sourceToken ||
       !params.destChain ||
       !params.destToken ||
-      !parseFloat(params.amount)
+      !parseFloat(params.amount) ||
+      routes.length === 0
     ) {
       return;
     }

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -4,7 +4,7 @@ import type { RootState } from 'store';
 import { routes } from '@wormhole-foundation/sdk';
 import useRoutesQuotesBulk from 'hooks/useRoutesQuotesBulk';
 import config from 'config';
-import { RouteState } from 'store/transferInput';
+import useFetchSupportedRoutes from './useFetchSupportedRoutes';
 
 type Quote = routes.Quote<
   routes.Options,
@@ -12,39 +12,26 @@ type Quote = routes.Quote<
 >;
 
 export type RouteWithQuote = {
-  route: RouteState;
+  route: string;
   quote: Quote;
 };
 
 type HookReturn = {
-  allSupportedRoutes: RouteState[];
-  sortedRoutes: RouteState[];
+  allSupportedRoutes: string[];
+  sortedRoutes: string[];
   sortedRoutesWithQuotes: RouteWithQuote[];
   quotesMap: ReturnType<typeof useRoutesQuotesBulk>['quotesMap'];
-  isFetchingQuotes: boolean;
+  isFetching: boolean;
 };
 
 export const useSortedRoutesWithQuotes = (): HookReturn => {
-  const {
-    amount,
-    routeStates,
-    fromChain,
-    token,
-    toChain,
-    destToken,
-    preferredRouteName,
-  } = useSelector((state: RootState) => state.transferInput);
+  const { amount, fromChain, token, toChain, destToken, preferredRouteName } =
+    useSelector((state: RootState) => state.transferInput);
+
   const { toNativeToken } = useSelector((state: RootState) => state.relay);
 
-  const supportedRoutes = useMemo(
-    () => (routeStates || []).filter((rs) => rs.supported),
-    [routeStates],
-  );
-
-  const supportedRoutesNames = useMemo(
-    () => supportedRoutes.map((r) => r.name),
-    [supportedRoutes],
-  );
+  const { supportedRoutes, isFetching: isFetchingSupportedRoutes } =
+    useFetchSupportedRoutes();
 
   const useQuotesBulkParams = useMemo(
     () => ({
@@ -58,15 +45,15 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
     [amount, fromChain, token, toChain, destToken, toNativeToken],
   );
 
-  const { quotesMap, isFetching } = useRoutesQuotesBulk(
-    supportedRoutesNames,
+  const { quotesMap, isFetching: isFetchingQuotes } = useRoutesQuotesBulk(
+    supportedRoutes,
     useQuotesBulkParams,
   );
 
   const routesWithQuotes = useMemo(() => {
     return supportedRoutes
       .map((route) => {
-        const quote = quotesMap[route.name];
+        const quote = quotesMap[route];
         if (quote?.success) {
           return {
             route,
@@ -83,15 +70,15 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
   // Only routes with quotes are sorted.
   const sortedRoutesWithQuotes = useMemo(() => {
     return [...routesWithQuotes].sort((routeA, routeB) => {
-      const routeConfigA = config.routes.get(routeA.route.name);
-      const routeConfigB = config.routes.get(routeB.route.name);
+      const routeConfigA = config.routes.get(routeA.route);
+      const routeConfigB = config.routes.get(routeB.route);
 
       // Prioritize preferred route to avoid flickering the UI
       // when the preferred route gets autoselected
       if (preferredRouteName) {
-        if (routeA.route.name === preferredRouteName) {
+        if (routeA.route === preferredRouteName) {
           return -1;
-        } else if (routeB.route.name === preferredRouteName) {
+        } else if (routeB.route === preferredRouteName) {
           return 1;
         }
       }
@@ -135,14 +122,15 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
       sortedRoutes,
       sortedRoutesWithQuotes,
       quotesMap,
-      isFetchingQuotes: isFetching,
+      isFetching: isFetchingSupportedRoutes || isFetchingQuotes,
     }),
     [
       supportedRoutes,
       sortedRoutes,
       sortedRoutesWithQuotes,
       quotesMap,
-      isFetching,
+      isFetchingSupportedRoutes,
+      isFetchingQuotes,
     ],
   );
 };

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -89,15 +89,9 @@ export type TransferValidations = {
   receiveAmount: ValidationErr;
 };
 
-export type RouteState = {
-  name: string;
-  supported: boolean;
-};
-
 export interface TransferInputState {
   showValidationState: boolean;
   validations: TransferValidations;
-  routeStates: RouteState[] | undefined;
   fromChain: Chain | undefined;
   toChain: Chain | undefined;
   token: string;
@@ -135,7 +129,6 @@ function getInitialState(): TransferInputState {
       relayerFee: '',
       receiveAmount: '',
     },
-    routeStates: undefined,
     fromChain: config.ui.defaultInputs?.fromChain || undefined,
     toChain: config.ui.defaultInputs?.toChain || undefined,
     token: config.ui.defaultInputs?.tokenKey || '',
@@ -235,12 +228,6 @@ export const transferInputSlice = createSlice({
     ) => {
       state.route = payload;
     },
-    setRoutes: (
-      state: TransferInputState,
-      { payload }: PayloadAction<RouteState[]>,
-    ) => {
-      state.routeStates = payload;
-    },
     // user input
     setToken: (
       state: TransferInputState,
@@ -336,14 +323,7 @@ export const transferInputSlice = createSlice({
         state.route = undefined;
         return;
       }
-      if (
-        state.routeStates &&
-        state.routeStates.some((rs) => rs.name === payload && rs.supported)
-      ) {
-        state.route = payload;
-      } else {
-        state.route = undefined;
-      }
+      state.route = payload;
     },
     // clear inputs
     clearTransfer: (state: TransferInputState) => {
@@ -444,7 +424,6 @@ export const selectChain = async (
 export const {
   setValidations,
   setRoute,
-  setRoutes,
   setToken,
   setDestToken,
   setFromChain,

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -228,13 +228,15 @@ export const validate = async (
     transferInput.token &&
     transferInput.destToken &&
     transferInput.amount &&
-    Number.parseFloat(transferInput.amount) >= 0 &&
-    transferInput.routeStates?.some((rs) => rs.supported) !== undefined
-      ? true
-      : false;
+    Number.parseFloat(transferInput.amount) >= 0;
 
   if (!isCanceled()) {
-    dispatch(setValidations({ validations, showValidationState }));
+    dispatch(
+      setValidations({
+        validations,
+        showValidationState: !!showValidationState,
+      }),
+    );
   }
 };
 

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -10,7 +10,6 @@ import { RoutesConfig } from 'config/routes';
 import SingleRoute from 'views/v2/Bridge/Routes/SingleRoute';
 
 import type { RootState } from 'store';
-import { RouteState } from 'store/transferInput';
 import { routes } from '@wormhole-foundation/sdk';
 import { Box, CircularProgress, Skeleton } from '@mui/material';
 
@@ -45,7 +44,7 @@ const useStyles = makeStyles()((theme: any) => ({
 }));
 
 type Props = {
-  routes: RouteState[];
+  routes: string[];
   selectedRoute?: string;
   onRouteChange: (route: string) => void;
   quotes: Record<string, routes.QuoteResult<routes.Options> | undefined>;
@@ -64,12 +63,8 @@ const Routes = ({ ...props }: Props) => {
   );
 
   const routes = useMemo(() => {
-    return props.routes.filter((rs) => props.quotes[rs.name] !== undefined);
+    return props.routes.filter((rs) => props.quotes[rs] !== undefined);
   }, [props.routes, props.quotes]);
-
-  const supportedRoutes = useMemo(() => {
-    return routes.filter((rs) => rs.supported);
-  }, [routes]);
 
   const walletsConnected = useMemo(
     () => !!sendingWallet.address && !!receivingWallet.address,
@@ -81,9 +76,7 @@ const Routes = ({ ...props }: Props) => {
       return routes;
     }
 
-    const selectedRoute = routes.find(
-      (route) => route.name === props.selectedRoute,
-    );
+    const selectedRoute = routes.find((route) => route === props.selectedRoute);
 
     return selectedRoute ? [selectedRoute] : routes.slice(0, 1);
   }, [showAll, routes]);
@@ -91,7 +84,7 @@ const Routes = ({ ...props }: Props) => {
   const fastestRoute = useMemo(() => {
     return routes.reduce(
       (fastest, route) => {
-        const quote = props.quotes[route.name];
+        const quote = props.quotes[route];
         if (!quote || !quote.success) return fastest;
 
         if (
@@ -99,7 +92,7 @@ const Routes = ({ ...props }: Props) => {
           quote.eta < fastest.eta &&
           quote.eta < 60_000
         ) {
-          return { name: route.name, eta: quote.eta };
+          return { name: route, eta: quote.eta };
         } else {
           return fastest;
         }
@@ -111,14 +104,13 @@ const Routes = ({ ...props }: Props) => {
   const cheapestRoute = useMemo(() => {
     return routes.reduce(
       (cheapest, route) => {
-        const quote = props.quotes[route.name];
-        const rc = config.routes.get(route.name);
-        // TODO put AUTOMATIC_DEPOSIT into RouteState
+        const quote = props.quotes[route];
+        const rc = config.routes.get(route);
         if (!quote || !quote.success || !rc.AUTOMATIC_DEPOSIT) return cheapest;
 
         const amountOut = BigInt(quote.destinationToken.amount.amount);
         if (amountOut > cheapest.amountOut) {
-          return { name: route.name, amountOut };
+          return { name: route, amountOut };
         } else {
           return cheapest;
         }
@@ -165,7 +157,7 @@ const Routes = ({ ...props }: Props) => {
       {props.isLoading && renderRoutes.length === 0 ? (
         <Skeleton variant="rounded" height={153} width="100%" />
       ) : (
-        renderRoutes.map(({ name }, index) => {
+        renderRoutes.map((name, index) => {
           const routeConfig = RoutesConfig[name];
           const isSelected = routeConfig.name === props.selectedRoute;
           const quoteResult = props.quotes[name];
@@ -184,7 +176,7 @@ const Routes = ({ ...props }: Props) => {
               isSelected={isSelected && !quoteError}
               isFastest={name === fastestRoute.name}
               isCheapest={name === cheapestRoute.name}
-              isOnlyChoice={supportedRoutes.length === 1}
+              isOnlyChoice={routes.length === 1}
               onSelect={props.onRouteChange}
               quote={quote}
             />

--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import { makeStyles } from 'tss-react/mui';
@@ -14,21 +13,6 @@ import { routes } from '@wormhole-foundation/sdk';
 import { Box, CircularProgress, Skeleton } from '@mui/material';
 
 const useStyles = makeStyles()((theme: any) => ({
-  connectWallet: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: '8px',
-    padding: '8px 16px',
-    borderRadius: '8px',
-    backgroundColor: theme.palette.button.primary,
-    cursor: 'not-allowed',
-    opacity: 0.7,
-    marginTop: '16px',
-    maxWidth: '420px',
-    height: '48px',
-    width: '100%',
-  },
   otherRoutesToggle: {
     display: 'block',
     width: '100%',
@@ -119,17 +103,7 @@ const Routes = ({ ...props }: Props) => {
     );
   }, [routes, props.quotes]);
 
-  if (walletsConnected && !(Number(amount) > 0)) {
-    return (
-      <Tooltip title="Please enter the amount to view available routes">
-        <div className={classes.connectWallet}>
-          <div>View routes</div>
-        </div>
-      </Tooltip>
-    );
-  }
-
-  if (props.hasError) {
+  if ((walletsConnected && !(Number(amount) > 0)) || props.hasError) {
     return null;
   }
 

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -174,8 +174,12 @@ const Bridge = () => {
       const isSelectedRouteValid =
         sortedRoutesWithQuotes.findIndex((r) => r.route === selectedRoute) > -1;
 
+      if (!isSelectedRouteValid) {
+        setSelectedRoute('');
+      }
+
       // If no route is autoselected or we already have a valid selected route,
-      // we should avoid to overwrite it
+      // we should avoid overwriting it
       if (!autoselectedRoute || (selectedRoute && isSelectedRouteValid)) {
         return;
       }
@@ -426,23 +430,12 @@ const Bridge = () => {
     Number(amount) > 0 &&
     !hasError;
 
-  const supportedRouteSelected = true; /*useMemo(
-    () =>
-      routeStates?.find?.((rs) => rs.name === selectedRoute && !!rs.supported),
-    [routeStates, selectedRoute],
-  );*/
-
   // Review transaction button is shown only when everything is ready
   const reviewTransactionButton = (
     <Button
       variant="primary"
       className={classes.reviewTransaction}
-      disabled={
-        !isValid ||
-        isFetchingQuotes ||
-        !supportedRouteSelected ||
-        !selectedRoute
-      }
+      disabled={!isValid || isFetchingQuotes || !selectedRoute}
       onClick={() => {
         dispatch(setTransferRoute(selectedRoute));
         setWillReviewTransaction(true);

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -204,6 +204,11 @@ const Bridge = () => {
   // Fetch token prices
   useFetchTokenPrices();
 
+  const walletsConnected = useMemo(
+    () => !!sendingWallet.address && !!receivingWallet.address,
+    [sendingWallet.address, receivingWallet.address],
+  );
+
   const sourceTokenArray = useMemo(() => {
     return sourceToken ? [config.tokens[sourceToken]] : [];
   }, [sourceToken]);
@@ -425,17 +430,19 @@ const Bridge = () => {
     sourceToken &&
     destChain &&
     destToken &&
-    sendingWallet.address &&
-    receivingWallet.address &&
-    Number(amount) > 0 &&
+    walletsConnected &&
     !hasError;
+
+  const hasEnteredAmount = Number(amount) > 0;
 
   // Review transaction button is shown only when everything is ready
   const reviewTransactionButton = (
     <Button
       variant="primary"
       className={classes.reviewTransaction}
-      disabled={!isValid || isFetchingQuotes || !selectedRoute}
+      disabled={
+        !isValid || isFetchingQuotes || !selectedRoute || !hasEnteredAmount
+      }
       onClick={() => {
         dispatch(setTransferRoute(selectedRoute));
         setWillReviewTransaction(true);
@@ -446,6 +453,14 @@ const Bridge = () => {
       </Typography>
     </Button>
   );
+
+  const reviewButtonTooltip = !hasEnteredAmount
+    ? 'Please enter an amount'
+    : isFetchingQuotes
+    ? 'Loading quotes...'
+    : !selectedRoute
+    ? 'Please select a quote'
+    : '';
 
   if (willReviewTransaction) {
     return (
@@ -478,9 +493,13 @@ const Bridge = () => {
         hasError={hasError}
       />
       <span className={classes.ctaContainer}>
-        {showReviewTransactionButton
-          ? reviewTransactionButton
-          : walletConnector}
+        {showReviewTransactionButton ? (
+          <Tooltip title={reviewButtonTooltip}>
+            <span>{reviewTransactionButton}</span>
+          </Tooltip>
+        ) : (
+          walletConnector
+        )}
       </span>
       {config.ui.showHamburgerMenu ? null : <FooterNavBar />}
       <div className={classes.poweredBy}>

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -127,7 +127,6 @@ const Bridge = () => {
     destToken,
     route,
     preferredRouteName,
-    routeStates,
     supportedDestTokens: supportedDestTokensBase,
     supportedSourceTokens,
     amount,
@@ -139,7 +138,7 @@ const Bridge = () => {
     sortedRoutes,
     sortedRoutesWithQuotes,
     quotesMap,
-    isFetchingQuotes,
+    isFetching: isFetchingQuotes,
   } = useSortedRoutesWithQuotes();
 
   // Compute and set source tokens
@@ -164,20 +163,16 @@ const Bridge = () => {
   // Set selectedRoute if the route is auto-selected
   // After the auto-selection, we set selectedRoute when user clicks on a route in the list
   useEffect(() => {
-    const validRoutes = sortedRoutesWithQuotes.filter(
-      (rs) => rs.route.supported,
-    );
-
-    if (validRoutes.length === 0) {
+    if (sortedRoutesWithQuotes.length === 0) {
       setSelectedRoute('');
     } else {
-      const preferredRoute = validRoutes.find(
-        (route) => route.route.name === preferredRouteName,
+      const preferredRoute = sortedRoutesWithQuotes.find(
+        (route) => route.route === preferredRouteName,
       );
       const autoselectedRoute =
-        route ?? preferredRoute?.route.name ?? validRoutes[0].route.name;
+        route ?? preferredRoute?.route ?? sortedRoutesWithQuotes[0].route;
       const isSelectedRouteValid =
-        validRoutes.findIndex((r) => r.route.name === selectedRoute) > -1;
+        sortedRoutesWithQuotes.findIndex((r) => r.route === selectedRoute) > -1;
 
       // If no route is autoselected or we already have a valid selected route,
       // we should avoid to overwrite it
@@ -185,11 +180,11 @@ const Bridge = () => {
         return;
       }
 
-      const routeData = validRoutes?.find(
-        (rs) => rs.route.name === autoselectedRoute,
+      const routeData = sortedRoutesWithQuotes?.find(
+        (rs) => rs.route === autoselectedRoute,
       );
 
-      if (routeData) setSelectedRoute(routeData.route.name);
+      if (routeData) setSelectedRoute(routeData.route);
     }
   }, [route, sortedRoutesWithQuotes]);
 
@@ -431,11 +426,11 @@ const Bridge = () => {
     Number(amount) > 0 &&
     !hasError;
 
-  const supportedRouteSelected = useMemo(
+  const supportedRouteSelected = true; /*useMemo(
     () =>
       routeStates?.find?.((rs) => rs.name === selectedRoute && !!rs.supported),
     [routeStates, selectedRoute],
-  );
+  );*/
 
   // Review transaction button is shown only when everything is ready
   const reviewTransactionButton = (


### PR DESCRIPTION
This change moves the "supported routes" list out of Redux, because the only place we really need it is the `useSupportedRoutesWithQuotes` hook. It is now fetched in there and pipelined into the downstream quotes call.

Here is a loom demonstrating the reason I made this change in the first place... it improves how the UI transitions through the loading state:

https://www.loom.com/share/5aab31c51e8346e09bd533d05ffde5e5