### PR TITLE
Parse and display AmountInTooSmall error from Mayan

### DIFF
--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -61,9 +61,7 @@ export const ERR_DESTINATION_CONTRACT_PAUSED = 'destination_contract_paused';
 export const ERR_UNSUPPORTED_ABI_VERSION = 'unsupported_abi_version';
 export const ERR_INSUFFICIENT_GAS = 'insufficient_gas';
 export const ERR_AMOUNT_TOO_LARGE = 'amount_too_large';
-
-// Mayan errors
-export const ERR_AMOUNT_IN_TOO_SMALL = 'amount_too_small';
+export const ERR_AMOUNT_TOO_SMALL = 'amount_too_small';
 
 export const ERR_USER_REJECTED = 'user_rejected';
 export const ERR_TIMEOUT = 'user_timeout';
@@ -77,7 +75,7 @@ export type TransferErrorType =
   | typeof ERR_UNSUPPORTED_ABI_VERSION
   | typeof ERR_INSUFFICIENT_GAS
   | typeof ERR_AMOUNT_TOO_LARGE
-  | typeof ERR_AMOUNT_IN_TOO_SMALL
+  | typeof ERR_AMOUNT_TOO_SMALL
   | typeof ERR_USER_REJECTED
   | typeof ERR_TIMEOUT
   | typeof ERR_UNKNOWN;

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -54,7 +54,6 @@ export interface TokenDetails {
 }
 
 export const ERR_INSUFFICIENT_ALLOWANCE = 'insufficient_allowance';
-export const ERR_SWAP_FAILED = 'swap_failed';
 // NTT errors
 export const ERR_NOT_ENOUGH_CAPACITY = 'swap_failed';
 export const ERR_SOURCE_CONTRACT_PAUSED = 'source_contract_paused';
@@ -63,19 +62,22 @@ export const ERR_UNSUPPORTED_ABI_VERSION = 'unsupported_abi_version';
 export const ERR_INSUFFICIENT_GAS = 'insufficient_gas';
 export const ERR_AMOUNT_TOO_LARGE = 'amount_too_large';
 
+// Mayan errors
+export const ERR_AMOUNT_IN_TOO_SMALL = 'amount_too_small';
+
 export const ERR_USER_REJECTED = 'user_rejected';
 export const ERR_TIMEOUT = 'user_timeout';
 export const ERR_UNKNOWN = 'unknown';
 
 export type TransferErrorType =
   | typeof ERR_INSUFFICIENT_ALLOWANCE
-  | typeof ERR_SWAP_FAILED
   | typeof ERR_NOT_ENOUGH_CAPACITY
   | typeof ERR_SOURCE_CONTRACT_PAUSED
   | typeof ERR_DESTINATION_CONTRACT_PAUSED
   | typeof ERR_UNSUPPORTED_ABI_VERSION
   | typeof ERR_INSUFFICIENT_GAS
   | typeof ERR_AMOUNT_TOO_LARGE
+  | typeof ERR_AMOUNT_IN_TOO_SMALL
   | typeof ERR_USER_REJECTED
   | typeof ERR_TIMEOUT
   | typeof ERR_UNKNOWN;

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -10,7 +10,7 @@ import {
   ERR_UNKNOWN,
   ERR_USER_REJECTED,
   ERR_AMOUNT_TOO_LARGE,
-  ERR_AMOUNT_IN_TOO_SMALL,
+  ERR_AMOUNT_TOO_SMALL,
 } from 'telemetry/types';
 import { InsufficientFundsForGasError } from 'sdklegacy';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
@@ -51,7 +51,7 @@ export function interpretTransferError(
       internalErrorCode = ERR_USER_REJECTED;
     } else if (AMOUNT_IN_TOO_SMALL.test(e?.message)) {
       uiErrorMessage = 'Amount is too small for the selected route';
-      internalErrorCode = ERR_AMOUNT_IN_TOO_SMALL;
+      internalErrorCode = ERR_AMOUNT_TOO_SMALL;
     } else if (
       transferDetails.route.includes('CCTP') &&
       /burn.*exceed/i.test(e?.toString())

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -5,12 +5,12 @@ import type {
 } from 'telemetry/types';
 import {
   ERR_INSUFFICIENT_ALLOWANCE,
-  //ERR_SWAP_FAILED,
   ERR_INSUFFICIENT_GAS,
   ERR_TIMEOUT,
   ERR_UNKNOWN,
   ERR_USER_REJECTED,
   ERR_AMOUNT_TOO_LARGE,
+  ERR_AMOUNT_IN_TOO_SMALL,
 } from 'telemetry/types';
 import { InsufficientFundsForGasError } from 'sdklegacy';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
@@ -22,6 +22,7 @@ export const USER_REJECTED_REGEX = new RegExp(
   'user rejected|rejected the request|rejected from user|user cancel|aborted by user|plugin closed',
   'mi',
 );
+export const AMOUNT_IN_TOO_SMALL = new RegExp('AmountInTooSmall', 'm');
 
 export function interpretTransferError(
   e: any,
@@ -48,6 +49,9 @@ export function interpretTransferError(
     } else if (USER_REJECTED_REGEX.test(e?.message)) {
       uiErrorMessage = 'Transfer rejected in wallet, please try again';
       internalErrorCode = ERR_USER_REJECTED;
+    } else if (AMOUNT_IN_TOO_SMALL.test(e?.message)) {
+      uiErrorMessage = 'Amount is too small for the selected route';
+      internalErrorCode = ERR_AMOUNT_IN_TOO_SMALL;
     } else if (
       transferDetails.route.includes('CCTP') &&
       /burn.*exceed/i.test(e?.toString())


### PR DESCRIPTION
Although not very frequent, I've seen this error multiple times. It seems to be happening only in Mayan routes and I also found the error in Mayan code.
This PR adds a parsing for that error and shows a more helpful message for it: "Amount is too small for the selected route."