### PR TITLE
Wallet Connect storage prefix for Solana

### DIFF
--- a/wormhole-connect/src/utils/wallet/solana.ts
+++ b/wormhole-connect/src/utils/wallet/solana.ts
@@ -111,6 +111,7 @@ export function fetchOptions() {
                 : SolanaNetwork.Devnet,
               options: {
                 projectId: config.ui.walletConnectProjectId,
+                customStoragePrefix: 'wh-connect-solana-adapter',
               },
             }),
             connection,


### PR DESCRIPTION
Add a different storage prefix for the Solana WalletConnectAdapter in order to avoid state collisions if another wallet is connected through WC