### PR TITLE
Fixing tx tracking issues between in-progress widget and redeem view

### DIFF
--- a/wormhole-connect/src/hooks/useTrackTransfer.ts
+++ b/wormhole-connect/src/hooks/useTrackTransfer.ts
@@ -19,9 +19,10 @@ type Props = {
 type ReturnProps = {
   isCompleted: boolean;
   isReadyToClaim: boolean;
+  receipt: routes.Receipt<AttestationReceipt> | undefined;
 };
 
-const useTrackTransferV2 = (props: Props): ReturnProps => {
+const useTrackTransfer = (props: Props): ReturnProps => {
   const [completed, setCompleted] = useState(false);
   const [readyToClaim, setReadyToClaim] = useState(false);
   const [receipt, setReceipt] = useState<routes.Receipt<AttestationReceipt>>();
@@ -116,7 +117,8 @@ const useTrackTransferV2 = (props: Props): ReturnProps => {
   return {
     isCompleted: completed,
     isReadyToClaim: readyToClaim,
+    receipt,
   };
 };
 
-export default useTrackTransferV2;
+export default useTrackTransfer;

--- a/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
@@ -125,10 +125,7 @@ const WidgetItem = (props: Props) => {
   // We have the initial receipt from local storage,
   // but the receipt from useTrackTransfer is more up-to-date,
   // so we need to use that one first.
-  const receipt = useMemo(
-    () => trackingReceipt || initialReceipt,
-    [trackingReceipt, initialReceipt],
-  );
+  const receipt = trackingReceipt || initialReceipt;
 
   // Remaining from the original ETA since the creation of this transaction
   const etaRemaining = useMemo(() => {


### PR DESCRIPTION
There are two main changes in this PR:
- Setting latest receipt in routeContext during tracking, which is used in Redeem view.
- useTrackTransfer now returning the latest receipt as an option property so in-progress widget can use it to set RouteContext before navigating to Redeem view.
- Display "Start new transaction" when manual tx is in progress, instead of disabled "Transfer in progress".
- Fixing more exhaustive-deps lint errors

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2885
Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2920

See the loom for more details (sorry about my lower voice, still recovering since yesterday):
https://www.loom.com/share/ff58c7d63dca451680f4c7600916a66d?sid=a11ee5d8-c5ce-4ca5-9527-cc806ca9289c