### PR TITLE
safe wallet wallet connect rpc override

### DIFF
--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -60,9 +60,6 @@ const eip6963Wallets = Object.entries(Eip6963Wallets).reduce(
   {},
 );
 
-// eslint-disable-next-line no-debugger
-debugger;
-
 export const wallets = {
   ...eip6963Wallets,
   okxwallet: new Eip6963Wallet({


### PR DESCRIPTION
## Screencast

https://github.com/user-attachments/assets/c0ba10ff-5dd3-43ce-bb9f-d4e32594c005

## Scenario

Given a safeWallet connected using wallet connect, the configured RCP by default is cloudflare-eth.com, this RPC has reported stale or outdated data for a given transaction ending in an infinite spinner at the Connect side or failed to estimate gas. 

To mitigate the reported issues, this logic will pick the RPC configured at connect and forward it to wallet connect.
