### PR TITLE
Don't log expected errors

### DIFF
--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -54,7 +54,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
             });
           }
         } catch (e) {
-          maybeLogError(e);
+          maybeLogError(e, `Error when checking route (${name}) is supported`);
         }
 
         if (supported) {

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
-import { maybeLogError } from 'utils/errors';
+import { maybeLogSdkError } from 'utils/errors';
 
 type HookReturn = {
   supportedRoutes: string[];
@@ -54,7 +54,10 @@ const useFetchSupportedRoutes = (): HookReturn => {
             });
           }
         } catch (e) {
-          maybeLogError(e, `Error when checking route (${name}) is supported`);
+          maybeLogSdkError(
+            e,
+            `Error when checking route (${name}) is supported`,
+          );
         }
 
         if (supported) {

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
+import { maybeLogError } from 'utils/errors';
 
 type HookReturn = {
   supportedRoutes: string[];
@@ -53,7 +54,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
             });
           }
         } catch (e) {
-          console.error('Error when checking route is supported:', e, name);
+          maybeLogError(e);
         }
 
         if (supported) {

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -14,7 +14,7 @@ import {
 import '@wormhole-foundation/sdk-definitions-ntt';
 import '@wormhole-foundation/sdk-evm-ntt';
 import '@wormhole-foundation/sdk-solana-ntt';
-import { maybeLogError } from 'utils/errors';
+import { maybeLogSdkError } from 'utils/errors';
 
 export interface TxInfo {
   route: string;
@@ -168,7 +168,7 @@ export default class RouteOperator {
           supported[token.key] = token;
         }
       } catch (e) {
-        maybeLogError(e);
+        maybeLogSdkError(e);
       }
     });
     return Object.values(supported);

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -14,6 +14,7 @@ import {
 import '@wormhole-foundation/sdk-definitions-ntt';
 import '@wormhole-foundation/sdk-evm-ntt';
 import '@wormhole-foundation/sdk-solana-ntt';
+import { maybeLogError } from 'utils/errors';
 
 export interface TxInfo {
   route: string;
@@ -167,7 +168,7 @@ export default class RouteOperator {
           supported[token.key] = token;
         }
       } catch (e) {
-        console.error(e);
+        maybeLogError(e);
       }
     });
     return Object.values(supported);

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -66,10 +66,10 @@ export function interpretTransferError(
   return [uiErrorMessage, { type: internalErrorCode, original: e }];
 }
 
-export function maybeLogError(e: any) {
+export function maybeLogError(e: any, prefix?: string) {
   const ignore =
     e instanceof Error && e.message.startsWith('No protocols registered for');
   if (!ignore) {
-    console.error(e);
+    console.error(prefix ? `${prefix}: ${e}` : e);
   }
 }

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -67,9 +67,8 @@ export function interpretTransferError(
 }
 
 export function maybeLogError(e: any, prefix?: string) {
-  const ignore =
-    e instanceof Error && e.message.startsWith('No protocols registered for');
-  if (!ignore) {
-    console.error(prefix ? `${prefix}: ${e}` : e);
-  }
+  if (e instanceof Error && e.message.startsWith('No protocols registered for'))
+    return;
+
+  console.error(prefix ? `${prefix}: ${e}` : e);
 }

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -65,3 +65,11 @@ export function interpretTransferError(
 
   return [uiErrorMessage, { type: internalErrorCode, original: e }];
 }
+
+export function maybeLogError(e: any) {
+  const ignore =
+    e instanceof Error && e.message.startsWith('No protocols registered for');
+  if (!ignore) {
+    console.error(e);
+  }
+}

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -66,7 +66,7 @@ export function interpretTransferError(
   return [uiErrorMessage, { type: internalErrorCode, original: e }];
 }
 
-export function maybeLogError(e: any, prefix?: string) {
+export function maybeLogSdkError(e: any, prefix?: string) {
   if (e instanceof Error && e.message.startsWith('No protocols registered for'))
     return;
 


### PR DESCRIPTION
Errors like 'No protocols registered' are actually expected and just spam the console. This change adds a maybeLogError function to skip logging those errors.