### PR TITLE
Display timeout error message for TransactionExpiredBlockheightExceededError as well

### DIFF
--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -35,7 +35,10 @@ export function interpretTransferError(
     if (INSUFFICIENT_ALLOWANCE_REGEX.test(e?.message)) {
       uiErrorMessage = 'Error with transfer, please try again';
       internalErrorCode = ERR_INSUFFICIENT_ALLOWANCE;
-    } else if (e.name === 'TransactionExpiredTimeoutError') {
+    } else if (
+      e.name === 'TransactionExpiredTimeoutError' ||
+      e.name === 'TransactionExpiredBlockheightExceededError'
+    ) {
       // Solana timeout
       uiErrorMessage = 'Transfer timed out, please try again';
       internalErrorCode = ERR_TIMEOUT;


### PR DESCRIPTION
This error type is also a result of a timeout when a transaction fails to be confirmed within a designated time. Therefore we can let the user to know about this and ask to retry. I added this error code to the existing timeout messaging, but please LMK if you think it's better to display another error message for this error 🙏 