### PR TITLE
fix styled_default is not a function attempt number 2

### DIFF
--- a/wormhole-connect/vite.config.ts
+++ b/wormhole-connect/vite.config.ts
@@ -91,7 +91,6 @@ const plugins = [
 const optimizeDeps = {
   include: [
     '@emotion/react',
-    '@emotion/styled',
     '@mui/material/Tooltip',
     '@mui/material/Unstable_Grid2',
   ],


### PR DESCRIPTION
I noticed that when I removed this line that the styled_default error would go away, but happen again when I added it back. I don't see the harm in just removing this line.