### PR TITLE
Adding back in-progress indicator for Redeem view

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -674,7 +674,7 @@ const Redeem = () => {
       !isTxFailed &&
       (isTxDestQueued || !isAutomaticRoute)
     ) {
-      if (isTxAttested) {
+      if (isTxAttested && !isClaimInProgress) {
         return isConnectedToReceivingWallet ? (
           <Button
             className={joinClass([classes.actionButton, classes.claimButton])}
@@ -693,6 +693,20 @@ const Redeem = () => {
           >
             <Typography textTransform="none">
               Connect receiving wallet
+            </Typography>
+          </Button>
+        );
+      } else {
+        return (
+          <Button disabled variant="primary" className={classes.actionButton}>
+            <Typography
+              display="flex"
+              alignItems="center"
+              gap={1}
+              textTransform="none"
+            >
+              <CircularProgress color="secondary" size={16} />
+              Transfer in progress
             </Typography>
           </Button>
         );


### PR DESCRIPTION
Adding back in progress state for manual transactions in redeem view that has been accidentally removed by https://github.com/wormhole-foundation/wormhole-connect/pull/2865

<img width="581" alt="Screenshot 2024-10-28 at 11 36 34 AM" src="https://github.com/user-attachments/assets/6c6a16c5-586a-4b80-972c-31e0ed88ffa2">
