### PR TITLE
Parsing decimals from WHScan api when available

### DIFF
--- a/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
@@ -44,6 +44,7 @@ interface WormholeScanTransaction {
       feeAddress: string;
       feeChain: number;
       fee: string;
+      normalizedDecimals?: number;
     };
   };
   sourceChain: {
@@ -172,7 +173,7 @@ const useTransactionHistoryWHScan = (
       sdkAmount.display(
         {
           amount: standarizedProperties.amount,
-          decimals: DECIMALS,
+          decimals: standarizedProperties.normalizedDecimals ?? DECIMALS,
         },
         0,
       );


### PR DESCRIPTION
WHScan API is now returning decimals for NTT transactions. I'm adding a check for that for all txs since this may become available for others as well.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/2980