### PR TITLE
Remove wallet type from sidebar and fix an issue with empty wallet address

### DIFF
--- a/wormhole-connect/src/hooks/useAvailableWallets.ts
+++ b/wormhole-connect/src/hooks/useAvailableWallets.ts
@@ -6,7 +6,7 @@ import { Chain } from '@wormhole-foundation/sdk';
 import config from 'config';
 import { WalletData, getWalletOptions } from 'utils/wallet';
 
-type walletOptions = {
+type WalletOptions = {
   state: 'result' | 'loading' | 'error';
   options?: WalletData[];
   error?: string;
@@ -18,7 +18,7 @@ type Props = {
 };
 
 type ReturnProps = {
-  walletOptionsResult: walletOptions;
+  walletOptionsResult: WalletOptions;
 };
 
 const FAILED_TO_LOAD_ERR =
@@ -27,7 +27,7 @@ const FAILED_TO_LOAD_ERR =
 export const useAvailableWallets = (props: Props): ReturnProps => {
   const { chain, supportedChains } = props;
 
-  const [walletOptionsResult, setWalletOptionsResult] = useState<walletOptions>(
+  const [walletOptionsResult, setWalletOptionsResult] = useState<WalletOptions>(
     {
       state: 'loading',
     },

--- a/wormhole-connect/src/hooks/useAvailableWallets.ts
+++ b/wormhole-connect/src/hooks/useAvailableWallets.ts
@@ -6,19 +6,11 @@ import { Chain } from '@wormhole-foundation/sdk';
 import config from 'config';
 import { WalletData, getWalletOptions } from 'utils/wallet';
 
-type GetWalletsLoading = {
-  state: 'loading';
+type walletOptions = {
+  state: 'result' | 'loading' | 'error';
+  options?: WalletData[];
+  error?: string;
 };
-type GetWalletsError = {
-  state: 'error';
-  error: string;
-};
-type GetWalletsResult = {
-  state: 'result';
-  options: WalletData[];
-};
-
-type GetWallets = GetWalletsLoading | GetWalletsError | GetWalletsResult;
 
 type Props = {
   chain: Chain | undefined;
@@ -26,7 +18,7 @@ type Props = {
 };
 
 type ReturnProps = {
-  walletOptionsResult: GetWallets;
+  walletOptionsResult: walletOptions;
 };
 
 const FAILED_TO_LOAD_ERR =
@@ -35,9 +27,11 @@ const FAILED_TO_LOAD_ERR =
 export const useAvailableWallets = (props: Props): ReturnProps => {
   const { chain, supportedChains } = props;
 
-  const [walletOptionsResult, setWalletOptionsResult] = useState<GetWallets>({
-    state: 'loading',
-  });
+  const [walletOptionsResult, setWalletOptionsResult] = useState<walletOptions>(
+    {
+      state: 'loading',
+    },
+  );
 
   useEffect(() => {
     let cancelled = false;

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -25,11 +25,13 @@ import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
 
 const useStyles = makeStyles()((theme) => ({
+  listButton: {
+    display: 'flex',
+    flexDirection: 'row',
+    padding: '12px 16px',
+  },
   drawer: {
     width: '360px',
-  },
-  context: {
-    opacity: 0.6,
   },
   notInstalled: {
     opacity: 0.6,
@@ -91,7 +93,7 @@ const WalletSidebar = (props: Props) => {
       props.onClose?.();
       await connectWallet(props.type, selectedChain, walletInfo, dispatch);
     },
-    [props.type, props.onClose, selectedChain],
+    [selectedChain, props, dispatch],
   );
 
   const renderWalletOptions = useCallback(
@@ -116,8 +118,8 @@ const WalletSidebar = (props: Props) => {
             walletsFiltered.map((wallet) => (
               <ListItemButton
                 key={wallet.name}
+                className={classes.listButton}
                 dense
-                sx={{ display: 'flex', flexDirection: 'row' }}
                 onClick={() =>
                   wallet.isReady
                     ? connect(wallet)
@@ -131,9 +133,6 @@ const WalletSidebar = (props: Props) => {
                   <div className={`${!wallet.isReady && classes.notInstalled}`}>
                     {!wallet.isReady && 'Install'} {wallet.name}
                   </div>
-                  <div className={classes.context}>
-                    {wallet.type.toUpperCase()}
-                  </div>
                 </Typography>
               </ListItemButton>
             ))
@@ -141,7 +140,7 @@ const WalletSidebar = (props: Props) => {
         </>
       );
     },
-    [connect, search],
+    [classes.listButton, classes.notInstalled, connect, search],
   );
 
   const sidebarContent = useMemo(() => {
@@ -191,7 +190,16 @@ const WalletSidebar = (props: Props) => {
         // TODO: Do we ever get to this case? If so, what should be the UI?
         return <></>;
     }
-  }, [walletOptionsResult, renderWalletOptions]);
+  }, [
+    walletOptionsResult.state,
+    walletOptionsResult.error,
+    walletOptionsResult.options,
+    classes.title,
+    classes.smOnly,
+    search,
+    props.onClose,
+    renderWalletOptions,
+  ]);
 
   return (
     <Drawer

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -71,13 +71,17 @@ const WalletConnector = (props: Props) => {
   );
 
   const connected = useMemo(() => {
+    if (!wallet?.address) {
+      return null;
+    }
+
     return (
       <div className={classes.connected}>{`Connected to ${displayWalletAddress(
         wallet.type,
         wallet.address,
       )}`}</div>
     );
-  }, []);
+  }, [classes.connected, wallet.address, wallet.type]);
 
   const disconnected = useMemo(() => {
     const button = (
@@ -122,7 +126,15 @@ const WalletConnector = (props: Props) => {
         </>
       );
     }
-  }, [disabled, isOpen, mobile, props.side, props.type]);
+  }, [
+    disabled,
+    isOpen,
+    mobile,
+    props.side,
+    props.type,
+    classes.connectWallet,
+    connectWallet,
+  ]);
 
   if (wallet && wallet.address) {
     return connected;


### PR DESCRIPTION
The main goal of this PR was to remove the wallet type in the sidebar. In addition to that I've fix a few `exhaustive-deps` issues and a bug where `wallet.address` being empty can throw an error.

**BEFORE:**
<img width="1055" alt="Screenshot 2024-11-25 at 3 34 55 PM" src="https://github.com/user-attachments/assets/00cd956d-ca36-4bc6-a869-8169d5648d70">

**AFTER:**
<img width="1068" alt="Screenshot 2024-11-25 at 3 20 00 PM" src="https://github.com/user-attachments/assets/95ce9d1d-91b4-4201-a4a7-8f4a33d404c2">
