### PR TITLE
Bump Wormhole SDK to 1.2.0-beta.0, override dependencies

### DIFF
--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -31,13 +31,13 @@
         "@solana/spl-token": "^0.3.9",
         "@solana/wallet-adapter-wallets": "^0.19.25",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk": "^1.0.3",
-        "@wormhole-foundation/sdk-definitions": "^1.0.3",
-        "@wormhole-foundation/sdk-definitions-ntt": "^0.5.1",
-        "@wormhole-foundation/sdk-evm-ntt": "^0.5.1",
+        "@wormhole-foundation/sdk": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-definitions-ntt": "^0.5.2",
+        "@wormhole-foundation/sdk-evm-ntt": "^0.5.2",
         "@wormhole-foundation/sdk-icons": "^1.0.0",
-        "@wormhole-foundation/sdk-route-ntt": "^0.5.1",
-        "@wormhole-foundation/sdk-solana-ntt": "^0.5.1",
+        "@wormhole-foundation/sdk-route-ntt": "^0.5.2",
+        "@wormhole-foundation/sdk-solana-ntt": "^0.5.2",
         "@xlabs-libs/wallet-aggregator-aptos": "^0.0.1-alpha.14",
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18",
         "@xlabs-libs/wallet-aggregator-evm": "^0.0.2-alpha.2",
@@ -151,9 +151,10 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.11.8",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.8.tgz",
-      "integrity": "sha512-CgG1wbtMjsV2pRGe/eYITmV5B8lXUCYljB2gB/6jWTFQcrvirUVvKg7qtFdjYkQSFbIffU1IDyxgeaN81eTjbA==",
+      "version": "3.11.10",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.10.tgz",
+      "integrity": "sha512-IfGc+X4il0rDqVQBBWdxIKM+ciDCiDzBq9+Bg9z4tJMi87uF6po4v+ddiac1wP0ARgVPsFwEIGxK7jhN4pW8jg==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -4241,55 +4242,14 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@injectivelabs/dmm-proto-ts": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/dmm-proto-ts/-/dmm-proto-ts-1.0.20.tgz",
-      "integrity": "sha512-S9vGOAZbNNa+N5QDW2HcXn7ohvU/4qze6wELA9gF8zu8uWbE+UKWTqzkZ+B4XuG1MkJwoHL7pVcj3M+nC9Qe4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@injectivelabs/dmm-proto-ts/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@injectivelabs/dmm-proto-ts/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.16.tgz",
-      "integrity": "sha512-6kDldpoLjc69kH2i0RMCYTE/KQ2xnpd37A9et2K6IlhIZTVmAy3t5mBSj956Gzsg/82Q7K9fX8UNoG0iGQiOTw==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.19.tgz",
+      "integrity": "sha512-QwU6Q6jLWjQ11pUFcEczvmQodDXtOBVQr4Q19k+6M4Te5AfF6qRkwaQxUZWpTelRHwrL6zHj8OBbePso7TKhaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/ts-types": "^1.14.16",
+        "@injectivelabs/ts-types": "^1.14.19",
         "http-status-codes": "^2.2.0",
         "shx": "^0.3.2"
       }
@@ -4400,14 +4360,57 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.16.tgz",
-      "integrity": "sha512-t0gF4uxv/39oAOHsnelX9QUfirxvNKgQYZwNpHvhE6JnEYjRYmaEifqB/LZBZ06Xj+SS/f2DZ7DwNdVTYuvaAw==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.19.tgz",
+      "integrity": "sha512-U6rdOTZSnZlvMF1iJCgL1QQ77tyZhNZ83e0+pdS1v51KW/i2Q4+1gnaNoUYySoVpgeIbJRN1FItAHfK5wLM2EA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/exceptions": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "shx": "^0.3.2"
+      }
+    },
+    "node_modules/@injectivelabs/olp-proto-ts": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/olp-proto-ts/-/olp-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-dKxse7mZpmvRhm00Wn8Yy93EVEvFD7FPWeWFfxga0Patow3HK0D7k43VV7fE5kX9CDM1bxTatEVQ7WYGq4w0Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@injectivelabs/grpc-web": "^0.0.1",
+        "google-protobuf": "^3.14.0",
+        "protobufjs": "^7.0.0",
+        "rxjs": "^7.4.0"
+      }
+    },
+    "node_modules/@injectivelabs/olp-proto-ts/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@injectivelabs/olp-proto-ts/node_modules/protobufjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
@@ -4664,14 +4667,15 @@
       }
     },
     "node_modules/@injectivelabs/test-utils": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.16.tgz",
-      "integrity": "sha512-GCIEctKhQIxka7OexiG/3kUvua4XDA54oH5ltimFncLKKSWH1EQ8xk5euonW0q+3G3VV/YKScxmZ4LcKXtEf4Q==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.19.tgz",
+      "integrity": "sha512-6y0v0FeNGeJJN2sCkOw6BypozaKnf07DtzoomTsev1+6CKMEmO8xryta+aI15Z+2LpQtMaiJi1cqQMEcya6r3Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.16",
-        "@injectivelabs/networks": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/exceptions": "^1.14.19",
+        "@injectivelabs/networks": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "axios": "^1.6.4",
         "bignumber.js": "^9.0.1",
         "shx": "^0.3.2",
@@ -4699,20 +4703,22 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.16.tgz",
-      "integrity": "sha512-JzAwMQ0jneOCKQZWCHQD400HU5DFUnwD0DYxXCpcHE149BSorova3d+5oTL+HxibOzhr25j9zrCQVVsTC/+MmA==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.19.tgz",
+      "integrity": "sha512-nQVJrHC+yDPK4IaYKWZ/CUZPJ4oeKLUwArObvJhlNGMtsypthDGj1MLctc0otMigdTc64ZEpVcdrT9Q3g5P6wQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.16.tgz",
-      "integrity": "sha512-eS4SED2VqDD1m20drau8LrGjxmg8W+2CZj1hNXRB1bDk5+dAk92bw1/0LwiwzPsRX1bHV45w9sL0pk0VSZvV6w==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.19.tgz",
+      "integrity": "sha512-iiUanV6Y7cUlH5PBoyYpHd4HWDRHlo806DyRZP7IZCpIIvWhyrKRn1JOtzz4j4XDYxH34/99vN3TsK+VUmrQzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
+        "@injectivelabs/exceptions": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
         "axios": "^1.6.4",
         "bignumber.js": "^9.0.1",
         "http-status-codes": "^2.2.0",
@@ -12203,48 +12209,48 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.0.3.tgz",
-      "integrity": "sha512-2R/6W0Cdhst74dsqFq+LzSHSn3/E+IYRAnRqeF3xRvYEjleEbuk1pLTtQ+cfJ/TFxefv/VwG4nrUdK42Kxaoqg==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.2.0-beta.0.tgz",
+      "integrity": "sha512-bSfQ7+sU8N2OASOYuF/9A0CNNS2nhgyPXPPFG7+ewvg+xgzb8uWIm5eVn7heAIFFXkeInFPhFCy5KeDA3j4dug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.3",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.3",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.0.3",
-        "@wormhole-foundation/sdk-aptos": "1.0.3",
-        "@wormhole-foundation/sdk-aptos-core": "1.0.3",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.0.3",
-        "@wormhole-foundation/sdk-base": "1.0.3",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.0.3",
-        "@wormhole-foundation/sdk-definitions": "1.0.3",
-        "@wormhole-foundation/sdk-evm": "1.0.3",
-        "@wormhole-foundation/sdk-evm-cctp": "1.0.3",
-        "@wormhole-foundation/sdk-evm-core": "1.0.3",
-        "@wormhole-foundation/sdk-evm-portico": "1.0.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.3",
-        "@wormhole-foundation/sdk-solana": "1.0.3",
-        "@wormhole-foundation/sdk-solana-cctp": "1.0.3",
-        "@wormhole-foundation/sdk-solana-core": "1.0.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.0.3",
-        "@wormhole-foundation/sdk-sui": "1.0.3",
-        "@wormhole-foundation/sdk-sui-core": "1.0.3",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.0.3"
+        "@wormhole-foundation/sdk-algorand": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-aptos": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-base": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.0.3.tgz",
-      "integrity": "sha512-DWq1Nbi8hUtiPabpm1NZQ5OJwokWTH4Qp2xwbKtIT1zJvvi6VFVyXwzygh5VrFkxDpmYqsz7pQB8Iqa5pJXL1w==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.2.0-beta.0.tgz",
+      "integrity": "sha512-LqRJpteA67Kf9n2YAzihaBqmNGvxYX3YFMEA9M9skViOKHtAHdxtv3yOliENM+E5YMA21r0Y+EsQqU5eq44JLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -12252,39 +12258,39 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.0.3.tgz",
-      "integrity": "sha512-ZuoQdSqq8ScsfxKAIK0r0zIrhfVF3rHcRgTwLgYc1/sH9/FoJG/DH9SxebXIiC8yBGMRfhKEhncNS8oZd6/4CQ==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-q1IM+gm0wNcnNifvxl4lVEnzSmHOLc6uXcHii7AnxtIMUETAiHB6F4OSH7EBBLqPBRQNprKG8qPhh7ASyrtKpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.3",
-        "@wormhole-foundation/sdk-connect": "1.0.3"
+        "@wormhole-foundation/sdk-algorand": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-DqfD+x7bPDViWq5EcKIX2NIQUYtMC+Lrewe/jmldmTwxrZLQzwMi7F+UnqyUacmVhRQ45MsTBoZ0ec6/XUgWvw==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-OmpjDVbzuMhxsk32Gnta2y9aQu/95uO6SpRi5MZah8RFwRPWrC64Hv+RCoyL9bybcU9h+NdlcoB6WnCa6XCJBQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.0.3",
-        "@wormhole-foundation/sdk-algorand-core": "1.0.3",
-        "@wormhole-foundation/sdk-connect": "1.0.3"
+        "@wormhole-foundation/sdk-algorand": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.0.3.tgz",
-      "integrity": "sha512-fE2SnqQs2zcrg6BnagBSAS6SlkXkcfZi7CWBsOrMgmEjuwKUBXyM/fjjUJPCHgDTWwUPd1j3Kr10gdhxDffmVw==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.2.0-beta.0.tgz",
+      "integrity": "sha512-dqJ69gelEswwo4e9bynitVROmxCwuQJWmtUrBJI6zkDcE3dOU54zKPW0rZmAjUmJouH/PyT2b1W9hPwXYVX9Rw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
         "aptos": "1.21.0"
       },
       "engines": {
@@ -12292,26 +12298,26 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.0.3.tgz",
-      "integrity": "sha512-IMFqPmENwqwTFIKpCDeVbaTzc8RuUWEZmvi40yhF0fu4SWahSBoh/G0q0iwf/yUpDRyEO8ynrcUOU+AoQta4Qw==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-9bXv9Dn4fptZ+f9ASoCKkYNcpt5Q7dV9aw9E2oBNiKm02AsZ3cYnO0NpwGXmz4fyJy7gPyk66p8Ie65nyMhZ3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.3",
-        "@wormhole-foundation/sdk-connect": "1.0.3"
+        "@wormhole-foundation/sdk-aptos": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-KlEqzHg9SkSaNgRpIEcjXOYVt7/ra/kJtYG0F/6wt3YwjsM3mTANTSGUqoF1z9VsViPdffcCwfxKt2U92dZqJA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-SVK0AG7H6fuhMoby/ed2NFliQdTn7ev8EVt+xxAfBJOrmRFrFIKSJbvgG0eu6ph41CBjVvJXJT/T7/L4s5NarA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.0.3",
-        "@wormhole-foundation/sdk-connect": "1.0.3"
+        "@wormhole-foundation/sdk-aptos": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -12367,47 +12373,40 @@
       "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.2.tgz",
-      "integrity": "sha512-5HIkquipfVDXu5EVvw1h9gclLVo+5PhQqlPN/ra3cT4iBJjjUcRSkRjTPi80G8pbynFS9ODP2hsBTuHdpbZgKg==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.2.0-beta.0.tgz",
+      "integrity": "sha512-165q0/QrNppM3pi/qew1DlOoXS1SSrT3J7zwSxyK7lMz8XaVNM9JZSXi/qUYNlPfZPk0/UyozqT5Qp40lZgYNw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^1.1.3"
+        "@scure/base": "^1.1.3",
+        "binary-layout": "^1.0.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.0.3.tgz",
-      "integrity": "sha512-edXkPv2NDe1CSs9dcxC03lbknl1pI3YC/IEEmmn3BXD8xDL9wdvOsOzXifOhHAwUO8mGJiSVuTFRzfxiBIs56w==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.2.0-beta.0.tgz",
+      "integrity": "sha512-7g5rT4tnITJ7RxPNBAHt3joNaX+Py4q1Q0QoKsV+NmTJvvmv4CBiIe1OjWAjnftoySRL75mE2DvOvFdfOwHzSQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.3",
-        "@wormhole-foundation/sdk-definitions": "1.0.3",
+        "@wormhole-foundation/sdk-base": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
         "axios": "^1.4.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-connect/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.3.tgz",
-      "integrity": "sha512-zhieqHzyopDN9Z60tqa1EBaJhjRsY56qgP9qpaXT7GkMgp5HI1j2msTaJrpVtVOnTKBt78uJXatKP7+pFDKiJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.0.3.tgz",
-      "integrity": "sha512-0nP9ZASRyrP/lyRGHof9QQNPLngoP/Ic0R8r+r9/UQyydJhNVzYLtf6YWMqUZzpkugFCpMhz04nKMocnto1I4A==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.2.0-beta.0.tgz",
+      "integrity": "sha512-QGHABXeBNziydbE6vbUEhBFtQs3Z91RDGshY4MmpHJvp17s/nW5keDDyPfnR7AOWl8o9yC6FBGQTnpin55T2ag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -12415,16 +12414,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.0.3.tgz",
-      "integrity": "sha512-RzrJktyotuHi/2esFFqFgoHqppIZfbjJizYVB6BNtYTGHu/3X9hTedVaMGyLzagAyaxWSCuS4OCN4K1LpqNX9g==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-sGoMnWhroHcnz2PgqAA0LzMAo2iuaN/NJGwm8YDIw0QhwZE8YdkWNb7vdsp7OR8tCFUfEQgYW7F3i0JZyazPmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -12583,9 +12582,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.34.tgz",
-      "integrity": "sha512-kg25j+aCFCR/zkfn6U7JlH4Be4VEHO77cjfSLCQfOavQZ2nrXy9pvc9X88OBTYTCL7wLngIqAe0edt39bDk3tQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-G7gr9pJM/bDDtmW8fuXlUQZ+pNjFsypxM8gpd6bA7BbbBnZArdC8NlZvqfHgKYcaI27/CwIix2jlnz0okstjMg==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12595,9 +12594,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.11.56",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.56.tgz",
-      "integrity": "sha512-hEnN7DTVLGsol9Y/zaaDMDt1BZS/4KpMG419oCyM+MP1FVEOTp2BG/TDnIu7kXOwf66hCugBbnV84bvp2aY7SA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-w5C2qREyNZyc7bvGUvxzl5JetUkChFDTzZqW55qox+Iy6jiCkNILPTiArlHMlv/i04ymJ3B70Ftsr1j7V4lZrA==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12607,9 +12606,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.65.tgz",
-      "integrity": "sha512-kceZP68QrgFop387RYyO7tkfJCYxoktuceHTs9DQP3dJceLqj/V2mz0NlpkkacjgE5NhYkQ/zc0Z40hr8tnYqQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12619,28 +12618,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.16.tgz",
-      "integrity": "sha512-D8/7CbjK1h3DCNm8p/Lp3RcVnnHI5+JX70Y5rJ2ewjjCZSsWixIEta2mnLX6eH5zQUpfHLl3EC3/mN2Q0MaJww==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.19.tgz",
+      "integrity": "sha512-cNmE7nEobZSSxbrnygmSqBASGXmEkk0ftA06qhQTwK/GiYJI6GK5ihRehsSbtatibopqBXB2s3TfsB2cN/IVzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.5.8",
+        "@apollo/client": "^3.11.9",
         "@cosmjs/amino": "^0.32.3",
         "@cosmjs/proto-signing": "^0.32.3",
         "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "0.0.34",
-        "@injectivelabs/dmm-proto-ts": "1.0.20",
-        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/core-proto-ts": "1.13.3",
+        "@injectivelabs/exceptions": "^1.14.19",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.11.56",
-        "@injectivelabs/mito-proto-ts": "1.0.65",
-        "@injectivelabs/networks": "^1.14.16",
-        "@injectivelabs/test-utils": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/indexer-proto-ts": "1.13.1",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.19",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "@metamask/eth-sig-util": "^4.0.0",
         "@noble/curves": "^1.4.0",
         "axios": "^1.6.4",
@@ -12697,17 +12696,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.0.3.tgz",
-      "integrity": "sha512-4SDKVr3/gLJUsvNwMFa74KbIdSW5tm4QQVEys/Y0PfRKSSmGlcn9hgj+e7wfvyR8t6TFjkllypuoJYe6o5dybA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.2.0-beta.0.tgz",
+      "integrity": "sha512-zl3xxL4bOccmhcl69lvO7A3okeGnN2k/i/e1g1Ye4lDsR/VAStMV7EYby6mwnc+zoEUfXzkXyL3xSbTpKH9yDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.2.0-beta.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -12867,9 +12866,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.34.tgz",
-      "integrity": "sha512-kg25j+aCFCR/zkfn6U7JlH4Be4VEHO77cjfSLCQfOavQZ2nrXy9pvc9X88OBTYTCL7wLngIqAe0edt39bDk3tQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-G7gr9pJM/bDDtmW8fuXlUQZ+pNjFsypxM8gpd6bA7BbbBnZArdC8NlZvqfHgKYcaI27/CwIix2jlnz0okstjMg==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12879,9 +12878,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.11.56",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.56.tgz",
-      "integrity": "sha512-hEnN7DTVLGsol9Y/zaaDMDt1BZS/4KpMG419oCyM+MP1FVEOTp2BG/TDnIu7kXOwf66hCugBbnV84bvp2aY7SA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-w5C2qREyNZyc7bvGUvxzl5JetUkChFDTzZqW55qox+Iy6jiCkNILPTiArlHMlv/i04ymJ3B70Ftsr1j7V4lZrA==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12891,9 +12890,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.65.tgz",
-      "integrity": "sha512-kceZP68QrgFop387RYyO7tkfJCYxoktuceHTs9DQP3dJceLqj/V2mz0NlpkkacjgE5NhYkQ/zc0Z40hr8tnYqQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -12903,28 +12902,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.16.tgz",
-      "integrity": "sha512-D8/7CbjK1h3DCNm8p/Lp3RcVnnHI5+JX70Y5rJ2ewjjCZSsWixIEta2mnLX6eH5zQUpfHLl3EC3/mN2Q0MaJww==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.19.tgz",
+      "integrity": "sha512-cNmE7nEobZSSxbrnygmSqBASGXmEkk0ftA06qhQTwK/GiYJI6GK5ihRehsSbtatibopqBXB2s3TfsB2cN/IVzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.5.8",
+        "@apollo/client": "^3.11.9",
         "@cosmjs/amino": "^0.32.3",
         "@cosmjs/proto-signing": "^0.32.3",
         "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "0.0.34",
-        "@injectivelabs/dmm-proto-ts": "1.0.20",
-        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/core-proto-ts": "1.13.3",
+        "@injectivelabs/exceptions": "^1.14.19",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.11.56",
-        "@injectivelabs/mito-proto-ts": "1.0.65",
-        "@injectivelabs/networks": "^1.14.16",
-        "@injectivelabs/test-utils": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/indexer-proto-ts": "1.13.1",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.19",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "@metamask/eth-sig-util": "^4.0.0",
         "@noble/curves": "^1.4.0",
         "axios": "^1.6.4",
@@ -12981,15 +12980,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-DQU31rPOloLj3iBqsz9MAzNnCIawyN7mN0uCto441+RRMYGyyW/knVIY05rQyB/xDXXhuToCwQNxtEnu75uuwg==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-LH+D9NvycCjvcDjbGGFC7Ga/udErSZ2Yg54V627AZrZ3RjNwca1lG38/Ykm5ptQ4+iTtno8gkb3/XDEo5pWCUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -13148,9 +13147,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.34.tgz",
-      "integrity": "sha512-kg25j+aCFCR/zkfn6U7JlH4Be4VEHO77cjfSLCQfOavQZ2nrXy9pvc9X88OBTYTCL7wLngIqAe0edt39bDk3tQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-G7gr9pJM/bDDtmW8fuXlUQZ+pNjFsypxM8gpd6bA7BbbBnZArdC8NlZvqfHgKYcaI27/CwIix2jlnz0okstjMg==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13160,9 +13159,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.11.56",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.56.tgz",
-      "integrity": "sha512-hEnN7DTVLGsol9Y/zaaDMDt1BZS/4KpMG419oCyM+MP1FVEOTp2BG/TDnIu7kXOwf66hCugBbnV84bvp2aY7SA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-w5C2qREyNZyc7bvGUvxzl5JetUkChFDTzZqW55qox+Iy6jiCkNILPTiArlHMlv/i04ymJ3B70Ftsr1j7V4lZrA==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13172,9 +13171,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.65.tgz",
-      "integrity": "sha512-kceZP68QrgFop387RYyO7tkfJCYxoktuceHTs9DQP3dJceLqj/V2mz0NlpkkacjgE5NhYkQ/zc0Z40hr8tnYqQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13184,28 +13183,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.16.tgz",
-      "integrity": "sha512-D8/7CbjK1h3DCNm8p/Lp3RcVnnHI5+JX70Y5rJ2ewjjCZSsWixIEta2mnLX6eH5zQUpfHLl3EC3/mN2Q0MaJww==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.19.tgz",
+      "integrity": "sha512-cNmE7nEobZSSxbrnygmSqBASGXmEkk0ftA06qhQTwK/GiYJI6GK5ihRehsSbtatibopqBXB2s3TfsB2cN/IVzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.5.8",
+        "@apollo/client": "^3.11.9",
         "@cosmjs/amino": "^0.32.3",
         "@cosmjs/proto-signing": "^0.32.3",
         "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "0.0.34",
-        "@injectivelabs/dmm-proto-ts": "1.0.20",
-        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/core-proto-ts": "1.13.3",
+        "@injectivelabs/exceptions": "^1.14.19",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.11.56",
-        "@injectivelabs/mito-proto-ts": "1.0.65",
-        "@injectivelabs/networks": "^1.14.16",
-        "@injectivelabs/test-utils": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/indexer-proto-ts": "1.13.1",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.19",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "@metamask/eth-sig-util": "^4.0.0",
         "@noble/curves": "^1.4.0",
         "axios": "^1.6.4",
@@ -13414,9 +13413,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.34.tgz",
-      "integrity": "sha512-kg25j+aCFCR/zkfn6U7JlH4Be4VEHO77cjfSLCQfOavQZ2nrXy9pvc9X88OBTYTCL7wLngIqAe0edt39bDk3tQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-G7gr9pJM/bDDtmW8fuXlUQZ+pNjFsypxM8gpd6bA7BbbBnZArdC8NlZvqfHgKYcaI27/CwIix2jlnz0okstjMg==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13426,9 +13425,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.11.56",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.56.tgz",
-      "integrity": "sha512-hEnN7DTVLGsol9Y/zaaDMDt1BZS/4KpMG419oCyM+MP1FVEOTp2BG/TDnIu7kXOwf66hCugBbnV84bvp2aY7SA==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-w5C2qREyNZyc7bvGUvxzl5JetUkChFDTzZqW55qox+Iy6jiCkNILPTiArlHMlv/i04ymJ3B70Ftsr1j7V4lZrA==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13438,9 +13437,9 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.65",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.65.tgz",
-      "integrity": "sha512-kceZP68QrgFop387RYyO7tkfJCYxoktuceHTs9DQP3dJceLqj/V2mz0NlpkkacjgE5NhYkQ/zc0Z40hr8tnYqQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
@@ -13450,28 +13449,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.16",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.16.tgz",
-      "integrity": "sha512-D8/7CbjK1h3DCNm8p/Lp3RcVnnHI5+JX70Y5rJ2ewjjCZSsWixIEta2mnLX6eH5zQUpfHLl3EC3/mN2Q0MaJww==",
+      "version": "1.14.19",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.19.tgz",
+      "integrity": "sha512-cNmE7nEobZSSxbrnygmSqBASGXmEkk0ftA06qhQTwK/GiYJI6GK5ihRehsSbtatibopqBXB2s3TfsB2cN/IVzQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@apollo/client": "^3.5.8",
+        "@apollo/client": "^3.11.9",
         "@cosmjs/amino": "^0.32.3",
         "@cosmjs/proto-signing": "^0.32.3",
         "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "0.0.34",
-        "@injectivelabs/dmm-proto-ts": "1.0.20",
-        "@injectivelabs/exceptions": "^1.14.16",
+        "@injectivelabs/core-proto-ts": "1.13.3",
+        "@injectivelabs/exceptions": "^1.14.19",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.11.56",
-        "@injectivelabs/mito-proto-ts": "1.0.65",
-        "@injectivelabs/networks": "^1.14.16",
-        "@injectivelabs/test-utils": "^1.14.16",
-        "@injectivelabs/ts-types": "^1.14.16",
-        "@injectivelabs/utils": "^1.14.16",
+        "@injectivelabs/indexer-proto-ts": "1.13.1",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.19",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.19",
+        "@injectivelabs/ts-types": "^1.14.19",
+        "@injectivelabs/utils": "^1.14.19",
         "@metamask/eth-sig-util": "^4.0.0",
         "@noble/curves": "^1.4.0",
         "axios": "^1.6.4",
@@ -13528,40 +13527,31 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.0.3.tgz",
-      "integrity": "sha512-ni7msDLSCKOHSTyTTxEI9IPXlOtKtkpdyJ1i4LweOKP5qcncvLo4IJJU69C+kKc+8KwCpmz+VS+z9YAE6e+QHA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.2.0-beta.0.tgz",
+      "integrity": "sha512-JqVxZUWlrDdlG734+3F6EyiQJJok9ra90vCTF6HtV+T3ZY65eLGJq5hf/X4ChfNgEQ2bnJl2MsIAmv1v2opmjA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.0.3"
+        "@wormhole-foundation/sdk-base": "1.2.0-beta.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-0.5.1.tgz",
-      "integrity": "sha512-SzeRkJlxihXEoAojKgmxwvihwCMgh0qGqIlP4Rgxkso5ZFfwnYeqctuboHkLcuD9b91X8BZGKcdbPhuFPzMguQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-0.5.2.tgz",
+      "integrity": "sha512-D5SI0OyajEPHZ/xWdmb7YBcV2PIfNMh/baNgtSVo5evZGV14QtAmO2IKebkSQMPXls5ktmFPZxlBBbPfIESzOQ==",
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-definitions/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.3.tgz",
-      "integrity": "sha512-zhieqHzyopDN9Z60tqa1EBaJhjRsY56qgP9qpaXT7GkMgp5HI1j2msTaJrpVtVOnTKBt78uJXatKP7+pFDKiJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^1.1.3"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.0.3.tgz",
-      "integrity": "sha512-RI9t/s1AnuqMQzzGXjqCegKoOGo3RGH79uwj/u4xttkkQ2yxjZw8zXt/QwNQjBaa8F7OnOAMt9T5gAyl49BTGg==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.2.0-beta.0.tgz",
+      "integrity": "sha512-k5MnX4It0KMBftcpKdkOBa5dgzorZLhciIHrcPoLm1AxbbFBgrn7DBBMmC86j7j+nLY37cAlovH/fr657OR+rQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13569,13 +13559,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.0.3.tgz",
-      "integrity": "sha512-UfMyrZ4SNbKX+szw7NNPC8qSrP9jO3yEa+y2zVS67TyM0HB6/+pvg+vDaRN4H52kFmqRkIQDZjTNb7FbE5Z/ZA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.2.0-beta.0.tgz",
+      "integrity": "sha512-XUFAHGlxgYUMFPnNXgw+6+0FSc4hUyPea7obyQhqq29rKUsFEtk3oYTjytVT8mM+iORXDOaGn7Gfy2keY1sFwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-evm": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13583,13 +13573,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.0.3.tgz",
-      "integrity": "sha512-jpk2kamEMP9TAhAOaaD+yJhGVKm3h8yfEUPdyBKAcUvBMuRmf1RY410Z1PPqW9fOLaynFmzukd44ITsh8wsnIQ==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-t1EVzowdAhG5dpE8jedwkJ9SP586V1c0sUGa1Mpg0tW9MlkRFpAtW9gajizIXHpnKRDUoP5hUwU5HqixaUlxvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-evm": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13597,12 +13587,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-ntt": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-ntt/-/sdk-evm-ntt-0.5.1.tgz",
-      "integrity": "sha512-O2nX8LqzO2Jll5Bv4+UppzlLi+71v3SGKlmz6CTTNp5C98lq77YNbK/unjOtD5gtXMFb2r4bYn+yGRRZxDc3qA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-ntt/-/sdk-evm-ntt-0.5.2.tgz",
+      "integrity": "sha512-kaBKcI9dso3Iue6wSdxvFkkjwhVBpkhdLM2CUGF7cBPOPWFiRDiDdXikgLTL7gvlDP7wl9FqbFrReEQOFoYqxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-definitions-ntt": "0.5.1",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.2",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13616,15 +13606,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.0.3.tgz",
-      "integrity": "sha512-j0fXggpWb7OR4xDHiQtI5imd620akTVUMw7gL4TLYyAFg4nPDeXyLe3uG7uyfvMoJd6hhhSkVQE2AEZFok0WsA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.2.0-beta.0.tgz",
+      "integrity": "sha512-RHLwMbROkvVjE92UB1ZSMdmbnlANK9/53MKUiXxAPVSV2dnX4VhAGvLl7j9l/luW2GDTH7n5vCF0FRW3HeOU+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-evm": "1.0.3",
-        "@wormhole-foundation/sdk-evm-core": "1.0.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.2.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13632,14 +13622,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-2Fuxui8JET3chLs98WZAx2lqjGa4U8Gi3ulDFyCRGic/OkLRaWQhwKHW0+9qUYQgzbd5upvVBwMHtmcBzK3aiw==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-1n0zThq7OwhUsFcs4rMNCZD9WyH5YGyOIkyBoZygn/PhWJQp00StNsuVu/l+KSif9fySCnjPJMFibGEq0nKhIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-evm": "1.0.3",
-        "@wormhole-foundation/sdk-evm-core": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-evm-core": "1.2.0-beta.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -13654,15 +13644,24 @@
         "@wormhole-foundation/sdk-base": "1.0.2"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-route-ntt": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-route-ntt/-/sdk-route-ntt-0.5.1.tgz",
-      "integrity": "sha512-ZXNsBPCSUYs9BPepNXK8s7V+oZQCir/XkuCQ5u8YwVBsdBQ+4SNBipvOsBMiy7Cadoce6Twl6YnCmTZ3qy5zag==",
+    "node_modules/@wormhole-foundation/sdk-icons/node_modules/@wormhole-foundation/sdk-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.2.tgz",
+      "integrity": "sha512-5HIkquipfVDXu5EVvw1h9gclLVo+5PhQqlPN/ra3cT4iBJjjUcRSkRjTPi80G8pbynFS9ODP2hsBTuHdpbZgKg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-definitions-ntt": "0.5.1",
-        "@wormhole-foundation/sdk-evm-ntt": "0.5.1",
-        "@wormhole-foundation/sdk-solana-ntt": "0.5.1"
+        "@scure/base": "^1.1.3"
+      }
+    },
+    "node_modules/@wormhole-foundation/sdk-route-ntt": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-route-ntt/-/sdk-route-ntt-0.5.2.tgz",
+      "integrity": "sha512-GpvJUJOdD9zfOLG59Z74TcPOLNIHbyYCPN+ZHGfIgWOIT6hGvn4TXBwpSZlhpR9jS0V7eNbJXzCPiex5dN5/GQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.2",
+        "@wormhole-foundation/sdk-evm-ntt": "0.5.2",
+        "@wormhole-foundation/sdk-solana-ntt": "0.5.2"
       },
       "engines": {
         "node": ">=16"
@@ -13672,16 +13671,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.0.3.tgz",
-      "integrity": "sha512-HRR13E9qfgoYpcijc+UZU16ZRfB01Z4GqXyc1HuNpQRMvkwGWzBaBZOcmehmCITvU8izIW7DhGgSLWXraWL3hg==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.2.0-beta.0.tgz",
+      "integrity": "sha512-l8+qget8sDqy5M04U64X8gTj/BUNI1w2+IoIxYCdlMpTpm9PaYPtNE+ICIwOfMVf3nKFPpnjwwns0wD295JB8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -13689,16 +13688,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.0.3.tgz",
-      "integrity": "sha512-eyhvxRTcKwpj5KFWIbdyRN7xds16g/IT65ctJgUv5wdd+tEoESuVIK0Ad+11Ep5JtwmSdF6IiwcN0Sfl6ckG1Q==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.2.0-beta.0.tgz",
+      "integrity": "sha512-ceOPy+s7AkDWSsQ45KqpBDobWW0n2jPA3zGH//pNVdpwkoiPJ5JDPZfF/cXzT5Uwplk8BVbdEKrk3Ap8Uz4KxA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-solana": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -13722,32 +13721,32 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.0.3.tgz",
-      "integrity": "sha512-k65W7URd0vAw58UmIKibz+CkXijpVtAER46F9D+HZzSPGggcf/Ps9xfY285+fYMgAKSkyMqlLNrwsTR2STM/0w==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-ibuPLyhwLR3C7JgRB8lL062G71Le/NuhRhRhAnRoMDmjEI7UCGWHyISOZADz+9Xmb6JSYTAuXGHFquE/gsJZgA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-solana": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-ntt": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-0.5.1.tgz",
-      "integrity": "sha512-TT04yt3L9tVLzvVKkWUbHizwFj3755SoLpXVCtf6FvG/m35Hm2t24G2rbYEtzPaatBno+W9Y8MS8fr4LJS3jPA==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-0.5.2.tgz",
+      "integrity": "sha512-CMWyj0Jpaq1pqN3iOsVvYJ7hNvhyFgyI2sEKCOThDLIZC5CPnHhkxDhC+wj5vRLbZbHWkIlFYrzjH5V+pdU5IA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.4.0",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-definitions-ntt": "0.5.1",
+        "@wormhole-foundation/sdk-definitions-ntt": "0.5.2",
         "bn.js": "5.2.1"
       },
       "engines": {
@@ -13779,17 +13778,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-2ifcR3PZu/ggGrkzqlbgMlEEEELWBzOJXpPhE4gmMdynXMlZYl5HYOcx4qBnOTI336VjawPnTG+EFc54VeJoZA==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-nZHIkfSZd26/3auiOVkQ90v9OA7lboO3ML4BhYIwVWivVIRscTgtUDkUsEWCDU3W3p60D7taQz9jHWseAUjSZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.2",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-solana": "1.0.3",
-        "@wormhole-foundation/sdk-solana-core": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-solana-core": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -13830,27 +13829,27 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.0.3.tgz",
-      "integrity": "sha512-dsZ8ymv/sV0N6nmbcIquQJazBi1YNsqtKvIlhMqes0uS2iv+YvpPLfLKLzxn3KGWlXbteuJWdZtwOl/v3zhySQ==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.2.0-beta.0.tgz",
+      "integrity": "sha512-hED9mQJz7WbuDyCLmb5GeRWB1IzAcVVeBPjYFJN8haM64nRp7W5pBeUossKLYp6LpFIThHq1ww62IjjliVRDCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.0.3.tgz",
-      "integrity": "sha512-5JzbJpg81XWKcY3HsCDX17dxaEgs8wMzDwZhNI2cnyBDXD8rhhDMcbTfiOLxygPtjjrplTMW6JE/QHurdXEJWw==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.2.0-beta.0.tgz",
+      "integrity": "sha512-4p0bxp938KmeJghmGX7u0c/4uigqN264p1nbYBDcOFihN2zPg7sgbWrMFTsrVtaGv27xpsNrVdC4AVatP021Xg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-sui": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -13920,15 +13919,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.0.3.tgz",
-      "integrity": "sha512-lN8MLanfGUM7P3ISORITx9nYJTkFahrbd108pp8QTA6uA0kU4AW5FHLaNZoYxPGQZOhvQV6C94s3fQZFAYSi1w==",
+      "version": "1.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.2.0-beta.0.tgz",
+      "integrity": "sha512-m7bURPjYj085JHLulNyU0s/Uz+tL0ZuQz4RQ9f/usvQEtdefOcTxL6Lrv0u7JYcnN5QNHV6nhIHjiiXrRvXfsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
-        "@wormhole-foundation/sdk-connect": "1.0.3",
-        "@wormhole-foundation/sdk-sui": "1.0.3",
-        "@wormhole-foundation/sdk-sui-core": "1.0.3"
+        "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui": "1.2.0-beta.0",
+        "@wormhole-foundation/sdk-sui-core": "1.2.0-beta.0"
       },
       "engines": {
         "node": ">=16"
@@ -14058,15 +14057,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.3.tgz",
-      "integrity": "sha512-zhieqHzyopDN9Z60tqa1EBaJhjRsY56qgP9qpaXT7GkMgp5HI1j2msTaJrpVtVOnTKBt78uJXatKP7+pFDKiJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scure/base": "^1.1.3"
       }
     },
     "node_modules/@wry/caches": {
@@ -14694,6 +14684,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/binary-layout": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.0.3.tgz",
+      "integrity": "sha512-kpXCSOko4wbQaQswZk4IPcjVZwN77TKZgjMacdoX54EvUHAn/CzJclCt25SUmpXfzFrGovoq3LkPJkMy10bZxQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/binary-parser": {
       "version": "2.2.1",

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -156,7 +156,7 @@
     },
     "@mayanfinance/wormhole-sdk-route": {
       "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
-      "@wormhole-foundation/sdk-evm": "^1.2.0-beta.0",
+      "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
       "@wormhole-foundation/sdk-solana": "1.2.0-beta.0"
     },
     "@wormhole-foundation/sdk-definitions-ntt": {

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -40,13 +40,13 @@
     "@solana/spl-token": "^0.3.9",
     "@solana/wallet-adapter-wallets": "^0.19.25",
     "@solana/web3.js": "^1.95.2",
-    "@wormhole-foundation/sdk": "^1.0.3",
-    "@wormhole-foundation/sdk-definitions": "^1.0.3",
-    "@wormhole-foundation/sdk-definitions-ntt": "^0.5.1",
-    "@wormhole-foundation/sdk-evm-ntt": "^0.5.1",
+    "@wormhole-foundation/sdk": "1.2.0-beta.0",
+    "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
+    "@wormhole-foundation/sdk-definitions-ntt": "^0.5.2",
+    "@wormhole-foundation/sdk-evm-ntt": "^0.5.2",
     "@wormhole-foundation/sdk-icons": "^1.0.0",
-    "@wormhole-foundation/sdk-route-ntt": "^0.5.1",
-    "@wormhole-foundation/sdk-solana-ntt": "^0.5.1",
+    "@wormhole-foundation/sdk-route-ntt": "^0.5.2",
+    "@wormhole-foundation/sdk-solana-ntt": "^0.5.2",
     "@xlabs-libs/wallet-aggregator-aptos": "^0.0.1-alpha.14",
     "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18",
     "@xlabs-libs/wallet-aggregator-evm": "^0.0.2-alpha.2",
@@ -153,6 +153,30 @@
       "@ledgerhq/errors": "6.10.2",
       "@ledgerhq/logs": "6.12.0",
       "@ledgerhq/devices": "6.27.1"
+    },
+    "@mayanfinance/wormhole-sdk-route": {
+      "@wormhole-foundation/sdk-connect": "^1.2.0-beta.0",
+      "@wormhole-foundation/sdk-evm": "^1.2.0-beta.0",
+      "@wormhole-foundation/sdk-solana": "^1.2.0-beta.0"
+    },
+    "@wormhole-foundation/sdk-definitions-ntt": {
+      "@wormhole-foundation/sdk-base": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0"
+    },
+    "@wormhole-foundation/sdk-evm-ntt": {
+      "@wormhole-foundation/sdk-base": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-evm": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-evm-core": "1.2.0-beta.0"
+    },
+    "@wormhole-foundation/sdk-route-ntt": {
+      "@wormhole-foundation/sdk-connect": "1.2.0-beta.0"
+    },
+    "@wormhole-foundation/sdk-solana-ntt": {
+      "@wormhole-foundation/sdk-base": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-definitions": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-solana": "1.2.0-beta.0",
+      "@wormhole-foundation/sdk-solana-core": "1.2.0-beta.0"
     },
     "@wormhole-foundation/wormhole-connect": {
       "aptos": "1.5.0"

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -155,9 +155,9 @@
       "@ledgerhq/devices": "6.27.1"
     },
     "@mayanfinance/wormhole-sdk-route": {
-      "@wormhole-foundation/sdk-connect": "^1.2.0-beta.0",
+      "@wormhole-foundation/sdk-connect": "1.2.0-beta.0",
       "@wormhole-foundation/sdk-evm": "^1.2.0-beta.0",
-      "@wormhole-foundation/sdk-solana": "^1.2.0-beta.0"
+      "@wormhole-foundation/sdk-solana": "1.2.0-beta.0"
     },
     "@wormhole-foundation/sdk-definitions-ntt": {
       "@wormhole-foundation/sdk-base": "1.2.0-beta.0",


### PR DESCRIPTION
Notably, 1.2.0-beta.0 extracted out the layout code into a separate package which is backwards compatible.