### PR TITLE
Bucket quotes by ETA, then sort by rate

### DIFF
--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -148,7 +148,7 @@ const bucketByEta = (
     for (let i = 0; i < thresholds.length; i++) {
       const threshold = thresholds[i];
       if (quote.eta && quote.eta <= threshold) {
-        buckets[i]!.push(routeAndQuote);
+        buckets[i].push(routeAndQuote);
         break;
       }
     }

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -141,14 +141,13 @@ const bucketByEta = (
   routesWithQuotes: RouteWithQuote[],
 ): RouteWithQuote[][] => {
   const thresholds = [60 * 1000, Infinity];
-  const buckets: RouteWithQuote[][] = [];
+  const buckets: RouteWithQuote[][] = Array(thresholds.length).fill([]);
 
   for (const routeAndQuote of routesWithQuotes) {
     const { quote } = routeAndQuote;
     for (let i = 0; i < thresholds.length; i++) {
       const threshold = thresholds[i];
       if (quote.eta && quote.eta <= threshold) {
-        if (buckets[i] === undefined) buckets[i] = [];
         buckets[i]!.push(routeAndQuote);
         break;
       }

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -69,46 +69,48 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
 
   // Only routes with quotes are sorted.
   const sortedRoutesWithQuotes = useMemo(() => {
-    return [...routesWithQuotes].sort((routeA, routeB) => {
-      const routeConfigA = config.routes.get(routeA.route);
-      const routeConfigB = config.routes.get(routeB.route);
+    return bucketByEta(routesWithQuotes)
+      .map((bucket) => {
+        return bucket.sort((routeA, routeB) => {
+          const routeConfigA = config.routes.get(routeA.route);
+          const routeConfigB = config.routes.get(routeB.route);
 
-      // Prioritize preferred route to avoid flickering the UI
-      // when the preferred route gets autoselected
-      if (preferredRouteName) {
-        if (routeA.route === preferredRouteName) {
-          return -1;
-        } else if (routeB.route === preferredRouteName) {
-          return 1;
-        }
-      }
+          // Prioritize preferred route to avoid flickering the UI
+          // when the preferred route gets autoselected
+          if (preferredRouteName) {
+            if (routeA.route === preferredRouteName) {
+              return -1;
+            } else if (routeB.route === preferredRouteName) {
+              return 1;
+            }
+          }
 
-      // 1. Prioritize automatic routes
-      if (routeConfigA.AUTOMATIC_DEPOSIT && !routeConfigB.AUTOMATIC_DEPOSIT) {
-        return -1;
-      } else if (
-        !routeConfigA.AUTOMATIC_DEPOSIT &&
-        routeConfigB.AUTOMATIC_DEPOSIT
-      ) {
-        return 1;
-      }
+          // 1. Prioritize automatic routes
+          if (
+            routeConfigA.AUTOMATIC_DEPOSIT &&
+            !routeConfigB.AUTOMATIC_DEPOSIT
+          ) {
+            return -1;
+          } else if (
+            !routeConfigA.AUTOMATIC_DEPOSIT &&
+            routeConfigB.AUTOMATIC_DEPOSIT
+          ) {
+            return 1;
+          }
 
-      // 2. Prioritize estimated time
-      if (routeA.quote.eta && routeB.quote.eta) {
-        if (routeA.quote.eta > routeB.quote.eta) {
-          return 1;
-        } else if (routeA.quote.eta < routeB.quote.eta) {
-          return -1;
-        }
-      }
-
-      // 3. Compare destination token amounts
-      const destAmountA = BigInt(routeA.quote.destinationToken.amount.amount);
-      const destAmountB = BigInt(routeB.quote.destinationToken.amount.amount);
-      // Note: Sort callback return strictly expects Number
-      // Returning BigInt results in TypeError
-      return Number(destAmountB - destAmountA);
-    });
+          // 2. Compare destination token amounts
+          const destAmountA = BigInt(
+            routeA.quote.destinationToken.amount.amount,
+          );
+          const destAmountB = BigInt(
+            routeB.quote.destinationToken.amount.amount,
+          );
+          // Note: Sort callback return strictly expects Number
+          // Returning BigInt results in TypeError
+          return Number(destAmountB - destAmountA);
+        });
+      })
+      .flat();
   }, [preferredRouteName, routesWithQuotes]);
 
   const sortedRoutes = useMemo(
@@ -133,4 +135,25 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
       isFetchingQuotes,
     ],
   );
+};
+
+const bucketByEta = (
+  routesWithQuotes: RouteWithQuote[],
+): RouteWithQuote[][] => {
+  const thresholds = [60 * 1000, Infinity];
+  const buckets: RouteWithQuote[][] = [];
+
+  for (const routeAndQuote of routesWithQuotes) {
+    const { quote } = routeAndQuote;
+    for (let i = 0; i < thresholds.length; i++) {
+      const threshold = thresholds[i];
+      if (quote.eta && quote.eta <= threshold) {
+        if (buckets[i] === undefined) buckets[i] = [];
+        buckets[i]!.push(routeAndQuote);
+        break;
+      }
+    }
+  }
+
+  return buckets;
 };


### PR DESCRIPTION
Addresses #2889

As per discussion with @Wesleyleung - group quotes first by ETA, then sort by conversion rate. We will first show all quotes that land in under a minute, sorted by rate. Then, all the others also sorted by rate.