### PR TITLE
Do not allow tokens supported by NTT to be bridged via the token bridge

### DIFF
--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -439,6 +439,7 @@ export class SDKv2Route {
   }
 }
 
+// returns true if the token is supported by a NTT route, false otherwise
 const isNttSupportedToken = async (
   token: TokenIdV2,
   fromContext: ChainContext<Network, Chain>,
@@ -453,10 +454,8 @@ const isNttSupportedToken = async (
       route.rc.supportedDestinationTokens(token, fromContext, toContext),
     ]);
 
-    const isSourceTokenSupported = sourceTokens.some(
-      ({ chain, address }) =>
-        chain === token.chain &&
-        address.toString() === token.address.toString(),
+    const isSourceTokenSupported = sourceTokens.some((t) =>
+      isSameToken(t, token),
     );
 
     return isSourceTokenSupported && destTokens.length > 0;

--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -90,6 +90,18 @@ export class SDKv2Route {
 
     if (!fromTokenIdV2 || !toTokenIdV2) return false;
 
+    // Do not allow tokens supported by NTT to be bridged via the token bridge
+    if (
+      this.IS_TOKEN_BRIDGE_ROUTE &&
+      (await isNttSupportedToken(
+        fromTokenIdV2,
+        fromContext.context,
+        toContext.context,
+      ))
+    ) {
+      return false;
+    }
+
     const fromTokenSupported = !!(
       await this.rc.supportedSourceTokens(fromContext.context)
     ).find((tokenId) => {
@@ -426,3 +438,34 @@ export class SDKv2Route {
     return false;
   }
 }
+
+const isNttSupportedToken = async (
+  token: TokenIdV2,
+  fromContext: ChainContext<Network, Chain>,
+  toContext: ChainContext<Network, Chain>,
+): Promise<boolean> => {
+  const checkRouteSupport = async (routeName: string): Promise<boolean> => {
+    const route: SDKv2Route | undefined = config.routes.get(routeName);
+    if (!route) return false;
+
+    const [sourceTokens, destTokens] = await Promise.all([
+      route.rc.supportedSourceTokens(fromContext),
+      route.rc.supportedDestinationTokens(token, fromContext, toContext),
+    ]);
+
+    const isSourceTokenSupported = sourceTokens.some(
+      ({ chain, address }) =>
+        chain === token.chain &&
+        address.toString() === token.address.toString(),
+    );
+
+    return isSourceTokenSupported && destTokens.length > 0;
+  };
+
+  const [isManualSupported, isAutomaticSupported] = await Promise.all([
+    checkRouteSupport('ManualNtt'),
+    checkRouteSupport('AutomaticNtt'),
+  ]);
+
+  return isManualSupported || isAutomaticSupported;
+};


### PR DESCRIPTION
Somebody could deep link / configure Connect with the source and dest token to be the same and it would result in the TB route showing. If the source token is enabled by NTT, we don't want to show the TB route. This change is a fix for that.