### PR TITLE
override wallet connect rpcs to avoid been using the default rpcs provided on wallet connect

### DIFF
--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -37,20 +37,7 @@ const getRpcForChain = (
  */
 const coalesceWormholeChainName = (name: string) =>
   ({
-    Ethereum: 'ethereum',
-    'BNB Smart Chain': 'bsc',
-    Polygon: 'polygon',
-    Avalanche: 'avalanche',
-    Fantom: 'fantom',
-    Celo: 'celo',
-    Moonbeam: 'moonbeam',
-    Arbitrum: 'arbitrum',
-    Optimism: 'optimism',
-    Base: 'base',
-    Scroll: 'scroll',
-    Mantle: 'mantle',
-    XLayer: 'xlayer',
-    Kujira: 'kujira',
+    'bnb smart chain': 'bsc',
   }[name] || name);
 
 const WAGMI_CONFIG_FOR_CHAINS = DEFAULT_CHAINS.map((wagmiConfig) => ({
@@ -58,11 +45,11 @@ const WAGMI_CONFIG_FOR_CHAINS = DEFAULT_CHAINS.map((wagmiConfig) => ({
   rpcUrls: {
     ...wagmiConfig.rpcUrls,
     default: getRpcForChain(
-      coalesceWormholeChainName(wagmiConfig.name),
+      coalesceWormholeChainName(wagmiConfig.name.toLowerCase()),
       wagmiConfig.rpcUrls.default,
     ),
     public: getRpcForChain(
-      coalesceWormholeChainName(wagmiConfig.name),
+      coalesceWormholeChainName(wagmiConfig.name.toLowerCase()),
       wagmiConfig.rpcUrls.public,
     ),
   },

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -12,35 +12,61 @@ import config from 'config';
 const isChainResourceKey = (key: string): key is keyof ChainResourceMap =>
   Object.keys(config.rpcs).includes(key);
 
-const CHAINS_CONFIG = Object.entries(DEFAULT_CHAINS).map(
-  ([wagmiChainName, wagmiConfig]) => {
-    if (isChainResourceKey(wagmiChainName)) {
-      const rpc = config.rpcs[wagmiChainName];
-      if (rpc) {
-        return {
-          ...wagmiConfig,
-          rpcUrls: {
-            ...wagmiConfig.rpcUrls,
-            [wagmiChainName]: {
-              http: [rpc],
-            },
-            default: {
-              http: [rpc],
-            },
-            public: {
-              http: [rpc],
-            },
-          },
-        };
-      }
-    }
-    return wagmiConfig;
+type ChainRpcUrls = (typeof DEFAULT_CHAINS)[0]['rpcUrls']['default'];
+
+const getRpcForChain = (
+  wormholeChainName: string,
+  defaultRpc: ChainRpcUrls,
+): ChainRpcUrls =>
+  wormholeChainName in config.rpcs && isChainResourceKey(wormholeChainName)
+    ? { ...defaultRpc, http: [config.rpcs[wormholeChainName]!] }
+    : defaultRpc;
+
+/**
+ * Should be used to coalesce a wagmi chain name to a wormhole chain name.
+ * This is necessary because the wormhole chain names are different from the wagmi chain names.
+ *
+ * @param name a wagmi chain name
+ * @returns a wormhole chain name
+ *
+ * NOTE: mapping could be incomplete
+ */
+const coalesceWormholeChainName = (name: string) =>
+  ({
+    Ethereum: 'ethereum',
+    'BNB Smart Chain': 'bsc',
+    Polygon: 'polygon',
+    Avalanche: 'avalanche',
+    Fantom: 'fantom',
+    Celo: 'celo',
+    Moonbeam: 'moonbeam',
+    Arbitrum: 'arbitrum',
+    Optimism: 'optimism',
+    Base: 'base',
+    Scroll: 'scroll',
+    Mantle: 'mantle',
+    XLayer: 'xlayer',
+    Kujira: 'kujira',
+  }[name] || name);
+
+const WAGMI_CONFIG_FOR_CHAINS = DEFAULT_CHAINS.map((wagmiConfig) => ({
+  ...wagmiConfig,
+  rpcUrls: {
+    ...wagmiConfig.rpcUrls,
+    default: getRpcForChain(
+      coalesceWormholeChainName(wagmiConfig.name),
+      wagmiConfig.rpcUrls.default,
+    ),
+    public: getRpcForChain(
+      coalesceWormholeChainName(wagmiConfig.name),
+      wagmiConfig.rpcUrls.public,
+    ),
   },
-);
+}));
 
 export const wallets = {
   injected: new InjectedWallet({
-    chains: CHAINS_CONFIG,
+    chains: WAGMI_CONFIG_FOR_CHAINS,
   }),
   binance: new BinanceWallet({
     options: {},
@@ -48,7 +74,7 @@ export const wallets = {
   ...(config.walletConnectProjectId
     ? {
         walletConnect: new WalletConnectWallet({
-          chains: CHAINS_CONFIG,
+          chains: WAGMI_CONFIG_FOR_CHAINS,
           connectorOptions: {
             projectId: config.walletConnectProjectId,
           },

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -18,8 +18,12 @@ const getRpcForChain = (
   wormholeChainName: string,
   defaultRpc: ChainRpcUrls,
 ): ChainRpcUrls =>
-  wormholeChainName in config.rpcs && isChainResourceKey(wormholeChainName)
-    ? { ...defaultRpc, http: [config.rpcs[wormholeChainName]!] }
+  wormholeChainName in config.rpcs &&
+  isChainResourceKey(wormholeChainName) &&
+  config.rpcs[wormholeChainName] !== null &&
+  config.rpcs[wormholeChainName] !== undefined &&
+  config.rpcs[wormholeChainName] !== ''
+    ? { ...defaultRpc, http: [config.rpcs[wormholeChainName]] }
     : defaultRpc;
 
 /**

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -23,7 +23,7 @@ const getRpcForChain = (
   config.rpcs[wormholeChainName] !== null &&
   config.rpcs[wormholeChainName] !== undefined &&
   config.rpcs[wormholeChainName] !== ''
-    ? { ...defaultRpc, http: [config.rpcs[wormholeChainName]] }
+    ? { ...defaultRpc, http: [config.rpcs[wormholeChainName]!] }
     : defaultRpc;
 
 /**


### PR DESCRIPTION
## Screencast

https://github.com/user-attachments/assets/2fa533f9-3069-44d8-8fb3-94c73339a9d4

## Scenario

Given a safeWallet connected using wallet connect, the configured RCP by default is cloudflare-eth.com, this RPC has reported stale or outdated data for a given transaction ending in an infinite spinner at the Connect side or failed to estimate gas. 

To mitigate the reported issues, this logic will pick the RPC configured at connect and forward it to wallet connect.
