### PR TITLE
Fix EVM wallet loading issue

### DIFF
--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -334,11 +334,11 @@ export const getWalletOptions = async (
   if (config === undefined) {
     return [];
   } else if (config.context === Context.ETH) {
-    const { wallets } = await import('utils/wallet/evm');
-    return Object.values(mapWallets(wallets, Context.ETH));
+    const evm = await import('utils/wallet/evm');
+    return Object.values(mapWallets(evm.wallets, Context.ETH));
   } else if (config.context === Context.SOLANA) {
-    const { fetchOptions } = await import('utils/wallet/solana');
-    const solanaWallets = fetchOptions();
+    const solana = await import('utils/wallet/solana');
+    const solanaWallets = solana.fetchOptions();
     return Object.values(mapWallets(solanaWallets, Context.SOLANA));
   } else if (config.context === Context.SUI) {
     const suiWallet = await import('utils/wallet/sui');


### PR DESCRIPTION
For some reason the generated code struggles to destructure an async require. I verified this diff fixes the issue using `npm pack` and connect-in-style previews.

<img width="895" alt="image" src="https://github.com/user-attachments/assets/84e85492-f317-4bf6-949e-9a0a262df3d5">
