### PR TITLE
Prevent amount input to auto-clear zero value strings as user is still typing, such as '0.00'

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -60,9 +60,11 @@ const DebouncedTextField = memo(
     );
 
     // Propagate any outside changes to the inner TextField value.
-    // Please note that we need to compare Number values, because '' and 0 are the same in terms of the amount value.
+    // Please note that we need to compare parsed values, because '' and 0 are the same in terms of the amount value.
     useEffect(() => {
-      if (Number(innerValue) !== Number(value)) {
+      const parsedInnerValue = sdkAmount.parse(innerValue, 0)?.amount;
+      const parsedValue = sdkAmount.parse(value, 0)?.amount;
+      if (parsedInnerValue !== parsedValue) {
         setInnerValue(value);
       }
     }, [value]);
@@ -133,9 +135,10 @@ const AmountInput = (props: Props) => {
 
   // Clear the amount input value if the amount is reset outside of this component
   // This can happen if user swaps selected source and destination assets.
-  // Please note that we need to compare Number values, because '' and 0 are the same in terms of the amount value.
+  // Please note that we need to compare parsed values, because '' and 0 are the same in terms of the amount value.
   useEffect(() => {
-    if (Number(amountInput) !== 0 && !amount) {
+    const parsedAmountInput = sdkAmount.parse(amountInput, 0)?.amount;
+    if (!amount && parsedAmountInput !== '0') {
       setAmountInput('');
     }
   }, [amount]);

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -39,7 +39,7 @@ const DebouncedTextField = memo(
     onChange: (event: string) => void;
   }) => {
     const [innerValue, setInnerValue] = useState<string>(value);
-    const defferedOnChange = useDebouncedCallback(onChange, INPUT_DEBOUNCE);
+    const deferredOnChange = useDebouncedCallback(onChange, INPUT_DEBOUNCE);
 
     const onInnerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
       (e) => {
@@ -54,13 +54,17 @@ const DebouncedTextField = memo(
         }
 
         setInnerValue(e.target.value);
-        defferedOnChange(e.target.value);
+        deferredOnChange(e.target.value);
       },
       [],
     );
 
+    // Propagate any outside changes to the inner TextField value.
+    // Please note that we need to compare Number values, because '' and 0 are the same in terms of the amount value.
     useEffect(() => {
-      setInnerValue(value);
+      if (Number(innerValue) !== Number(value)) {
+        setInnerValue(value);
+      }
     }, [value]);
 
     return <TextField {...props} value={innerValue} onChange={onInnerChange} />;
@@ -128,12 +132,13 @@ const AmountInput = (props: Props) => {
   );
 
   // Clear the amount input value if the amount is reset outside of this component
-  // This can happen if user swaps selected source and destination assets
+  // This can happen if user swaps selected source and destination assets.
+  // Please note that we need to compare Number values, because '' and 0 are the same in terms of the amount value.
   useEffect(() => {
-    if (amountInput && !amount) {
+    if (Number(amountInput) !== 0 && !amount) {
       setAmountInput('');
     }
-  }, [amount, amountInput]);
+  }, [amount]);
 
   const tokenBalance = useMemo(
     () => balances?.[sourceToken]?.balance || null,


### PR DESCRIPTION
This was a regression after fixing the swap-asset functionality. Please see the loom for more details.

https://www.loom.com/share/95a2e6770a1e4178a9413e1b66d24182?sid=1ccd5fe5-784f-4d2e-b172-5f070e8feff9
