### PR TITLE
Show whWBTC and whWETH on Solana by default

### DIFF
--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -418,7 +418,13 @@ export const isWrappedToken = (token: TokenConfig, chain: Chain) => {
 // Canonical tokens may be Wormhole-wrapped tokens that are canonical on the chain
 // e.g., Wormhole-wrapped Ethereum USDC is canonical on Sui
 export const isCanonicalToken = (token: TokenConfig, chain: Chain) => {
-  return token.key === 'USDCeth' && chain === 'Sui';
+  if (token.key === 'USDCeth' && chain === 'Sui') return true;
+
+  // These tokens are highly liquid on Solana
+  if ((token.key === 'WETH' || token.key === 'WBTC') && chain === 'Solana')
+    return true;
+
+  return false;
 };
 
 export const isStableCoin = (token: TokenConfig) => {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f850d7af-6f2d-4993-9c5d-5f5ed1164d97)

These are highly liquid tokens, so display them even when the user doesn't have their wallet connected.