### PR TITLE
Adding validation when reading transaction from localStorage

### DIFF
--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -300,6 +300,7 @@ export interface Transaction {
   // In-progress status
   inProgress: boolean;
 }
+
 // Transanction data in local storage
 export interface TransactionLocal {
   receipt: routes.Receipt<AttestationReceipt>;


### PR DESCRIPTION
Adding simple validation of all required props when reading from localStorage. We need this to add more guarding for in-progress widget to enable it on Portal Bridge. 
AFAIK there is no runtime validation of types/interfaces available in Typescript libs. For this type of validation an alternative is to generate a JSON from the type/interface at build time and use that to validate the parsed objects from localStorage at runtime. This seems a bit of an overkill at this moment. That being said, in the future, if we happen to add more functionality around `TransactionLocal` interface; this would be a better way to type-guard the feature.