### PR TITLE
clean up Axios versions, get rid of 1.7.9

### DIFF
--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -39,7 +39,7 @@
         "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
         "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",
         "aptos": "1.5.0",
-        "axios": "^1.7.9",
+        "axios": "1.4.0",
         "binary-parser": "^2.2.1",
         "ethers": "^6.4.2",
         "lz-string": "^1.5.0",
@@ -14701,11 +14701,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
+        "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -9,13 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.29.0",
-        "@cosmjs/cosmwasm-stargate": "^0.31.3",
-        "@cosmjs/stargate": "^0.31.3",
-        "@cosmjs/tendermint-rpc": "^0.31.3",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
-        "@injectivelabs/sdk-ts": "1.10.72",
-        "@injectivelabs/token-metadata": "1.10.42",
         "@ledgerhq/devices": "6.27.1",
         "@ledgerhq/errors": "6.10.2",
         "@ledgerhq/hw-transport": "6.27.1",
@@ -44,9 +39,8 @@
         "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
         "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",
         "aptos": "1.5.0",
-        "axios": "^1.2.4",
+        "axios": "^1.7.9",
         "binary-parser": "^2.2.1",
-        "cosmjs-types": "^0.9.0",
         "ethers": "^6.4.2",
         "lz-string": "^1.5.0",
         "material-ui-popup-state": "^5.0.4",
@@ -96,9 +90,9 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.8.tgz",
-      "integrity": "sha512-8BG6woLtDMvXB9Ajb/uE+Zr/U7y4qJ3upXi0JQHZmsKUJa7HjF/gFvmL2f3/mSmfZoQGRr9VoY97LCX2uaFMzA==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.12.tgz",
+      "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA==",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -151,10 +145,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.11.10",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.11.10.tgz",
-      "integrity": "sha512-IfGc+X4il0rDqVQBBWdxIKM+ciDCiDzBq9+Bg9z4tJMi87uF6po4v+ddiac1wP0ARgVPsFwEIGxK7jhN4pW8jg==",
-      "license": "MIT",
+      "version": "3.12.3",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.3.tgz",
+      "integrity": "sha512-KZ5zymRdb8bMbGUb1wP2U04ff7qIGgaC1BCdCVC+IPFiXkxEhHBc5fDEQOwAUT+vUo9KbBh3g7QK/JCOswn59w==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -174,8 +167,8 @@
       "peerDependencies": {
         "graphql": "^15.0.0 || ^16.0.0",
         "graphql-ws": "^5.5.5",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -203,16 +196,6 @@
       },
       "engines": {
         "node": ">=15.10.0"
-      }
-    },
-    "node_modules/@aptos-labs/aptos-client/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@artursapek/vite-plugin-checker": {
@@ -281,130 +264,13 @@
         }
       }
     },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.21.3"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@artursapek/vite-plugin-checker/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@babel/code-frame": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.25.7.tgz",
-      "integrity": "sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==",
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dependencies": {
-        "@babel/highlight": "^7.25.7",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
         "picocolors": "^1.0.0"
       },
       "engines": {
@@ -412,29 +278,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.7.tgz",
-      "integrity": "sha512-9ickoLz+hcXCeh7jrcin+/SLWm+GkxE2kTvoYyp38p4WkdFXfQJxDFGWp/YHjiKLPx06z2A7W8XKuqbReXDzsw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-      "integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helpers": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/template": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -450,11 +316,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.7.tgz",
-      "integrity": "sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
       "dependencies": {
-        "@babel/types": "^7.25.7",
+        "@babel/parser": "^7.26.3",
+        "@babel/types": "^7.26.3",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -464,36 +331,23 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.7.tgz",
-      "integrity": "sha512-4xwU8StnqnlIhhioZf1tqnVWeQ9pvH/ujS8hRfw/WOza+/a+1qv69BWNy+oY231maTCWgKWhfBU7kDpsds6zAA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dependencies": {
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.7.tgz",
-      "integrity": "sha512-12xfNeKNH7jubQNm7PAkzlLwEmCs1tfuX3UjIw6vP6QXi+leKh6+LyC/+Ed4EIQermwd58wsyh070yjDHFlNGg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.7.tgz",
-      "integrity": "sha512-DniTEax0sv6isaw6qSQSfV4gVRNtw2rte8HHM45t9ZR0xILaufBRNkpMifCRiAPyvL4ACD6v0gfCwCmtOQaV4A==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.25.7",
-        "@babel/helper-validator-option": "^7.25.7",
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -503,16 +357,16 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.7.tgz",
-      "integrity": "sha512-bD4WQhbkx80mAyj/WCm4ZHcF4rDxkoLFO6ph8/5/mQ3z4vAzltQXAmbc7GvVJx5H+lk5Mi5EmbTeox5nMGCsbw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-member-expression-to-functions": "^7.25.7",
-        "@babel/helper-optimise-call-expression": "^7.25.7",
-        "@babel/helper-replace-supers": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -523,13 +377,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.7.tgz",
-      "integrity": "sha512-byHhumTj/X47wJ6C6eLpK7wW/WBEcnUeb7D0FNc/jFQnQVw7DOso3Zz5u9x/zLrFVkHa89ZGDbkAa1D54NdrCQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
+      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "regexpu-core": "^6.1.1",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "regexpu-core": "^6.2.0",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -540,9 +394,9 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz",
-      "integrity": "sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -556,38 +410,37 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.7.tgz",
-      "integrity": "sha512-O31Ssjd5K6lPbTX9AAYpSKrZmLeagt9uwschJd+Ixo6QiRyfpvgtVQp8qrDR9UNFjZ8+DO34ZkdrN+BnPXemeA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.7.tgz",
-      "integrity": "sha512-o0xCgpNmRohmnoWKQ0Ij8IdddjyBFE4T2kagL/x6M3+4zUgc+4qTOUBoNe4XxDskt1HPKO007ZPiMgLDq2s7Kw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.7.tgz",
-      "integrity": "sha512-k/6f8dKG3yDz/qCwSM+RKovjMix563SLxQFo0UhRNo239SP6n9u5/eLtKD6EAjwta2JHJ49CsD8pms2HdNiMMQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.7",
-        "@babel/helper-simple-access": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -597,33 +450,33 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.7.tgz",
-      "integrity": "sha512-VAwcwuYhv/AT+Vfr28c9y6SHzTan1ryqrydSTFGjU0uDJHw3uZ+PduI8plCLkRsDnqK2DMEDmwrOQRsK/Ykjng==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz",
-      "integrity": "sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.7.tgz",
-      "integrity": "sha512-kRGE89hLnPfcz6fTrlNU+uhgcwv0mBE4Gv3P9Ke9kLVJYpi4AMVVEElXvB5CabrPZW4nCM8P8UyyjrzCM0O2sw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-wrap-function": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-wrap-function": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -633,13 +486,13 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.7.tgz",
-      "integrity": "sha512-iy8JhqlUW9PtZkd4pHM96v6BdJ66Ba9yWSE4z0W4TvSZwLBPkyDsiIU3ENe4SmrzRBs76F7rQXTy1lYC49n6Lw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.25.7",
-        "@babel/helper-optimise-call-expression": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-member-expression-to-functions": "^7.25.9",
+        "@babel/helper-optimise-call-expression": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -648,101 +501,75 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.7.tgz",
-      "integrity": "sha512-FPGAkJmyoChQeM+ruBGIDyrT2tKfZJO8NcxdC+CWNJi7N8/rZpSxK7yvBJ5O/nF1gfu5KzN7VKG3YVSLFfRSxQ==",
-      "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.7.tgz",
-      "integrity": "sha512-pPbNbchZBkPMD50K0p3JGcFMNLVUCuU/ABybm/PGNj4JiHrpmNyqqCphBk4i19xXtNV0JhldQJJtbSW5aUvbyA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "dependencies": {
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.7.tgz",
-      "integrity": "sha512-CbkjYdsJNHFk8uqpEkpCvRs3YRp9tY6FmFY7wLMSYuGYkrdUi7r2lc4/wqsvlHoMznX3WJ9IP8giGPq68T/Y6g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz",
-      "integrity": "sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.7.tgz",
-      "integrity": "sha512-ytbPLsm+GjArDYXJ8Ydr1c/KJuutjF2besPNbIZnZ6MKUxi/uTA22t2ymmA4WFjZFpjiAMO0xuuJPqK2nvDVfQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.7.tgz",
-      "integrity": "sha512-MA0roW3JF2bD1ptAaJnvcabsVlNQShUaThyJbCDD4bCp8NEgiFvpoqRI2YS22hHlc2thjO/fTg2ShLMC3jygAg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.7.tgz",
-      "integrity": "sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "peer": true,
       "dependencies": {
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.7.tgz",
-      "integrity": "sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.7.tgz",
-      "integrity": "sha512-aZn7ETtQsjjGG5HruveUK06cU3Hljuhd9Iojm4M8WWv3wLE6OkE5PWbDUkItmMgegmccaITudyuW5RPYrYlgWw==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
       "dependencies": {
-        "@babel/types": "^7.25.7"
+        "@babel/types": "^7.26.3"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -752,13 +579,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.7.tgz",
-      "integrity": "sha512-UV9Lg53zyebzD1DwQoT9mzkEKa922LNUp5YkTJ6Uta0RbyXaQNUgcvSt7qIu1PpPzVb6rd10OVNTzkyBGeVmxQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -768,12 +595,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.7.tgz",
-      "integrity": "sha512-GDDWeVLNxRIkQTnJn2pDOM1pkCgYdSqPeT1a9vh9yIqu2uzzgw1zcqEb+IJOhy+dTBMlNdThrDIksr2o09qrrQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -783,12 +610,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.7.tgz",
-      "integrity": "sha512-wxyWg2RYaSUYgmd9MR0FyRGyeOMQE/Uzr1wzd/g5cf5bwi9A4v6HFdDm7y1MgDtod/fLOSTZY6jDgV0xU9d5bA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -798,14 +625,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.7.tgz",
-      "integrity": "sha512-Xwg6tZpLxc4iQjorYsyGMyfJE7nP5MV8t/Ka58BgiA7Jw0fRqQNcANlLfdJ/yvBt9z9LD2We+BEkT7vLqZRWng==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/plugin-transform-optional-chaining": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -815,13 +642,13 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.7.tgz",
-      "integrity": "sha512-UVATLMidXrnH+GMUIuxq55nejlj02HP7F5ETyBONzP6G87fPBogG4CH6kxrSrdIuAjdwNO9VzyaYsrZPscWUrw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -849,76 +676,13 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-async-generators": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-properties": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-class-static-block": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-dynamic-import": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-      "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-      "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.3"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.7.tgz",
-      "integrity": "sha512-ZvZQRmME0zfJnDQnVBKYzHxXT7lYBB3Revz1GuS7oLXWMgqUPX4G+DDbT30ICClht9WKV34QVrZhSw6WdklwZQ==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -928,125 +692,29 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.7.tgz",
-      "integrity": "sha512-AqVo+dguCgmpi/3mYBdu9lkngOBlQ2w2vnNpa6gfiCxQZLzV4ZbhsXitJ2Yblkoe1VQwtHSaNmIaGll/26YWRw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-import-meta": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-json-strings": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.7.tgz",
-      "integrity": "sha512-ruZOnKO+ajVL/MVx+PwNBPOkrnXTXoWMtte1MBpegfCArhqOe3Bj52avVj1huLLxNKYKXYaSxZ2F+woK1ekXfw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-numeric-separator": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.10.4"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-object-rest-spread": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-syntax-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.8.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1067,27 +735,12 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-top-level-await": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.7.tgz",
-      "integrity": "sha512-rR+5FDjpCHqqZN2bzZm18bVYGaejGq5ZkpVCJLXor/+zlSrSoc4KWcHI0URVWjl/68Dyr1uwZUz/1njycEAv9g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1113,12 +766,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.7.tgz",
-      "integrity": "sha512-EJN2mKxDwfOUCPxMO6MUI58RN3ganiRAG/MS/S3HfB6QFNjroAMelQo/gybyYq97WerCBAZoyrAoW8Tzdq2jWg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1128,15 +781,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.7.tgz",
-      "integrity": "sha512-4B6OhTrwYKHYYgcwErvZjbmH9X5TxQBsaBHdzEIB4l71gR5jh/tuHGlb9in47udL2+wVUcOz5XXhhfhVJwEpEg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
+      "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-remap-async-to-generator": "^7.25.7",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-remap-async-to-generator": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1146,14 +798,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.7.tgz",
-      "integrity": "sha512-ZUCjAavsh5CESCmi/xCpX1qcCaAglzs/7tmuvoFnJgA1dM7gQplsguljoTg+Ru8WENpX89cQyAtWoaE0I3X3Pg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-remap-async-to-generator": "^7.25.7"
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-remap-async-to-generator": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1163,12 +815,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.7.tgz",
-      "integrity": "sha512-xHttvIM9fvqW+0a3tZlYcZYSBpSWzGBFIt/sYG3tcdSzBB8ZeVgz2gBP7Df+sM0N1850jrviYSSeUuc+135dmQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
+      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1178,12 +830,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.7.tgz",
-      "integrity": "sha512-ZEPJSkVZaeTFG/m2PARwLZQ+OG0vFIhPlKHK/JdIMy8DbRJ/htz6LRrTFtdzxi9EHmcwbNPAKDnadpNSIW+Aow==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
+      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1193,13 +845,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.7.tgz",
-      "integrity": "sha512-mhyfEW4gufjIqYFo9krXHJ3ElbFLIze5IDp+wQTxoPd+mwFb1NxatNAwmv8Q8Iuxv7Zc+q8EkiMQwc9IhyGf4g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1209,14 +861,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.25.7.tgz",
-      "integrity": "sha512-rvUUtoVlkDWtDWxGAiiQj0aNktTPn3eFynBcMC2IhsXweehwgdI9ODe+XjWw515kEmv22sSOTp/rxIRuTiB7zg==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1226,16 +877,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.7.tgz",
-      "integrity": "sha512-9j9rnl+YCQY0IGoeipXvnk3niWicIB6kCsWRGLwX241qSXpbA4MKxtp/EdvFxsc4zI5vqfLxzOd0twIJ7I99zg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-replace-supers": "^7.25.7",
-        "@babel/traverse": "^7.25.7",
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1246,13 +897,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.7.tgz",
-      "integrity": "sha512-QIv+imtM+EtNxg/XBKL3hiWjgdLjMOmZ+XzQwSgmBfKbfxUjBzGgVPklUuE55eq5/uVoh8gg3dqlrwR/jw3ZeA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/template": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/template": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1262,12 +913,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.7.tgz",
-      "integrity": "sha512-xKcfLTlJYUczdaM1+epcdh1UGewJqr9zATgrNHcLBcV2QmfvPPEixo/sK/syql9cEmbr7ulu5HMFG5vbbt/sEA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1277,13 +928,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.7.tgz",
-      "integrity": "sha512-kXzXMMRzAtJdDEgQBLF4oaiT6ZCU3oWHgpARnTKDAqPkDJ+bs3NrZb310YYevR5QlRo3Kn7dzzIdHbZm1VzJdQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1293,12 +944,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.7.tgz",
-      "integrity": "sha512-by+v2CjoL3aMnWDOyCIg+yxU9KXSRa9tN6MbqggH5xvymmr9p4AMjYkNlQy4brMceBnUyHZ9G8RnpvT8wP7Cfg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1308,13 +959,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.7.tgz",
-      "integrity": "sha512-HvS6JF66xSS5rNKXLqkk7L9c/jZ/cdIVIcoPVrnl8IsVpLggTjXs8OWekbLHs/VtYDDh5WXnQyeE3PPUGm22MA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1324,13 +975,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.7.tgz",
-      "integrity": "sha512-UvcLuual4h7/GfylKm2IAA3aph9rwvAM2XBA0uPKU3lca+Maai4jBjjEVUS568ld6kJcgbouuumCBhMd/Yz17w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1340,13 +990,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.7.tgz",
-      "integrity": "sha512-yjqtpstPfZ0h/y40fAXRv2snciYr0OAoMXY/0ClC7tm4C/nG5NJKmIItlaYlLbIVAWNfrYuy9dq1bE0SbX0PEg==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1356,13 +1005,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.7.tgz",
-      "integrity": "sha512-h3MDAP5l34NQkkNulsTNyjdaR+OiB0Im67VU//sFupouP8Q6m9Spy7l66DcaAQxtmCqGdanPByLsnwFttxKISQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1372,13 +1020,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.7.tgz",
-      "integrity": "sha512-n/TaiBGJxYFWvpJDfsxSj9lEEE44BFM1EPGz4KEiTipTgkoFVVcCmzAL3qA7fdQU96dpo4gGf5HBx/KnDvqiHw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
+      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1388,14 +1036,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.7.tgz",
-      "integrity": "sha512-5MCTNcjCMxQ63Tdu9rxyN6cAWurqfrDZ76qvVPrGYdBxIj+EawuuxTu/+dgJlhK5eRz3v1gLwp6XwS8XaX2NiQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1405,13 +1053,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-json-strings": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.7.tgz",
-      "integrity": "sha512-Ot43PrL9TEAiCe8C/2erAjXMeVSnE/BLEx6eyrKLNFCCw5jvhTHKyHxdI1pA0kz5njZRYAnMO2KObGqOCRDYSA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-json-strings": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1421,12 +1068,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.7.tgz",
-      "integrity": "sha512-fwzkLrSu2fESR/cm4t6vqd7ebNIopz2QHGtjoU+dswQo/P6lwAG04Q98lliE3jkz/XqnbGFLnUcE0q0CVUf92w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1436,13 +1083,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.7.tgz",
-      "integrity": "sha512-iImzbA55BjiovLyG2bggWS+V+OLkaBorNvc/yJoeeDQGztknRnDdYfp2d/UPmunZYEnZi6Lg8QcTmNMHOB0lGA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1452,12 +1098,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.7.tgz",
-      "integrity": "sha512-Std3kXwpXfRV0QtQy5JJcRpkqP8/wG4XL7hSKZmGlxPlDqmpXtEPRmhF7ztnlTCtUN3eXRUJp+sBEZjaIBVYaw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1467,13 +1113,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.7.tgz",
-      "integrity": "sha512-CgselSGCGzjQvKzghCvDTxKHP3iooenLpJDO842ehn5D2G5fJB222ptnDwQho0WjEvg7zyoxb9P+wiYxiJX5yA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1483,13 +1129,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.7.tgz",
-      "integrity": "sha512-L9Gcahi0kKFYXvweO6n0wc3ZG1ChpSFdgG+eV1WYZ3/dGbJK7vvk91FgGgak8YwRgrCuihF8tE/Xg07EkL5COg==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+      "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-simple-access": "^7.25.7"
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1499,15 +1144,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.7.tgz",
-      "integrity": "sha512-t9jZIvBmOXJsiuyOwhrIGs8dVcD6jDyg2icw1VL4A/g+FnWyJKwUfSSU2nwJuMV2Zqui856El9u+ElB+j9fV1g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "@babel/traverse": "^7.25.7"
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1517,13 +1162,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.7.tgz",
-      "integrity": "sha512-p88Jg6QqsaPh+EB7I9GJrIqi1Zt4ZBHUQtjw3z1bzEXcLh6GfPqzZJ6G+G1HBGKUNukT58MnKG7EN7zXQBCODw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-module-transforms": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1533,13 +1178,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.7.tgz",
-      "integrity": "sha512-BtAT9LzCISKG3Dsdw5uso4oV1+v2NlVXIIomKJgQybotJY3OwCwJmkongjHgwGKoZXd0qG5UZ12JUlDQ07W6Ow==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1549,12 +1194,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.7.tgz",
-      "integrity": "sha512-CfCS2jDsbcZaVYxRFo2qtavW8SpdzmBXC2LOI4oO0rP+JSRDxxF3inF4GcPsLgfb5FjkhXG5/yR/lxuRs2pySA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1564,13 +1209,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.7.tgz",
-      "integrity": "sha512-FbuJ63/4LEL32mIxrxwYaqjJxpbzxPVQj5a+Ebrc8JICV6YX8nE53jY+K0RZT3um56GoNWgkS2BQ/uLGTjtwfw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
+      "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1580,13 +1224,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.7.tgz",
-      "integrity": "sha512-8CbutzSSh4hmD+jJHIA8vdTNk15kAzOnFLVVgBSMGr28rt85ouT01/rezMecks9pkU939wDInImwCKv4ahU4IA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1596,15 +1239,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.7.tgz",
-      "integrity": "sha512-1JdVKPhD7Y5PvgfFy0Mv2brdrolzpzSoUq2pr6xsR+m+3viGGeHEokFKsCgOkbeFOQxfB1Vt2F0cPJLRpFI4Zg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.25.7"
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1614,13 +1256,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.7.tgz",
-      "integrity": "sha512-pWT6UXCEW3u1t2tcAGtE15ornCBvopHj9Bps9D2DsH15APgNVOTwwczGckX+WkAvBmuoYKRCFa4DK+jM8vh5AA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-replace-supers": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-replace-supers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1630,13 +1272,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.7.tgz",
-      "integrity": "sha512-m9obYBA39mDPN7lJzD5WkGGb0GO54PPLXsbcnj1Hyeu8mSRz7Gb4b1A6zxNX32ZuUySDK4G6it8SDFWD1nCnqg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1646,14 +1287,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.7.tgz",
-      "integrity": "sha512-h39agClImgPWg4H8mYVAbD1qP9vClFbEjqoJmt87Zen8pjqK8FTPUwrOXAvqu5soytwxrLMd2fx2KSCp2CHcNg==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1663,12 +1303,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.7.tgz",
-      "integrity": "sha512-FYiTvku63me9+1Nz7TOx4YMtW3tWXzfANZtrzHhUZrz4d47EEtMQhzFoZWESfXuAMMT5mwzD4+y1N8ONAX6lMQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1678,13 +1318,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.7.tgz",
-      "integrity": "sha512-KY0hh2FluNxMLwOCHbxVOKfdB5sjWG4M183885FmaqWWiGMhRZq4DQRKH6mHdEucbJnyDyYiZNwNG424RymJjA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1694,15 +1334,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.7.tgz",
-      "integrity": "sha512-LzA5ESzBy7tqj00Yjey9yWfs3FKy4EmJyKOSWld144OxkTji81WWnUT8nkLUn+imN/zHL8ZQlOu/MTUAhHaX3g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1712,12 +1351,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.7.tgz",
-      "integrity": "sha512-lQEeetGKfFi0wHbt8ClQrUSUMfEeI3MMm74Z73T9/kuz990yYVtfofjf3NuA42Jy3auFOpbjDyCSiIkTs1VIYw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1727,12 +1366,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.7.tgz",
-      "integrity": "sha512-mgDoQCRjrY3XK95UuV60tZlFCQGXEtMg8H+IsW72ldw1ih1jZhzYXbJvghmAEpg5UVhhnCeia1CkGttUvCkiMQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
+      "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
+        "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
       },
       "engines": {
@@ -1742,13 +1381,29 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.7.tgz",
-      "integrity": "sha512-3OfyfRRqiGeOvIWSagcwUTVk2hXBsr/ww7bLn6TRTuXnexA+Udov2icFOxFX9abaj4l96ooYkcNN1qi2Zvqwng==",
+    "node_modules/@babel/plugin-transform-regexp-modifiers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-reserved-words": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1758,12 +1413,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.7.tgz",
-      "integrity": "sha512-uBbxNwimHi5Bv3hUccmOFlUy3ATO6WagTApenHz9KzoIdn0XeACdB12ZJ4cjhuB2WSi80Ez2FWzJnarccriJeA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1773,13 +1428,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.7.tgz",
-      "integrity": "sha512-Mm6aeymI0PBh44xNIv/qvo8nmbkpZze1KvR8MkEqbIREDxoiWTi18Zr2jryfRMwDfVZF9foKh060fWgni44luw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1789,12 +1444,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.7.tgz",
-      "integrity": "sha512-ZFAeNkpGuLnAQ/NCsXJ6xik7Id+tHuS+NT+ue/2+rn/31zcdnupCdmunOizEaP0JsUmTFSTOPoQY7PkK2pttXw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1804,12 +1459,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.7.tgz",
-      "integrity": "sha512-SI274k0nUsFFmyQupiO7+wKATAmMFf8iFgq2O+vVFXZ0SV9lNfT1NGzBEhjquFmD8I9sqHLguH+gZVN3vww2AA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
+      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1819,12 +1474,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.7.tgz",
-      "integrity": "sha512-OmWmQtTHnO8RSUbL0NTdtpbZHeNTnm68Gj5pA4Y2blFNh+V4iZR68V1qL9cI37J21ZN7AaCnkfdHtLExQPf2uA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
+      "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1834,15 +1489,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.7.tgz",
-      "integrity": "sha512-VKlgy2vBzj8AmEzunocMun2fF06bsSWV+FvVXohtL6FGve/+L217qhHxRTVGHEDO/YR8IANcjzgJsd04J8ge5Q==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
+      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.25.7",
-        "@babel/helper-create-class-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.7",
-        "@babel/plugin-syntax-typescript": "^7.25.7"
+        "@babel/helper-annotate-as-pure": "^7.25.9",
+        "@babel/helper-create-class-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+        "@babel/plugin-syntax-typescript": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1852,12 +1507,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.7.tgz",
-      "integrity": "sha512-BN87D7KpbdiABA+t3HbVqHzKWUDN3dymLaTnPFAMyc8lV+KN3+YzNhVRNdinaCPA4AUqx7ubXbQ9shRjYBl3SQ==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1867,13 +1522,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.7.tgz",
-      "integrity": "sha512-IWfR89zcEPQGB/iB408uGtSPlQd3Jpq11Im86vUgcmSTcoWAiQMCTOa2K2yNNqFJEBVICKhayctee65Ka8OB0w==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1883,13 +1538,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.7.tgz",
-      "integrity": "sha512-8JKfg/hiuA3qXnlLx8qtv5HWRbgyFx2hMMtpDDuU2rTckpKkGu4ycK5yYHwuEa16/quXfoxHBIApEsNyMWnt0g==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1899,13 +1554,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.7.tgz",
-      "integrity": "sha512-YRW8o9vzImwmh4Q3Rffd09bH5/hvY0pxg+1H1i0f7APoUeg12G7+HhLj9ZFNIrYkgBXhIijPJ+IXypN0hLTIbw==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1915,88 +1570,74 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-      "integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
+      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.25.7",
-        "@babel/helper-compilation-targets": "^7.25.7",
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-validator-option": "^7.25.7",
-        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
-        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
-        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
+        "@babel/compat-data": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
+        "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
+        "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
         "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-        "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-class-static-block": "^7.14.5",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-import-assertions": "^7.25.7",
-        "@babel/plugin-syntax-import-attributes": "^7.25.7",
-        "@babel/plugin-syntax-import-meta": "^7.10.4",
-        "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-        "@babel/plugin-syntax-top-level-await": "^7.14.5",
+        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/plugin-syntax-import-attributes": "^7.26.0",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-        "@babel/plugin-transform-arrow-functions": "^7.25.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.7",
-        "@babel/plugin-transform-async-to-generator": "^7.25.7",
-        "@babel/plugin-transform-block-scoped-functions": "^7.25.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.7",
-        "@babel/plugin-transform-class-properties": "^7.25.7",
-        "@babel/plugin-transform-class-static-block": "^7.25.7",
-        "@babel/plugin-transform-classes": "^7.25.7",
-        "@babel/plugin-transform-computed-properties": "^7.25.7",
-        "@babel/plugin-transform-destructuring": "^7.25.7",
-        "@babel/plugin-transform-dotall-regex": "^7.25.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.25.7",
-        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-        "@babel/plugin-transform-dynamic-import": "^7.25.7",
-        "@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-        "@babel/plugin-transform-export-namespace-from": "^7.25.7",
-        "@babel/plugin-transform-for-of": "^7.25.7",
-        "@babel/plugin-transform-function-name": "^7.25.7",
-        "@babel/plugin-transform-json-strings": "^7.25.7",
-        "@babel/plugin-transform-literals": "^7.25.7",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
-        "@babel/plugin-transform-member-expression-literals": "^7.25.7",
-        "@babel/plugin-transform-modules-amd": "^7.25.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.25.7",
-        "@babel/plugin-transform-modules-systemjs": "^7.25.7",
-        "@babel/plugin-transform-modules-umd": "^7.25.7",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
-        "@babel/plugin-transform-new-target": "^7.25.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-        "@babel/plugin-transform-numeric-separator": "^7.25.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.25.7",
-        "@babel/plugin-transform-object-super": "^7.25.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-        "@babel/plugin-transform-optional-chaining": "^7.25.7",
-        "@babel/plugin-transform-parameters": "^7.25.7",
-        "@babel/plugin-transform-private-methods": "^7.25.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.25.7",
-        "@babel/plugin-transform-property-literals": "^7.25.7",
-        "@babel/plugin-transform-regenerator": "^7.25.7",
-        "@babel/plugin-transform-reserved-words": "^7.25.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.25.7",
-        "@babel/plugin-transform-spread": "^7.25.7",
-        "@babel/plugin-transform-sticky-regex": "^7.25.7",
-        "@babel/plugin-transform-template-literals": "^7.25.7",
-        "@babel/plugin-transform-typeof-symbol": "^7.25.7",
-        "@babel/plugin-transform-unicode-escapes": "^7.25.7",
-        "@babel/plugin-transform-unicode-property-regex": "^7.25.7",
-        "@babel/plugin-transform-unicode-regex": "^7.25.7",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
+        "@babel/plugin-transform-arrow-functions": "^7.25.9",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.9",
+        "@babel/plugin-transform-async-to-generator": "^7.25.9",
+        "@babel/plugin-transform-block-scoped-functions": "^7.25.9",
+        "@babel/plugin-transform-block-scoping": "^7.25.9",
+        "@babel/plugin-transform-class-properties": "^7.25.9",
+        "@babel/plugin-transform-class-static-block": "^7.26.0",
+        "@babel/plugin-transform-classes": "^7.25.9",
+        "@babel/plugin-transform-computed-properties": "^7.25.9",
+        "@babel/plugin-transform-destructuring": "^7.25.9",
+        "@babel/plugin-transform-dotall-regex": "^7.25.9",
+        "@babel/plugin-transform-duplicate-keys": "^7.25.9",
+        "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-dynamic-import": "^7.25.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.25.9",
+        "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+        "@babel/plugin-transform-for-of": "^7.25.9",
+        "@babel/plugin-transform-function-name": "^7.25.9",
+        "@babel/plugin-transform-json-strings": "^7.25.9",
+        "@babel/plugin-transform-literals": "^7.25.9",
+        "@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.25.9",
+        "@babel/plugin-transform-modules-amd": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-modules-systemjs": "^7.25.9",
+        "@babel/plugin-transform-modules-umd": "^7.25.9",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
+        "@babel/plugin-transform-new-target": "^7.25.9",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.25.9",
+        "@babel/plugin-transform-numeric-separator": "^7.25.9",
+        "@babel/plugin-transform-object-rest-spread": "^7.25.9",
+        "@babel/plugin-transform-object-super": "^7.25.9",
+        "@babel/plugin-transform-optional-catch-binding": "^7.25.9",
+        "@babel/plugin-transform-optional-chaining": "^7.25.9",
+        "@babel/plugin-transform-parameters": "^7.25.9",
+        "@babel/plugin-transform-private-methods": "^7.25.9",
+        "@babel/plugin-transform-private-property-in-object": "^7.25.9",
+        "@babel/plugin-transform-property-literals": "^7.25.9",
+        "@babel/plugin-transform-regenerator": "^7.25.9",
+        "@babel/plugin-transform-regexp-modifiers": "^7.26.0",
+        "@babel/plugin-transform-reserved-words": "^7.25.9",
+        "@babel/plugin-transform-shorthand-properties": "^7.25.9",
+        "@babel/plugin-transform-spread": "^7.25.9",
+        "@babel/plugin-transform-sticky-regex": "^7.25.9",
+        "@babel/plugin-transform-template-literals": "^7.25.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.25.9",
+        "@babel/plugin-transform-unicode-escapes": "^7.25.9",
+        "@babel/plugin-transform-unicode-property-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-regex": "^7.25.9",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
         "babel-plugin-polyfill-corejs3": "^0.10.6",
@@ -2038,15 +1679,15 @@
       }
     },
     "node_modules/@babel/preset-typescript": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
-      "integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
+      "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.7",
-        "@babel/helper-validator-option": "^7.25.7",
-        "@babel/plugin-syntax-jsx": "^7.25.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.25.7",
-        "@babel/plugin-transform-typescript": "^7.25.7"
+        "@babel/helper-plugin-utils": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "@babel/plugin-syntax-jsx": "^7.25.9",
+        "@babel/plugin-transform-modules-commonjs": "^7.25.9",
+        "@babel/plugin-transform-typescript": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2056,9 +1697,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
-      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2067,28 +1708,28 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.7.tgz",
-      "integrity": "sha512-wRwtAgI3bAS+JGU2upWNL9lSlDcRCqD05BZ1n3X2ONLH1WilFP6O1otQjeMK/1g0pvYcXC7b/qVUB1keofjtZA==",
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/types": "^7.25.7"
+        "@babel/code-frame": "^7.25.9",
+        "@babel/parser": "^7.25.9",
+        "@babel/types": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.7.tgz",
-      "integrity": "sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==",
+      "version": "7.26.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
       "dependencies": {
-        "@babel/code-frame": "^7.25.7",
-        "@babel/generator": "^7.25.7",
-        "@babel/parser": "^7.25.7",
-        "@babel/template": "^7.25.7",
-        "@babel/types": "^7.25.7",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.3",
+        "@babel/parser": "^7.26.3",
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.3",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2097,13 +1738,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.7.tgz",
-      "integrity": "sha512-vwIVdXG+j+FOpkwqHRcBgHLYNL7XMkufrlaFvL9o6Ai9sJn9+PdyIL5qa0XzTZw084c+u9LOls53eoZWP/W5WQ==",
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.7",
-        "@babel/helper-validator-identifier": "^7.25.7",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2220,20 +1860,6 @@
         "js-base64": "^3.7.5"
       }
     },
-    "node_modules/@binance/w3w-qrcode-modal/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2251,22 +1877,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
-    },
-    "node_modules/@binance/w3w-qrcode-modal/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@binance/w3w-qrcode-modal/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2407,11 +2017,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@binance/w3w-qrcode-modal/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -2496,26 +2101,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
-    },
-    "node_modules/@binance/w3w-socket-transport/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@binance/w3w-types": {
       "version": "1.1.4",
@@ -2628,9 +2213,9 @@
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/preact": {
-      "version": "10.24.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "version": "10.25.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
+      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2643,6 +2228,31 @@
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/@confio/ics23/node_modules/protobufjs": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
       }
     },
     "node_modules/@coral-xyz/anchor": {
@@ -2685,51 +2295,41 @@
       }
     },
     "node_modules/@cosmjs/amino": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.31.3.tgz",
-      "integrity": "sha512-36emtUq895sPRX8PTSOnG+lhJDCVyIcE0Tr5ct59sUbgQiI14y43vj/4WAlJ/utSOxy+Zhj9wxcs4AZfu0BHsw==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
+      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3"
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.31.3.tgz",
-      "integrity": "sha512-Uv9TmCn3650gdFeZm7SEfUZF3uX3lfJfFhXOk6I2ZLr/FrKximnlb+vwAfZaZnWYvlA7qrKtHIjeRNHvT23zcw==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
+      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
       "dependencies": {
-        "@cosmjs/amino": "^0.31.3",
-        "@cosmjs/crypto": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/proto-signing": "^0.31.3",
-        "@cosmjs/stargate": "^0.31.3",
-        "@cosmjs/tendermint-rpc": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3",
-        "cosmjs-types": "^0.8.0",
-        "long": "^4.0.0",
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/proto-signing": "^0.32.4",
+        "@cosmjs/stargate": "^0.32.4",
+        "@cosmjs/tendermint-rpc": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0",
         "pako": "^2.0.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/cosmjs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
-      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
+      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
       "dependencies": {
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
         "elliptic": "^6.5.4",
@@ -2737,131 +2337,127 @@
       }
     },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
-      "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
+      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
         "readonly-date": "^1.0.0"
       }
     },
+    "node_modules/@cosmjs/encoding/node_modules/bech32": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
     "node_modules/@cosmjs/json-rpc": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.31.3.tgz",
-      "integrity": "sha512-7LVYerXjnm69qqYR3uA6LGCrBW2EO5/F7lfJxAmY+iII2C7xO3a0vAjMSt5zBBh29PXrJVS6c2qRP22W1Le2Wg==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
+      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
       "dependencies": {
-        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/stream": "^0.32.4",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/math": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
-      "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
+      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.31.3.tgz",
-      "integrity": "sha512-24+10/cGl6lLS4VCrGTCJeDRPQTn1K5JfknzXzDIHOx8THR31JxA7/HV5eWGHqWgAbudA7ccdSvEK08lEHHtLA==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
       "dependencies": {
-        "@cosmjs/amino": "^0.31.3",
-        "@cosmjs/crypto": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3",
-        "cosmjs-types": "^0.8.0",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@cosmjs/proto-signing/node_modules/cosmjs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
       }
     },
     "node_modules/@cosmjs/socket": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.31.3.tgz",
-      "integrity": "sha512-aqrDGGi7os/hsz5p++avI4L0ZushJ+ItnzbqA7C6hamFSCJwgOkXaOUs+K9hXZdX4rhY7rXO4PH9IH8q09JkTw==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
+      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
       "dependencies": {
-        "@cosmjs/stream": "^0.31.3",
+        "@cosmjs/stream": "^0.32.4",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
+    "node_modules/@cosmjs/socket/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@cosmjs/stargate": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.31.3.tgz",
-      "integrity": "sha512-53NxnzmB9FfXpG4KjOUAYAvWLYKdEmZKsutcat/u2BrDXNZ7BN8jim/ENcpwXfs9/Og0K24lEIdvA4gsq3JDQw==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
+      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/proto-signing": "^0.31.3",
-        "@cosmjs/stream": "^0.31.3",
-        "@cosmjs/tendermint-rpc": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3",
-        "cosmjs-types": "^0.8.0",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.3",
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/proto-signing": "^0.32.4",
+        "@cosmjs/stream": "^0.32.4",
+        "@cosmjs/tendermint-rpc": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0",
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.8.0.tgz",
-      "integrity": "sha512-Q2Mj95Fl0PYMWEhA2LuGEIhipF7mQwd9gTQ85DdP9jjjopeoGaDxvmPa5nakNzsq7FnO1DMTatXTAx6bxMH7Lg==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
     "node_modules/@cosmjs/stream": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.31.3.tgz",
-      "integrity": "sha512-8keYyI7X0RjsLyVcZuBeNjSv5FA4IHwbFKx7H60NHFXszN8/MvXL6aZbNIvxtcIHHsW7K9QSQos26eoEWlAd+w==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
+      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.31.3.tgz",
-      "integrity": "sha512-s3TiWkPCW4QceTQjpYqn4xttUJH36mTPqplMl+qyocdqk5+X5mergzExU/pHZRWQ4pbby8bnR7kMvG4OC1aZ8g==",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
+      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
       "dependencies": {
-        "@cosmjs/crypto": "^0.31.3",
-        "@cosmjs/encoding": "^0.31.3",
-        "@cosmjs/json-rpc": "^0.31.3",
-        "@cosmjs/math": "^0.31.3",
-        "@cosmjs/socket": "^0.31.3",
-        "@cosmjs/stream": "^0.31.3",
-        "@cosmjs/utils": "^0.31.3",
-        "axios": "^0.21.2",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/json-rpc": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/socket": "^0.32.4",
+        "@cosmjs/stream": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "axios": "^1.6.0",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
     "node_modules/@cosmjs/utils": {
-      "version": "0.31.3",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
-      "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
+      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -2873,15 +2469,15 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
-      "integrity": "sha512-y2WQb+oP8Jqvvclh8Q55gLUyb7UFvgv7eJfsj7td5TToBrIUtPay2kMrZi4xjq9qw2vD0ZR5fSho0yqoFgX7Rw==",
+      "version": "11.13.5",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
-        "@emotion/serialize": "^1.2.0",
+        "@emotion/serialize": "^1.3.3",
         "babel-plugin-macros": "^3.1.0",
         "convert-source-map": "^1.5.0",
         "escape-string-regexp": "^4.0.0",
@@ -2896,13 +2492,13 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/@emotion/cache": {
-      "version": "11.13.1",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.13.1.tgz",
-      "integrity": "sha512-iqouYkuEblRcXmylXIwwOodiEK5Ifl7JcX7o6V4jI3iW4mLXX3dmt5xwBtIkJiQEXFAI+pC8X0i67yiPkH9Ucw==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
-        "@emotion/utils": "^1.4.0",
+        "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
       }
@@ -2926,16 +2522,16 @@
       "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/react": {
-      "version": "11.13.3",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.3.tgz",
-      "integrity": "sha512-lIsdU6JNrmYfJ5EbUCf4xW1ovy5wKQ2CkPRM4xogziOxH1nXxBSjpC9YqbFAP7circxMfYp+6x676BqWcEiixg==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.12.0",
-        "@emotion/cache": "^11.13.0",
-        "@emotion/serialize": "^1.3.1",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
-        "@emotion/utils": "^1.4.0",
+        "@emotion/babel-plugin": "^11.13.5",
+        "@emotion/cache": "^11.14.0",
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "hoist-non-react-statics": "^3.3.1"
       },
@@ -2949,14 +2545,14 @@
       }
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.2.tgz",
-      "integrity": "sha512-grVnMvVPK9yUVE6rkKfAJlYZgo0cu3l9iMC77V7DW6E1DUIrU68pSEXRmFZFOFB1QFo57TncmOcvcbMDWsL4yA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
         "@emotion/unitless": "^0.10.0",
-        "@emotion/utils": "^1.4.1",
+        "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
       }
     },
@@ -2966,16 +2562,16 @@
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
-      "version": "11.13.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.13.0.tgz",
-      "integrity": "sha512-tkzkY7nQhW/zC4hztlwucpT8QEZ6eUzpXDRhww/Eej4tFfO0FxQYWRyg/c5CCXa4d/f174kqeXYjuQRnhzf6dA==",
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.12.0",
+        "@emotion/babel-plugin": "^11.13.5",
         "@emotion/is-prop-valid": "^1.3.0",
-        "@emotion/serialize": "^1.3.0",
-        "@emotion/use-insertion-effect-with-fallbacks": "^1.1.0",
-        "@emotion/utils": "^1.4.0"
+        "@emotion/serialize": "^1.3.3",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.2.0",
+        "@emotion/utils": "^1.4.2"
       },
       "peerDependencies": {
         "@emotion/react": "^11.0.0-rc.0",
@@ -2993,17 +2589,17 @@
       "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.1.0.tgz",
-      "integrity": "sha512-+wBOcIV5snwGgI2ya3u99D7/FJquOIniQT1IKyDsBmEgwvpxMNeS65Oib7OnE2d2aY+3BU4OiH+0Wchf8yk3Hw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/utils": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.1.tgz",
-      "integrity": "sha512-BymCXzCG3r72VKJxaYVwOXATqXIZ85cuvg0YOUDxMGNrKc1DJRZk8MgV5wyXRyEayIMd4FuXJIUgTBXvDNW5cA=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
@@ -3389,24 +2985,27 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -3675,25 +3274,6 @@
         "@ethersproject/bytes": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/basex": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz",
-      "integrity": "sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
@@ -3750,33 +3330,6 @@
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/contracts": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz",
-      "integrity": "sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "^5.7.0",
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
@@ -3802,70 +3355,6 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
       }
-    },
-    "node_modules/@ethersproject/hdnode": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz",
-      "integrity": "sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz",
-      "integrity": "sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/pbkdf2": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "aes-js": "3.0.0",
-        "scrypt-js": "3.0.1"
-      }
-    },
-    "node_modules/@ethersproject/json-wallets/node_modules/aes-js": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
-      "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
@@ -3919,25 +3408,6 @@
         "@ethersproject/logger": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/pbkdf2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz",
-      "integrity": "sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/properties": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
@@ -3953,82 +3423,6 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/providers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz",
-      "integrity": "sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/base64": "^5.7.0",
-        "@ethersproject/basex": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/networks": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/web": "^5.7.0",
-        "bech32": "1.1.4",
-        "ws": "7.4.6"
-      }
-    },
-    "node_modules/@ethersproject/providers/node_modules/ws": {
-      "version": "7.4.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ethersproject/random": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz",
-      "integrity": "sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
       }
     },
@@ -4049,26 +3443,6 @@
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/sha2": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz",
-      "integrity": "sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "hash.js": "1.1.7"
       }
     },
     "node_modules/@ethersproject/signing-key": {
@@ -4109,32 +3483,9 @@
       }
     },
     "node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/@ethersproject/strings": {
       "version": "5.7.0",
@@ -4182,58 +3533,6 @@
         "@ethersproject/signing-key": "^5.7.0"
       }
     },
-    "node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/wallet": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz",
-      "integrity": "sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abstract-provider": "^5.7.0",
-        "@ethersproject/abstract-signer": "^5.7.0",
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
-        "@ethersproject/hdnode": "^5.7.0",
-        "@ethersproject/json-wallets": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/random": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0",
-        "@ethersproject/transactions": "^5.7.0",
-        "@ethersproject/wordlists": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
@@ -4251,28 +3550,6 @@
       "dependencies": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/wordlists": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz",
-      "integrity": "sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/hash": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/strings": "^5.7.0"
@@ -4409,9 +3686,9 @@
       "dev": true
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.14.tgz",
-      "integrity": "sha512-NZWlgBzgVrXow9IknFQHvcYKX4QkUD25taRigoNYQK8PDn4+VXd9xM5WFUDRhzm2smTCguyl/+MghpEp4oTPWw==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
+      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -4419,39 +3696,18 @@
         "rxjs": "^7.4.0"
       }
     },
-    "node_modules/@injectivelabs/core-proto-ts/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
+    "node_modules/@injectivelabs/core-proto-ts/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/exceptions": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.33.tgz",
       "integrity": "sha512-2c8YzLgwTOOsyc1WheqdM8jEfgGBhVrXN4cZ0jsikFVsLF619IDRn3hjIYqTeNERaEpeRPiuJGfZDu0DomwFrQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -4487,9 +3743,9 @@
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.10.8-rc.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.10.8-rc.4.tgz",
-      "integrity": "sha512-IwbepTfsHHAv3Z36As6yH/+HIplOEpUu6SFHBCVgdSIaQ8GuvTib4HETiVnV4mjYqoyVgWs+zLSAfih46rdMJQ==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -4497,38 +3753,18 @@
         "rxjs": "^7.4.0"
       }
     },
-    "node_modules/@injectivelabs/indexer-proto-ts/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
+    "node_modules/@injectivelabs/indexer-proto-ts/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.9.tgz",
-      "integrity": "sha512-+TZMvJ4SHwcn6SFPdqaiQFZdNhjH7hyRFozY15nOTC2utdGij9jEsjz1NsyOejfYDA0s1z5Wm1SgrMYKaVpAmQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -4536,39 +3772,18 @@
         "rxjs": "^7.4.0"
       }
     },
-    "node_modules/@injectivelabs/mito-proto-ts/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
+    "node_modules/@injectivelabs/mito-proto-ts/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/networks": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
       "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -4587,292 +3802,59 @@
         "rxjs": "^7.4.0"
       }
     },
-    "node_modules/@injectivelabs/olp-proto-ts/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@injectivelabs/olp-proto-ts/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
+    "node_modules/@injectivelabs/olp-proto-ts/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.10.72",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.10.72.tgz",
-      "integrity": "sha512-A5mHNNBgO4fI1c/7CZ0bGfVXliy8laP+VaYZ++aWh1YyudoZw4CTCEmLetZRy7AUU3XcfbHa8sAImRi7db+v6Q==",
-      "hasInstallScript": true,
+      "version": "1.14.33",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
+      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
       "dependencies": {
-        "@apollo/client": "^3.5.8",
-        "@cosmjs/amino": "^0.30.1",
-        "@cosmjs/proto-signing": "^0.30.1",
-        "@cosmjs/stargate": "^0.30.1",
+        "@apollo/client": "^3.11.10",
+        "@cosmjs/amino": "^0.32.3",
+        "@cosmjs/proto-signing": "^0.32.3",
+        "@cosmjs/stargate": "^0.32.3",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "^0.0.14",
-        "@injectivelabs/exceptions": "^1.10.12",
+        "@injectivelabs/core-proto-ts": "1.13.4",
+        "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.10.8-rc.4",
-        "@injectivelabs/mito-proto-ts": "1.0.9",
-        "@injectivelabs/networks": "^1.10.12",
-        "@injectivelabs/test-utils": "^1.10.12",
-        "@injectivelabs/token-metadata": "^1.10.42",
-        "@injectivelabs/ts-types": "^1.10.12",
-        "@injectivelabs/utils": "^1.10.12",
+        "@injectivelabs/indexer-proto-ts": "1.13.3",
+        "@injectivelabs/mito-proto-ts": "1.13.0",
+        "@injectivelabs/networks": "^1.14.33",
+        "@injectivelabs/olp-proto-ts": "1.13.1",
+        "@injectivelabs/test-utils": "^1.14.33",
+        "@injectivelabs/ts-types": "^1.14.33",
+        "@injectivelabs/utils": "^1.14.33",
         "@metamask/eth-sig-util": "^4.0.0",
-        "axios": "^0.27.2",
+        "@noble/curves": "^1.4.0",
+        "axios": "^1.6.4",
         "bech32": "^2.0.0",
         "bip39": "^3.0.4",
-        "cosmjs-types": "^0.7.1",
-        "eth-crypto": "^2.6.0",
+        "cosmjs-types": "^0.9.0",
         "ethereumjs-util": "^7.1.4",
-        "ethers": "^5.7.2",
+        "ethers": "^6.5.1",
         "google-protobuf": "^3.21.0",
         "graphql": "^16.3.0",
         "http-status-codes": "^2.2.0",
         "js-sha3": "^0.8.0",
         "jscrypto": "^1.0.3",
         "keccak256": "^1.0.6",
-        "link-module-alias": "^1.2.0",
-        "rxjs": "^7.8.0",
         "secp256k1": "^4.0.3",
         "shx": "^0.3.2",
         "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/amino": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.30.1.tgz",
-      "integrity": "sha512-yNHnzmvAlkETDYIpeCTdVqgvrdt1qgkOXwuRVi8s27UKI5hfqyE9fJ/fuunXE6ZZPnKkjIecDznmuUOMrMvw4w==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.30.1",
-        "@cosmjs/encoding": "^0.30.1",
-        "@cosmjs/math": "^0.30.1",
-        "@cosmjs/utils": "^0.30.1"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/crypto": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.30.1.tgz",
-      "integrity": "sha512-rAljUlake3MSXs9xAm87mu34GfBLN0h/1uPPV6jEwClWjNkAMotzjC0ab9MARy5FFAvYHL3lWb57bhkbt2GtzQ==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.30.1",
-        "@cosmjs/math": "^0.30.1",
-        "@cosmjs/utils": "^0.30.1",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers": "^0.7.6"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/encoding": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.30.1.tgz",
-      "integrity": "sha512-rXmrTbgqwihORwJ3xYhIgQFfMSrwLu1s43RIK9I8EBudPx3KmnmyAKzMOVsRDo9edLFNuZ9GIvysUCwQfq3WlQ==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/encoding/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/json-rpc": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.30.1.tgz",
-      "integrity": "sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.30.1",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/math": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.30.1.tgz",
-      "integrity": "sha512-yaoeI23pin9ZiPHIisa6qqLngfnBR/25tSaWpkTm8Cy10MX70UF5oN4+/t1heLaM6SSmRrhk3psRkV4+7mH51Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/proto-signing": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.30.1.tgz",
-      "integrity": "sha512-tXh8pPYXV4aiJVhTKHGyeZekjj+K9s2KKojMB93Gcob2DxUjfKapFYBMJSgfKPuWUPEmyr8Q9km2hplI38ILgQ==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.30.1",
-        "@cosmjs/crypto": "^0.30.1",
-        "@cosmjs/encoding": "^0.30.1",
-        "@cosmjs/math": "^0.30.1",
-        "@cosmjs/utils": "^0.30.1",
-        "cosmjs-types": "^0.7.1",
-        "long": "^4.0.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/socket": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.30.1.tgz",
-      "integrity": "sha512-r6MpDL+9N+qOS/D5VaxnPaMJ3flwQ36G+vPvYJsXArj93BjgyFB7BwWwXCQDzZ+23cfChPUfhbINOenr8N2Kow==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.30.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/stargate": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.30.1.tgz",
-      "integrity": "sha512-RdbYKZCGOH8gWebO7r6WvNnQMxHrNXInY/gPHPzMjbQF6UatA6fNM2G2tdgS5j5u7FTqlCI10stNXrknaNdzog==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.30.1",
-        "@cosmjs/encoding": "^0.30.1",
-        "@cosmjs/math": "^0.30.1",
-        "@cosmjs/proto-signing": "^0.30.1",
-        "@cosmjs/stream": "^0.30.1",
-        "@cosmjs/tendermint-rpc": "^0.30.1",
-        "@cosmjs/utils": "^0.30.1",
-        "cosmjs-types": "^0.7.1",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.3",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/stream": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.30.1.tgz",
-      "integrity": "sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.30.1.tgz",
-      "integrity": "sha512-Z3nCwhXSbPZJ++v85zHObeUggrEHVfm1u18ZRwXxFE9ZMl5mXTybnwYhczuYOl7KRskgwlB+rID0WYACxj4wdQ==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.30.1",
-        "@cosmjs/encoding": "^0.30.1",
-        "@cosmjs/json-rpc": "^0.30.1",
-        "@cosmjs/math": "^0.30.1",
-        "@cosmjs/socket": "^0.30.1",
-        "@cosmjs/stream": "^0.30.1",
-        "@cosmjs/utils": "^0.30.1",
-        "axios": "^0.21.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/@cosmjs/utils": {
-      "version": "0.30.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.30.1.tgz",
-      "integrity": "sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g=="
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/cosmjs-types": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.7.2.tgz",
-      "integrity": "sha512-vf2uLyktjr/XVAgEq0DjMxeAWh1yYREe7AMHDKd7EiHVqxBPCaBS+qEEQUkXbR9ndnckqr1sUG8BQhazh4X5lA==",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
       }
     },
     "node_modules/@injectivelabs/test-utils": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.33.tgz",
       "integrity": "sha512-1SfIRsMnWcJAYNrrpY+ZUWmbD62lWWdIvD6c+FYmFKS14zU3yDIK9NXe9g1lTM/GdUVkVKQgGg2QAYZ5f2G/xA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/networks": "^1.14.33",
@@ -4885,30 +3867,10 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/token-metadata": {
-      "version": "1.10.42",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.10.42.tgz",
-      "integrity": "sha512-j5S+f05/Xtcqbg7pPHRI6hjJpdjIIuMHo16nLecU86mEHhXOzdJzhi/yzrtW7dstlgshyUJKRPZ7HaiOvZNrjA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@injectivelabs/exceptions": "^1.10.12",
-        "@injectivelabs/networks": "^1.10.12",
-        "@injectivelabs/ts-types": "^1.10.12",
-        "@injectivelabs/utils": "^1.10.12",
-        "@types/lodash.values": "^4.3.6",
-        "copyfiles": "^2.4.1",
-        "jsonschema": "^1.4.0",
-        "link-module-alias": "^1.2.0",
-        "lodash": "^4.17.21",
-        "lodash.values": "^4.3.0",
-        "shx": "^0.3.2"
-      }
-    },
     "node_modules/@injectivelabs/ts-types": {
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.33.tgz",
       "integrity": "sha512-sJZzMNJtZFFZoPKZ91G09bxrZqQ5aS9omoTjQWy+7OxfiRAakzhsarTueX47hm6oTaN0XeBgD3wkMukkWUaobw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "shx": "^0.3.2"
       }
@@ -4917,7 +3879,6 @@
       "version": "1.14.33",
       "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
       "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -5016,9 +3977,9 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -5071,11 +4032,32 @@
       }
     },
     "node_modules/@json-rpc-tools/provider/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@json-rpc-tools/provider/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@json-rpc-tools/types": {
@@ -5220,17 +4202,6 @@
         "react-dom": "~16"
       }
     },
-    "node_modules/@keystonehq/sdk/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/@keystonehq/sdk/node_modules/scheduler": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -5239,11 +4210,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
       }
-    },
-    "node_modules/@keystonehq/sdk/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@keystonehq/sdk/node_modules/typescript": {
       "version": "4.9.5",
@@ -5341,11 +4307,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -5373,17 +4334,6 @@
         "semver": "^7.3.5"
       }
     },
-    "node_modules/@ledgerhq/devices/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
     "node_modules/@ledgerhq/devices/node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -5394,11 +4344,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@ledgerhq/devices/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@ledgerhq/errors": {
       "version": "6.10.2",
@@ -5481,7 +4426,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mayanfinance/wormhole-sdk-route/-/wormhole-sdk-route-1.1.0.tgz",
       "integrity": "sha512-gYOVK2Ky0dFliU7ltBFvLLZqrx72djFiYMaTQjzQeXwsXsVa+bbBdYgHPF8Rm99qF2Oh2Swm/RwnhdspfIVzNw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@mayanfinance/swap-sdk": "9.3.0",
         "axios": "^1.4.0"
@@ -5599,9 +4543,9 @@
       }
     },
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
@@ -5667,9 +4611,9 @@
       }
     },
     "node_modules/@metamask/object-multiplex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-2.0.0.tgz",
-      "integrity": "sha512-+ItrieVZie3j2LfYE0QkdW3dsEMfMEp419IGx1zyeLqjRZ14iQUPRO0H6CGgfAAoC0x6k2PfCAGRwJUA9BMrqA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-2.1.0.tgz",
+      "integrity": "sha512-4vKIiv0DQxljcXwfpnbsXcfa5glMj5Zg9mqn4xpIWqkv6uJ2ma5/GtUfLFSxhlxnR8asRMv8dDmWya1Tc1sDFA==",
       "dependencies": {
         "once": "^1.4.0",
         "readable-stream": "^3.6.2"
@@ -5736,9 +4680,9 @@
       }
     },
     "node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-/u663aUaB6+Xe75i3Mt/1cCljm41HDYIsna5oBrwGvgkY2zH7/9k9Zjd706cxoAbxN7QgLSVAReUiGnuxCuXrQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.1.0",
@@ -5778,9 +4722,9 @@
       }
     },
     "node_modules/@metamask/safe-event-emitter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.1.tgz",
-      "integrity": "sha512-ihb3B0T/wJm1eUuArYP4lCTSEoZsClHhuWyfo/kMX3m/odpqNcPfsz5O2A3NT7dXCAgWPGDQGPqygCpgeniKMw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.2.tgz",
+      "integrity": "sha512-5yb2gMI1BDm0JybZezeoX/3XhPDOtTbcFvpTXM9kxsoZjPZFh4XciqRbpD6N86HYZqWDhEaKUDuOyR0sQHEjMA==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -5859,18 +4803,18 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.47.7",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.47.7.tgz",
-      "integrity": "sha512-fNiD3G55ZJGhPOBPMKD/enozj8yxJSYyVJWxRWdcUtw842rvthDHJgUWq9gXQTensFlMHv2wGuCjjivPv53j0A==",
+      "version": "7.48.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.48.1.tgz",
+      "integrity": "sha512-HN9Osa1WxqLM66RaqB5nPAadx+nTIQmY/XtkFdaJvusjG8Tus++QqZtD7KPZDSkhEMGHsYeSyeU8qUzCDUXPjg==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.29.6",
-        "@microsoft/tsdoc": "~0.15.0",
-        "@microsoft/tsdoc-config": "~0.17.0",
-        "@rushstack/node-core-library": "5.7.0",
+        "@microsoft/api-extractor-model": "7.30.1",
+        "@microsoft/tsdoc": "~0.15.1",
+        "@microsoft/tsdoc-config": "~0.17.1",
+        "@rushstack/node-core-library": "5.10.1",
         "@rushstack/rig-package": "0.5.3",
-        "@rushstack/terminal": "0.14.0",
-        "@rushstack/ts-command-line": "4.22.6",
+        "@rushstack/terminal": "0.14.4",
+        "@rushstack/ts-command-line": "4.23.2",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -5883,14 +4827,14 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.29.6",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.29.6.tgz",
-      "integrity": "sha512-gC0KGtrZvxzf/Rt9oMYD2dHvtN/1KPEYsrQPyMKhLHnlVuO/f4AFN3E4toqZzD2pt4LhkKoYmL2H9tX3yCOyRw==",
+      "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.1.tgz",
+      "integrity": "sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==",
       "dev": true,
       "dependencies": {
-        "@microsoft/tsdoc": "~0.15.0",
-        "@microsoft/tsdoc-config": "~0.17.0",
-        "@rushstack/node-core-library": "5.7.0"
+        "@microsoft/tsdoc": "~0.15.1",
+        "@microsoft/tsdoc-config": "~0.17.1",
+        "@rushstack/node-core-library": "5.10.1"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
@@ -5961,18 +4905,18 @@
       "dev": true
     },
     "node_modules/@microsoft/tsdoc": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.0.tgz",
-      "integrity": "sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "dev": true
     },
     "node_modules/@microsoft/tsdoc-config": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.0.tgz",
-      "integrity": "sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
+      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
       "dependencies": {
-        "@microsoft/tsdoc": "0.15.0",
+        "@microsoft/tsdoc": "0.15.1",
         "ajv": "~8.12.0",
         "jju": "~1.4.0",
         "resolve": "~1.22.2"
@@ -6086,18 +5030,18 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.7.tgz",
-      "integrity": "sha512-RtsCt4Geed2/v74sbihWzzRs+HsIQCfclHeORh5Ynu2fS4icIKozcSubwuG7vtzq2uW3fOR1zITSP84TNt2GoQ==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.12.tgz",
+      "integrity": "sha512-rkN+bPpe2Xn8h4ZLqKy5JsZt3nzMyTJ2ySdyLHHf0IL+PrxS46dxOIC1i66R8qi14kJBHfy7Byqv1yUvpwf0iw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
     "node_modules/@mui/icons-material": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.7.tgz",
-      "integrity": "sha512-UrGwDJCXEszbDI7yV047BYU5A28eGJ79keTCP4cc74WyncuVrnurlmIRxaHL8YK+LI1Kzq+/JM52IAkNnv4u+Q==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.12.tgz",
+      "integrity": "sha512-4Ocmbl1uzkWxAdYYARCLySJNqALgrJ+Fdr95FLpKZV7zMZxyoJRdPTO/CgUxjFjlj9Sy2Gi7j3HX4f5HS2GLeQ==",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -6110,8 +5054,8 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6120,21 +5064,21 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.7.tgz",
-      "integrity": "sha512-cwwVQxBhK60OIOqZOVLFt55t01zmarKJiJUWbk0+8s/Ix5IaUzAShqlJchxsIQ4mSrWqgcKCCXKtIlG5H+/Jmg==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.12.tgz",
+      "integrity": "sha512-+M0UPy0xa9xGo8TV1vp9Mmf85TNUqpk7OoSiw+BaZf3D584S3aqfl+CL+EBTt9t52A97GnCjVNvXTO7hmLqhHw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/core-downloads-tracker": "^5.16.7",
-        "@mui/system": "^5.16.7",
+        "@mui/core-downloads-tracker": "^5.16.12",
+        "@mui/system": "^5.16.12",
         "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
+        "@mui/utils": "^5.16.12",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.10",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^18.3.1",
+        "react-is": "^19.0.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -6147,9 +5091,9 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -6164,12 +5108,12 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.6.tgz",
-      "integrity": "sha512-rAk+Rh8Clg7Cd7shZhyt2HGTTE5wYKNSJ5sspf28Fqm/PZ69Er9o6KX25g03/FG2dfpg5GCwZh/xOojiTfm3hw==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.12.tgz",
+      "integrity": "sha512-hhLTSZxsazwZZ4bUAKgFcbsnfCrwizSnJI7/bXf/R9/tZkZBy+bKY05/Au/bIgGKzuZ4KTlKlPn+U/uufEXrNw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/utils": "^5.16.6",
+        "@mui/utils": "^5.16.12",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -6180,8 +5124,8 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6190,12 +5134,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.6.tgz",
-      "integrity": "sha512-zaThmS67ZmtHSWToTiHslbI8jwrmITcN93LQaR2lKArbvS7Z3iLkwRoiikNWutx9MBs8Q6okKvbZq1RQYB3v7g==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.12.tgz",
+      "integrity": "sha512-TMf3SN19rkJPh1hQZTjoY8UsJa5qExfr78owwCuEZLjIhsajAYiWmbJzJ8mM3grEWLiP3MziDA4zy4LFNri12Q==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@emotion/cache": "^11.11.0",
+        "@emotion/cache": "^11.13.5",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
       },
@@ -6209,7 +5153,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.4.1",
         "@emotion/styled": "^11.3.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -6221,15 +5165,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.16.7",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.7.tgz",
-      "integrity": "sha512-Jncvs/r/d/itkxh7O7opOunTqbbSSzMTHzZkNLM+FjAOg+cYAZHrPDlYe1ZGKUYORwwb2XexlWnpZp0kZ4AHuA==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.12.tgz",
+      "integrity": "sha512-rDsndVl0ug0Ex2rZt8x0WIF3Zc0EMFT2TmRVWP4jzk38aLS6WsxryXAZUQa0BKEnB3vfx1pSP/xa44TdKQ94dg==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
-        "@mui/private-theming": "^5.16.6",
-        "@mui/styled-engine": "^5.16.6",
+        "@mui/private-theming": "^5.16.12",
+        "@mui/styled-engine": "^5.16.12",
         "@mui/types": "^7.2.15",
-        "@mui/utils": "^5.16.6",
+        "@mui/utils": "^5.16.12",
         "clsx": "^2.1.0",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -6244,8 +5188,8 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/react": {
@@ -6260,9 +5204,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.17",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.17.tgz",
-      "integrity": "sha512-oyumoJgB6jDV8JFzRqjBo2daUuHpzDjoO/e3IrRhhHo/FxJlaVhET6mcNrKHUq2E+R+q3ql0qAtvQ4rfWHhAeQ==",
+      "version": "7.2.20",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
+      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -6273,16 +5217,16 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.16.6",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.6.tgz",
-      "integrity": "sha512-tWiQqlhxAt3KENNiSRL+DIn9H5xNVK6Jjf70x3PnfQPz1MPBdh7yyIcAyVBT9xiw7hP3SomRhPR7hzBMBCjqEA==",
+      "version": "5.16.12",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.12.tgz",
+      "integrity": "sha512-p3JAq7nA0ur8M/zLnBvR6ZeAjM8mD4LnPdKfsJAYPS26w4eDQjQzl55XvoOmch2MeXhmWaO4Pkvs/xurrISNBw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "^7.2.15",
         "@types/prop-types": "^15.7.12",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^18.3.1"
+        "react-is": "^19.0.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6292,8 +5236,8 @@
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0",
-        "react": "^17.0.0 || ^18.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6494,11 +5438,11 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
-      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "dependencies": {
-        "@noble/hashes": "1.5.0"
+        "@noble/hashes": "1.6.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -6507,10 +5451,21 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6569,6 +5524,26 @@
         "ws": "*"
       }
     },
+    "node_modules/@open-rpc/client-js/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@openblockhq/dappsdk": {
       "version": "5.0.15",
       "resolved": "https://registry.npmjs.org/@openblockhq/dappsdk/-/dappsdk-5.0.15.tgz",
@@ -6602,9 +5577,10 @@
       }
     },
     "node_modules/@parcel/watcher": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.4.1.tgz",
-      "integrity": "sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -6619,24 +5595,25 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.4.1",
-        "@parcel/watcher-darwin-arm64": "2.4.1",
-        "@parcel/watcher-darwin-x64": "2.4.1",
-        "@parcel/watcher-freebsd-x64": "2.4.1",
-        "@parcel/watcher-linux-arm-glibc": "2.4.1",
-        "@parcel/watcher-linux-arm64-glibc": "2.4.1",
-        "@parcel/watcher-linux-arm64-musl": "2.4.1",
-        "@parcel/watcher-linux-x64-glibc": "2.4.1",
-        "@parcel/watcher-linux-x64-musl": "2.4.1",
-        "@parcel/watcher-win32-arm64": "2.4.1",
-        "@parcel/watcher-win32-ia32": "2.4.1",
-        "@parcel/watcher-win32-x64": "2.4.1"
+        "@parcel/watcher-android-arm64": "2.5.0",
+        "@parcel/watcher-darwin-arm64": "2.5.0",
+        "@parcel/watcher-darwin-x64": "2.5.0",
+        "@parcel/watcher-freebsd-x64": "2.5.0",
+        "@parcel/watcher-linux-arm-glibc": "2.5.0",
+        "@parcel/watcher-linux-arm-musl": "2.5.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.0",
+        "@parcel/watcher-linux-arm64-musl": "2.5.0",
+        "@parcel/watcher-linux-x64-glibc": "2.5.0",
+        "@parcel/watcher-linux-x64-musl": "2.5.0",
+        "@parcel/watcher-win32-arm64": "2.5.0",
+        "@parcel/watcher-win32-ia32": "2.5.0",
+        "@parcel/watcher-win32-x64": "2.5.0"
       }
     },
     "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.4.1.tgz",
-      "integrity": "sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
       "cpu": [
         "arm64"
       ],
@@ -6653,9 +5630,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.4.1.tgz",
-      "integrity": "sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
       "cpu": [
         "arm64"
       ],
@@ -6672,9 +5649,9 @@
       }
     },
     "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.4.1.tgz",
-      "integrity": "sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
       "cpu": [
         "x64"
       ],
@@ -6691,9 +5668,9 @@
       }
     },
     "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.4.1.tgz",
-      "integrity": "sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
       "cpu": [
         "x64"
       ],
@@ -6710,9 +5687,28 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.4.1.tgz",
-      "integrity": "sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
       "cpu": [
         "arm"
       ],
@@ -6729,9 +5725,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.4.1.tgz",
-      "integrity": "sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
       "cpu": [
         "arm64"
       ],
@@ -6748,9 +5744,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.4.1.tgz",
-      "integrity": "sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
       "cpu": [
         "arm64"
       ],
@@ -6767,9 +5763,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.4.1.tgz",
-      "integrity": "sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
       "cpu": [
         "x64"
       ],
@@ -6786,9 +5782,9 @@
       }
     },
     "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.4.1.tgz",
-      "integrity": "sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
       "cpu": [
         "x64"
       ],
@@ -6805,9 +5801,9 @@
       }
     },
     "node_modules/@parcel/watcher-wasm": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.4.1.tgz",
-      "integrity": "sha512-/ZR0RxqxU/xxDGzbzosMjh4W6NdYFMqq2nvo2b8SLi7rsl/4jkL8S5stIikorNkdR50oVDvqb/3JT05WM+CRRA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.0.tgz",
+      "integrity": "sha512-Z4ouuR8Pfggk1EYYbTaIoxc+Yv4o7cGQnH0Xy8+pQ+HbiW+ZnwhcD2LPf/prfq1nIWpAxjOkQ8uSMFWMtBLiVQ==",
       "bundleDependencies": [
         "napi-wasm"
       ],
@@ -6830,9 +5826,9 @@
       "license": "MIT"
     },
     "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.4.1.tgz",
-      "integrity": "sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
       "cpu": [
         "arm64"
       ],
@@ -6849,9 +5845,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.4.1.tgz",
-      "integrity": "sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
       "cpu": [
         "ia32"
       ],
@@ -6868,9 +5864,9 @@
       }
     },
     "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.4.1.tgz",
-      "integrity": "sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
       "cpu": [
         "x64"
       ],
@@ -6892,9 +5888,9 @@
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node_modules/@particle-network/analytics": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@particle-network/analytics/-/analytics-1.0.1.tgz",
-      "integrity": "sha512-ApcSMo1BXQlywO+lvOpG3Y2/SVGNCpJzXO/4e3zHzE/9j+uMehsilDzPwWQwLhrCXZYwVm7mmE71Gs36yobiNw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@particle-network/analytics/-/analytics-1.0.2.tgz",
+      "integrity": "sha512-E4EpTRYcfNOkxj+bgNdQydBrvdLGo4HfVStZCuOr3967dYek30r6L7Nkaa9zJXRE2eGT4lPvcAXDV2WxDZl/Xg==",
       "dependencies": {
         "hash.js": "^1.1.7",
         "uuidv4": "^6.2.13"
@@ -6913,9 +5909,9 @@
       }
     },
     "node_modules/@particle-network/chains": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@particle-network/chains/-/chains-1.7.2.tgz",
-      "integrity": "sha512-dzYDh93V/7dd+4RCVIi0EyLQDepRTdWPIm+1hpIRrO3n29W8oVKvDzO7AlTsgYCBryh/f/iJB6JoQUB/+I8lZw=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@particle-network/chains/-/chains-1.8.0.tgz",
+      "integrity": "sha512-Mh96ihIdfI9KoZ5/HBayMdV46caO4dVH40R6KcBHUiFU8eq91iIxItAdZETlCt4HuHX57DUYVAj+B7u3sXXgnQ=="
     },
     "node_modules/@particle-network/crypto": {
       "version": "1.0.1",
@@ -7122,14 +6118,14 @@
       }
     },
     "node_modules/@rollup/pluginutils": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.2.tgz",
-      "integrity": "sha512-/FIdS3PyZ39bjZlwqFnWqCOVnW7o963LtKMwQOD0NhQqw22gSr2YY1afu3FxRip4ZCZNsD5jq6Aaz6QV3D/Njw==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
       "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
-        "picomatch": "^2.3.1"
+        "picomatch": "^4.0.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -7144,9 +6140,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.24.0.tgz",
-      "integrity": "sha512-Q6HJd7Y6xdB48x8ZNVDOqsbh2uByBhgK8PiQgPhwkIw/HC/YX5Ghq2mQY5sRMZWHb3VsFkWooUVOZHKr7DmDIA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
       "cpu": [
         "arm"
       ],
@@ -7157,9 +6153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.24.0.tgz",
-      "integrity": "sha512-ijLnS1qFId8xhKjT81uBHuuJp2lU4x2yxa4ctFPtG+MqEE6+C5f/+X/bStmxapgmwLwiL3ih122xv8kVARNAZA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
       "cpu": [
         "arm64"
       ],
@@ -7170,9 +6166,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.24.0.tgz",
-      "integrity": "sha512-bIv+X9xeSs1XCk6DVvkO+S/z8/2AMt/2lMqdQbMrmVpgFvXlmde9mLcbQpztXm1tajC3raFDqegsH18HQPMYtA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
       "cpu": [
         "arm64"
       ],
@@ -7183,9 +6179,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.24.0.tgz",
-      "integrity": "sha512-X6/nOwoFN7RT2svEQWUsW/5C/fYMBe4fnLK9DQk4SX4mgVBiTA9h64kjUYPvGQ0F/9xwJ5U5UfTbl6BEjaQdBQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
       "cpu": [
         "x64"
       ],
@@ -7195,10 +6191,36 @@
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.24.0.tgz",
-      "integrity": "sha512-0KXvIJQMOImLCVCz9uvvdPgfyWo93aHHp8ui3FrtOP57svqrF/roSSR5pjqL2hcMp0ljeGlU4q9o/rQaAQ3AYA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
       "cpu": [
         "arm"
       ],
@@ -7209,9 +6231,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.24.0.tgz",
-      "integrity": "sha512-it2BW6kKFVh8xk/BnHfakEeoLPv8STIISekpoF+nBgWM4d55CZKc7T4Dx1pEbTnYm/xEKMgy1MNtYuoA8RFIWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
       "cpu": [
         "arm"
       ],
@@ -7222,9 +6244,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.24.0.tgz",
-      "integrity": "sha512-i0xTLXjqap2eRfulFVlSnM5dEbTVque/3Pi4g2y7cxrs7+a9De42z4XxKLYJ7+OhE3IgxvfQM7vQc43bwTgPwA==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
       "cpu": [
         "arm64"
       ],
@@ -7235,9 +6257,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.24.0.tgz",
-      "integrity": "sha512-9E6MKUJhDuDh604Qco5yP/3qn3y7SLXYuiC0Rpr89aMScS2UAmK1wHP2b7KAa1nSjWJc/f/Lc0Wl1L47qjiyQw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
       "cpu": [
         "arm64"
       ],
@@ -7247,10 +6269,23 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.24.0.tgz",
-      "integrity": "sha512-2XFFPJ2XMEiF5Zi2EBf4h73oR1V/lycirxZxHZNc93SqDN/IWhYYSYj8I9381ikUFXZrz2v7r2tOVk2NBwxrWw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
       "cpu": [
         "ppc64"
       ],
@@ -7261,9 +6296,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.24.0.tgz",
-      "integrity": "sha512-M3Dg4hlwuntUCdzU7KjYqbbd+BLq3JMAOhCKdBE3TcMGMZbKkDdJ5ivNdehOssMCIokNHFOsv7DO4rlEOfyKpg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
       "cpu": [
         "riscv64"
       ],
@@ -7274,9 +6309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.24.0.tgz",
-      "integrity": "sha512-mjBaoo4ocxJppTorZVKWFpy1bfFj9FeCMJqzlMQGjpNPY9JwQi7OuS1axzNIk0nMX6jSgy6ZURDZ2w0QW6D56g==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
       "cpu": [
         "s390x"
       ],
@@ -7287,9 +6322,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.24.0.tgz",
-      "integrity": "sha512-ZXFk7M72R0YYFN5q13niV0B7G8/5dcQ9JDp8keJSfr3GoZeXEoMHP/HlvqROA3OMbMdfr19IjCeNAnPUG93b6A==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
       "cpu": [
         "x64"
       ],
@@ -7300,9 +6335,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
-      "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
       "cpu": [
         "x64"
       ],
@@ -7313,9 +6348,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.24.0.tgz",
-      "integrity": "sha512-VXBrnPWgBpVDCVY6XF3LEW0pOU51KbaHhccHw6AS6vBWIC60eqsH19DAeeObl+g8nKAz04QFdl/Cefta0xQtUQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
       "cpu": [
         "arm64"
       ],
@@ -7326,9 +6361,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.24.0.tgz",
-      "integrity": "sha512-xrNcGDU0OxVcPTH/8n/ShH4UevZxKIO6HJFK0e15XItZP2UcaiLFd5kiX7hJnqCbSztUF8Qot+JWBC/QXRPYWQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
       "cpu": [
         "ia32"
       ],
@@ -7339,9 +6374,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.24.0.tgz",
-      "integrity": "sha512-fbMkAF7fufku0N2dE5TBXcNlg0pt0cJue4xBRE2Qc5Vqikxr4VCgKj/ht6SMdFcOacVA9rqF70APJ8RN/4vMJw==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
       "cpu": [
         "x64"
       ],
@@ -7352,9 +6387,9 @@
       ]
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.7.0.tgz",
-      "integrity": "sha512-Ff9Cz/YlWu9ce4dmqNBZpA45AEya04XaBFIjV7xTVeEf+y/kTjEasmozqFELXlNG4ROdevss75JrrZ5WgufDkQ==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.1.tgz",
+      "integrity": "sha512-BSb/KcyBHmUQwINrgtzo6jiH0HlGFmrUy33vO6unmceuVKTEyL2q+P0fQq2oB5hvXVWOEUhxB2QvlkZluvUEmg==",
       "dev": true,
       "dependencies": {
         "ajv": "~8.13.0",
@@ -7487,12 +6522,12 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.0.tgz",
-      "integrity": "sha512-juTKMAMpTIJKudeFkG5slD8Z/LHwNwGZLtU441l/u82XdTBfsP+LbGKJLCNwP5se+DMCT55GB8x9p6+C4UL7jw==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.4.tgz",
+      "integrity": "sha512-NxACqERW0PHq8Rpq1V6v5iTHEwkRGxenjEW+VWqRYQ8T9puUzgmGHmEZUaUEDHAe9Qyvp0/Ew04sAiQw9XjhJg==",
       "dev": true,
       "dependencies": {
-        "@rushstack/node-core-library": "5.7.0",
+        "@rushstack/node-core-library": "5.10.1",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -7502,15 +6537,6 @@
         "@types/node": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rushstack/terminal/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@rushstack/terminal/node_modules/supports-color": {
@@ -7529,12 +6555,12 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.22.6",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.22.6.tgz",
-      "integrity": "sha512-QSRqHT/IfoC5nk9zn6+fgyqOPXHME0BfchII9EUPR19pocsNp/xSbeBCbD3PIR2Lg+Q5qk7OFqk1VhWPMdKHJg==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.2.tgz",
+      "integrity": "sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==",
       "dev": true,
       "dependencies": {
-        "@rushstack/terminal": "0.14.0",
+        "@rushstack/terminal": "0.14.4",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -7556,18 +6582,13 @@
       "dev": true
     },
     "node_modules/@safe-global/safe-apps-provider": {
-      "version": "0.18.3",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.3.tgz",
-      "integrity": "sha512-f/0cNv3S4v7p8rowAjj0hDCg8Q8P/wBjp5twkNWeBdvd0RDr7BuRBPPk74LCqmjQ82P+1ltLlkmVFSmxTIT7XQ==",
+      "version": "0.18.5",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.5.tgz",
+      "integrity": "sha512-9v9wjBi3TwLsEJ3C2ujYoexp3pFJ0omDLH/GX91e2QB+uwCKTBYyhxFSrTQ9qzoyQd+bfsk4gjOGW87QcJhf7g==",
       "dependencies": {
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "events": "^3.3.0"
       }
-    },
-    "node_modules/@safe-global/safe-apps-provider/node_modules/@adraffy/ens-normalize": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
-      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
       "version": "9.1.0",
@@ -7579,9 +6600,9 @@
       }
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/abitype": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
-      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -7613,9 +6634,9 @@
       }
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/viem": {
-      "version": "2.21.19",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.19.tgz",
-      "integrity": "sha512-FdlkN+UI1IU5sYOmzvygkxsUNjDRD5YHht3gZFu2X9xFv6Z3h9pXq9ycrYQ3F17lNfb41O2Ot4/aqbUkwOv9dA==",
+      "version": "2.21.55",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.55.tgz",
+      "integrity": "sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==",
       "funding": [
         {
           "type": "github",
@@ -7623,13 +6644,13 @@
         }
       ],
       "dependencies": {
-        "@adraffy/ens-normalize": "1.11.0",
-        "@noble/curves": "1.6.0",
-        "@noble/hashes": "1.5.0",
-        "@scure/bip32": "1.5.0",
-        "@scure/bip39": "1.4.0",
-        "abitype": "1.0.6",
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.6.1",
+        "@scure/bip32": "1.6.0",
+        "@scure/bip39": "1.5.0",
+        "abitype": "1.0.7",
         "isows": "1.0.6",
+        "ox": "0.1.2",
         "webauthn-p256": "0.0.10",
         "ws": "8.18.0"
       },
@@ -7638,26 +6659,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@safe-global/safe-apps-provider/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -7672,50 +6673,50 @@
       }
     },
     "node_modules/@safe-global/safe-gateway-typescript-sdk": {
-      "version": "3.22.2",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.2.tgz",
-      "integrity": "sha512-Y0yAxRaB98LFp2Dm+ACZqBSdAmI3FlpH/LjxOZ94g/ouuDJecSq0iR26XZ5QDuEL8Rf+L4jBJaoDC08CD0KkJw==",
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4.tgz",
+      "integrity": "sha512-Z7Z8w3GEJdJ/paF+NK23VN4AwqWPadq0AeRYjYLjIBiPWpRB2UO/FKq7ONABEq0YFgNPklazIV4IExQU1gavXA==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
-      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
       "dependencies": {
-        "@noble/curves": "~1.6.0",
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.7"
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
       "dependencies": {
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.8"
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.33.15",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.15.tgz",
-      "integrity": "sha512-R50kz7xohLjhwgmAiw+6qOAYkeFXsK8i1CbEQB1qJTiHMK5WywpvGIHJenE3n4t7dqj3bas+H1cD5dTZIfrAEw=="
+      "version": "0.33.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
+      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -7732,6 +6733,259 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
+    "node_modules/@solana/accounts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0.tgz",
+      "integrity": "sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/rpc-spec": "2.0.0",
+        "@solana/rpc-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/accounts/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0.tgz",
+      "integrity": "sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==",
+      "dependencies": {
+        "@solana/assertions": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/addresses/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0.tgz",
+      "integrity": "sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/assertions/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/assertions/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/assertions/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
@@ -7839,14 +7093,195 @@
       }
     },
     "node_modules/@solana/errors/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0.tgz",
+      "integrity": "sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0.tgz",
+      "integrity": "sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0.tgz",
+      "integrity": "sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/instructions/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0.tgz",
+      "integrity": "sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==",
+      "dependencies": {
+        "@solana/assertions": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/keys/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/options": {
@@ -7862,6 +7297,784 @@
       },
       "peerDependencies": {
         "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0.tgz",
+      "integrity": "sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/programs/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/programs/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/programs/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0.tgz",
+      "integrity": "sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0.tgz",
+      "integrity": "sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/fast-stable-stringify": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/rpc-api": "2.0.0",
+        "@solana/rpc-spec": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/rpc-transformers": "2.0.0",
+        "@solana/rpc-transport-http": "2.0.0",
+        "@solana/rpc-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0.tgz",
+      "integrity": "sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/rpc-parsed-types": "2.0.0",
+        "@solana/rpc-spec": "2.0.0",
+        "@solana/rpc-transformers": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-api/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0.tgz",
+      "integrity": "sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0.tgz",
+      "integrity": "sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0.tgz",
+      "integrity": "sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-spec/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-spec/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/fast-stable-stringify": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/promises": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/rpc-subscriptions-api": "2.0.0",
+        "@solana/rpc-subscriptions-channel-websocket": "2.0.0",
+        "@solana/rpc-subscriptions-spec": "2.0.0",
+        "@solana/rpc-transformers": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/subscribable": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0.tgz",
+      "integrity": "sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/rpc-subscriptions-spec": "2.0.0",
+        "@solana/rpc-transformers": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.0.0.tgz",
+      "integrity": "sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/rpc-subscriptions-spec": "2.0.0",
+        "@solana/subscribable": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5",
+        "ws": "^8.18.0"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0.tgz",
+      "integrity": "sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/promises": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/subscribable": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0.tgz",
+      "integrity": "sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/rpc-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-transformers/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0.tgz",
+      "integrity": "sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==",
+      "dependencies": {
+        "@solana/errors": "2.0.0",
+        "@solana/rpc-spec": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "undici-types": "^6.20.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0.tgz",
+      "integrity": "sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc-types/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/rpc/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0.tgz",
+      "integrity": "sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/instructions": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/signers/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/signers/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/signers/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/spl-token": {
@@ -7882,12 +8095,11 @@
       }
     },
     "node_modules/@solana/spl-token-metadata": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.5.tgz",
-      "integrity": "sha512-DSBlo7vjuLe/xvNn75OKKndDBkFxlqjLdWlq6rf40StnrhRn7TDntHGLZpry1cf3uzQFShqeLROGNPAJwvkPnA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
       "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1",
-        "@solana/spl-type-length-value": "0.1.0"
+        "@solana/codecs": "2.0.0-rc.1"
       },
       "engines": {
         "node": ">=16"
@@ -7896,15 +8108,539 @@
         "@solana/web3.js": "^1.95.3"
       }
     },
-    "node_modules/@solana/spl-type-length-value": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz",
-      "integrity": "sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==",
+    "node_modules/@solana/subscribable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.0.0.tgz",
+      "integrity": "sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==",
       "dependencies": {
-        "buffer": "^6.0.3"
+        "@solana/errors": "2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/subscribable/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0.tgz",
+      "integrity": "sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==",
+      "dependencies": {
+        "@solana/accounts": "2.0.0",
+        "@solana/codecs": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/rpc-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/options": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/@solana/options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/sysvars/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0.tgz",
+      "integrity": "sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/promises": "2.0.0",
+        "@solana/rpc": "2.0.0",
+        "@solana/rpc-subscriptions": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/transaction-confirmation/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0.tgz",
+      "integrity": "sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/instructions": "2.0.0",
+        "@solana/rpc-types": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/transaction-messages/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0.tgz",
+      "integrity": "sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==",
+      "dependencies": {
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/instructions": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/transaction-messages": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/transactions/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@solana/wallet-adapter-alpha": {
@@ -8560,10 +9296,9 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.95.8",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.95.8.tgz",
-      "integrity": "sha512-sBHzNh7dHMrmNS5xPD1d0Xa2QffW/RXaxu/OysRXBfwTp+LYqGGmMtCYYwrHPrN5rjAmJCsQRNAwv4FM0t3B6g==",
-      "license": "MIT",
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -8583,9 +9318,9 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -8623,26 +9358,6 @@
       "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@solflare-wallet/metamask-sdk": {
@@ -8885,14 +9600,14 @@
       "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
     },
     "node_modules/@swc/core": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.7.26.tgz",
-      "integrity": "sha512-f5uYFf+TmMQyYIoxkn/evWhNGuUzC730dFwAKGwBVHHVoPyak1/GvJUm6i1SKl+2Hrj9oN0i3WSoWWZ4pgI8lw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-rQ4dS6GAdmtzKiCRt3LFVxl37FaY1cgL9kSUTnhQ2xc3fmHOd7jdJK/V4pSZMG1ruGTd0bsi34O2R0Olg9Zo/w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.12"
+        "@swc/types": "^0.1.17"
       },
       "engines": {
         "node": ">=10"
@@ -8902,16 +9617,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.7.26",
-        "@swc/core-darwin-x64": "1.7.26",
-        "@swc/core-linux-arm-gnueabihf": "1.7.26",
-        "@swc/core-linux-arm64-gnu": "1.7.26",
-        "@swc/core-linux-arm64-musl": "1.7.26",
-        "@swc/core-linux-x64-gnu": "1.7.26",
-        "@swc/core-linux-x64-musl": "1.7.26",
-        "@swc/core-win32-arm64-msvc": "1.7.26",
-        "@swc/core-win32-ia32-msvc": "1.7.26",
-        "@swc/core-win32-x64-msvc": "1.7.26"
+        "@swc/core-darwin-arm64": "1.10.1",
+        "@swc/core-darwin-x64": "1.10.1",
+        "@swc/core-linux-arm-gnueabihf": "1.10.1",
+        "@swc/core-linux-arm64-gnu": "1.10.1",
+        "@swc/core-linux-arm64-musl": "1.10.1",
+        "@swc/core-linux-x64-gnu": "1.10.1",
+        "@swc/core-linux-x64-musl": "1.10.1",
+        "@swc/core-win32-arm64-msvc": "1.10.1",
+        "@swc/core-win32-ia32-msvc": "1.10.1",
+        "@swc/core-win32-x64-msvc": "1.10.1"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -8923,9 +9638,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.7.26.tgz",
-      "integrity": "sha512-FF3CRYTg6a7ZVW4yT9mesxoVVZTrcSWtmZhxKCYJX9brH4CS/7PRPjAKNk6kzWgWuRoglP7hkjQcd6EpMcZEAw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-NyELPp8EsVZtxH/mEqvzSyWpfPJ1lugpTQcSlMduZLj1EASLO4sC8wt8hmL1aizRlsbjCX+r0PyL+l0xQ64/6Q==",
       "cpu": [
         "arm64"
       ],
@@ -8939,9 +9654,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.7.26.tgz",
-      "integrity": "sha512-az3cibZdsay2HNKmc4bjf62QVukuiMRh5sfM5kHR/JMTrLyS6vSw7Ihs3UTkZjUxkLTT8ro54LI6sV6sUQUbLQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-L4BNt1fdQ5ZZhAk5qoDfUnXRabDOXKnXBxMDJ+PWLSxOGBbWE6aJTnu4zbGjJvtot0KM46m2LPAPY8ttknqaZA==",
       "cpu": [
         "x64"
       ],
@@ -8955,9 +9670,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.7.26.tgz",
-      "integrity": "sha512-VYPFVJDO5zT5U3RpCdHE5v1gz4mmR8BfHecUZTmD2v1JeFY6fv9KArJUpjrHEEsjK/ucXkQFmJ0jaiWXmpOV9Q==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-Y1u9OqCHgvVp2tYQAJ7hcU9qO5brDMIrA5R31rwWQIAKDkJKtv3IlTHF0hrbWk1wPR0ZdngkQSJZple7G+Grvw==",
       "cpu": [
         "arm"
       ],
@@ -8971,9 +9686,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.7.26.tgz",
-      "integrity": "sha512-YKevOV7abpjcAzXrhsl+W48Z9mZvgoVs2eP5nY+uoMAdP2b3GxC0Df1Co0I90o2lkzO4jYBpTMcZlmUXLdXn+Q==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-tNQHO/UKdtnqjc7o04iRXng1wTUXPgVd8Y6LI4qIbHVoVPwksZydISjMcilKNLKIwOoUQAkxyJ16SlOAeADzhQ==",
       "cpu": [
         "arm64"
       ],
@@ -8987,9 +9702,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.7.26.tgz",
-      "integrity": "sha512-3w8iZICMkQQON0uIcvz7+Q1MPOW6hJ4O5ETjA0LSP/tuKqx30hIniCGOgPDnv3UTMruLUnQbtBwVCZTBKR3Rkg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-x0L2Pd9weQ6n8dI1z1Isq00VHFvpBClwQJvrt3NHzmR+1wCT/gcYl1tp9P5xHh3ldM8Cn4UjWCw+7PaUgg8FcQ==",
       "cpu": [
         "arm64"
       ],
@@ -9003,9 +9718,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.7.26.tgz",
-      "integrity": "sha512-c+pp9Zkk2lqb06bNGkR2Looxrs7FtGDMA4/aHjZcCqATgp348hOKH5WPvNLBl+yPrISuWjbKDVn3NgAvfvpH4w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==",
       "cpu": [
         "x64"
       ],
@@ -9019,9 +9734,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.26.tgz",
-      "integrity": "sha512-PgtyfHBF6xG87dUSSdTJHwZ3/8vWZfNIXQV2GlwEpslrOkGqy+WaiiyE7Of7z9AvDILfBBBcJvJ/r8u980wAfQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-tcaS43Ydd7Fk7sW5ROpaf2Kq1zR+sI5K0RM+0qYLYYurvsJruj3GhBCaiN3gkzd8m/8wkqNqtVklWaQYSDsyqA==",
       "cpu": [
         "x64"
       ],
@@ -9035,9 +9750,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.7.26.tgz",
-      "integrity": "sha512-9TNXPIJqFynlAOrRD6tUQjMq7KApSklK3R/tXgIxc7Qx+lWu8hlDQ/kVPLpU7PWvMMwC/3hKBW+p5f+Tms1hmA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.1.tgz",
+      "integrity": "sha512-D3Qo1voA7AkbOzQ2UGuKNHfYGKL6eejN8VWOoQYtGHHQi1p5KK/Q7V1ku55oxXBsj79Ny5FRMqiRJpVGad7bjQ==",
       "cpu": [
         "arm64"
       ],
@@ -9051,9 +9766,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.7.26.tgz",
-      "integrity": "sha512-9YngxNcG3177GYdsTum4V98Re+TlCeJEP4kEwEg9EagT5s3YejYdKwVAkAsJszzkXuyRDdnHUpYbTrPG6FiXrQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.1.tgz",
+      "integrity": "sha512-WalYdFoU3454Og+sDKHM1MrjvxUGwA2oralknXkXL8S0I/8RkWZOB++p3pLaGbTvOO++T+6znFbQdR8KRaa7DA==",
       "cpu": [
         "ia32"
       ],
@@ -9067,9 +9782,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.7.26",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.7.26.tgz",
-      "integrity": "sha512-VR+hzg9XqucgLjXxA13MtV5O3C0bK0ywtLIBw/+a+O+Oc6mxFWHtdUeXDbIi5AiPbn0fjgVJMqYnyjGyyX8u0w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-JWobfQDbTnoqaIwPKQ3DVSywihVXlQMbDuwik/dDWlj33A8oEHcjPOGs4OqcA3RHv24i+lfCQpM3Mn4FAMfacA==",
       "cpu": [
         "x64"
       ],
@@ -9089,17 +9804,17 @@
       "dev": true
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.13.tgz",
-      "integrity": "sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.12.tgz",
-      "integrity": "sha512-wBJA+SdtkbFhHjTMYH+dEH1y4VpfGdAc2Kw/LK09i9bXd/K6j6PkDcFCEzb6iVfZMkPRrl/q0e3toqTAJdkIVA==",
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -9304,9 +10019,9 @@
       }
     },
     "node_modules/@toruslabs/base-controllers/node_modules/readable-stream": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.6.0.tgz",
+      "integrity": "sha512-cbAdYt0VcnpN2Bekq7PU+k363ZRsPwJoEEJOEtSJQlJXzwaxt3FIo/uL+KeDSGIjJqtkwyge4KQgD2S2kd+CQw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -9459,32 +10174,44 @@
       }
     },
     "node_modules/@trezor/analytics": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.2.1.tgz",
-      "integrity": "sha512-GKkHp+4e2YaX+nNf3C46Et8y9D7ExRSvlCinJfClFNbY3p5Mn83PwoXpSsM9omqmZkIy+0EoC/o6+JcaiA+p9A==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.2.5.tgz",
+      "integrity": "sha512-+6DnjUj1XHD9wHffilPYXIPGmIwPNlYJLlS98FhAv5tOVr9rWvomqtXx2GWwtiv2B3oR/h6oMiYGmS/yjpM2cA==",
       "dependencies": {
-        "@trezor/env-utils": "1.2.0",
-        "@trezor/utils": "9.2.1"
+        "@trezor/env-utils": "1.2.1",
+        "@trezor/utils": "9.2.5"
+      },
+      "peerDependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/analytics/node_modules/@trezor/utils": {
+      "version": "9.2.5",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.5.tgz",
+      "integrity": "sha512-FaGKQxwvivcWOa8vK4qQPdyvUm/AcjH0xOKfcvjNfaBhf+TVDzKn2ORKnioQb2Sgjncb8B2ubqrUI3MIc+RKKw==",
+      "dependencies": {
+        "bignumber.js": "^9.1.2"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/blockchain-link": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.3.1.tgz",
-      "integrity": "sha512-W4cvbPT3+3w3z/Xf8G49XbwkW8hnhiMEnJJfYGR0yPgqul7rtSmPHvII4pb+/AHAo1DfOaJCrRw87tEbhybU6Q==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.3.6.tgz",
+      "integrity": "sha512-cuqGJr5d5iTwGNbTAKDskE+m7yL/4RQsagNwA64793tli1fDWeeGT/B2mCvFwpUmIo9dVFDkYb++ZiltUIGZ3w==",
       "dependencies": {
-        "@solana/buffer-layout": "^4.0.1",
-        "@solana/web3.js": "^1.95.0",
-        "@trezor/blockchain-link-types": "1.2.1",
-        "@trezor/blockchain-link-utils": "1.2.1",
-        "@trezor/utils": "9.2.1",
-        "@trezor/utxo-lib": "2.2.1",
-        "@types/web": "^0.0.162",
+        "@solana-program/token": "^0.4.1",
+        "@solana/web3.js": "^2.0.0",
+        "@trezor/blockchain-link-types": "1.2.5",
+        "@trezor/blockchain-link-utils": "1.2.6",
+        "@trezor/env-utils": "1.2.1",
+        "@trezor/utils": "9.2.6",
+        "@trezor/utxo-lib": "2.2.6",
+        "@types/web": "^0.0.174",
         "events": "^3.3.0",
         "ripple-lib": "^1.10.1",
-        "socks-proxy-agent": "6.1.1",
+        "socks-proxy-agent": "8.0.4",
         "ws": "^8.18.0"
       },
       "peerDependencies": {
@@ -9492,72 +10219,390 @@
       }
     },
     "node_modules/@trezor/blockchain-link-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.2.1.tgz",
-      "integrity": "sha512-YokPYnMG60qWoaQU18st3A3lvvefFRLY/TK1sDHFpwKWDLWch+tvZINhviJ1bdbxPqYZVDCmL8yyXNAu0xS5iQ==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.2.5.tgz",
+      "integrity": "sha512-aGxLNGxhQqre4cCYDboy1s1gHAi92tTszLYl3GMhGmtB6EuAl049eO8ngCcMcuOZLTvFYA/1e/3mZoPIMBkeng==",
       "dependencies": {
-        "@solana/web3.js": "^1.95.0",
-        "@trezor/type-utils": "1.1.0",
-        "@trezor/utxo-lib": "2.2.1",
-        "socks-proxy-agent": "6.1.1"
+        "@solana/web3.js": "^2.0.0",
+        "@trezor/type-utils": "1.1.4",
+        "@trezor/utxo-lib": "2.2.6"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/options": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/@solana/web3.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
+      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
+      "dependencies": {
+        "@solana/accounts": "2.0.0",
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/instructions": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/programs": "2.0.0",
+        "@solana/rpc": "2.0.0",
+        "@solana/rpc-parsed-types": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/rpc-subscriptions": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/signers": "2.0.0",
+        "@solana/sysvars": "2.0.0",
+        "@solana/transaction-confirmation": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/blockchain-link-types/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@trezor/blockchain-link-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.2.1.tgz",
-      "integrity": "sha512-+h+TIHG6l1gCqguhiWt5ZLKH/ImDGqfaZ0ql/nl5QQUdtPh9g2RU1Wc0CwQHOLmWqI/YBPExhMFB9MTf5feZ3w==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.2.6.tgz",
+      "integrity": "sha512-6ExuAyKxGH79aZhT3eA6xng9ljYixiE9EBC635BLPc+lafpin2+Aplb0q2zA6f/S5ksl9ges63W627pb7IFgGw==",
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
-        "@solana/web3.js": "^1.95.0",
-        "@trezor/env-utils": "1.2.0",
-        "@trezor/utils": "9.2.1"
+        "@trezor/env-utils": "1.2.1",
+        "@trezor/utils": "9.2.6"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@trezor/blockchain-link/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+    "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.4.1.tgz",
+      "integrity": "sha512-eSYmjsapzE9jXT2J9xydlMj/zsangMEIZAy9dy75VCXM6kgDCSnH5R7+HsIoKOTvb2VggU7GojC+YhMwWGCIBw==",
+      "peerDependencies": {
+        "@solana/web3.js": "^2.0.0"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/options": "2.0.0"
+      },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "dependencies": {
+        "@solana/errors": "2.0.0"
       },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/options": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0",
+        "@solana/codecs-data-structures": "2.0.0",
+        "@solana/codecs-numbers": "2.0.0",
+        "@solana/codecs-strings": "2.0.0",
+        "@solana/errors": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/@solana/web3.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
+      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
+      "dependencies": {
+        "@solana/accounts": "2.0.0",
+        "@solana/addresses": "2.0.0",
+        "@solana/codecs": "2.0.0",
+        "@solana/errors": "2.0.0",
+        "@solana/functional": "2.0.0",
+        "@solana/instructions": "2.0.0",
+        "@solana/keys": "2.0.0",
+        "@solana/programs": "2.0.0",
+        "@solana/rpc": "2.0.0",
+        "@solana/rpc-parsed-types": "2.0.0",
+        "@solana/rpc-spec-types": "2.0.0",
+        "@solana/rpc-subscriptions": "2.0.0",
+        "@solana/rpc-types": "2.0.0",
+        "@solana/signers": "2.0.0",
+        "@solana/sysvars": "2.0.0",
+        "@solana/transaction-confirmation": "2.0.0",
+        "@solana/transaction-messages": "2.0.0",
+        "@solana/transactions": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/chalk": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@trezor/blockchain-link/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@trezor/connect": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.4.2.tgz",
-      "integrity": "sha512-SXp34aAZKicDd/3H3Et546MJtwmgSFUdnkIR7zBbqm9sdyxOzNmapE7bRpYYhSJtVarCY/COwdfXNOo1wO9JZQ==",
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.4.7.tgz",
+      "integrity": "sha512-Ky8AMWxhq0ieOCNgZtaIKTQie5qaQjK3uuv+TriUZXuxDqSoJcD8T50TAEY1Lxo1xl8Yv3wT0m6LQkmBn3T+xQ==",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
-        "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/tx": "^5.3.0",
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/tx": "^5.4.0",
         "@fivebinaries/coin-selection": "2.2.1",
-        "@trezor/blockchain-link": "2.3.1",
-        "@trezor/blockchain-link-types": "1.2.1",
-        "@trezor/connect-analytics": "1.2.1",
-        "@trezor/connect-common": "0.2.2",
-        "@trezor/protobuf": "1.2.2",
-        "@trezor/protocol": "1.2.1",
-        "@trezor/schema-utils": "1.2.1",
-        "@trezor/transport": "1.3.2",
-        "@trezor/utils": "9.2.1",
-        "@trezor/utxo-lib": "2.2.1",
+        "@trezor/blockchain-link": "2.3.6",
+        "@trezor/blockchain-link-types": "1.2.5",
+        "@trezor/connect-analytics": "1.2.4",
+        "@trezor/connect-common": "0.2.7",
+        "@trezor/protobuf": "1.2.6",
+        "@trezor/protocol": "1.2.2",
+        "@trezor/schema-utils": "1.2.3",
+        "@trezor/transport": "1.3.7",
+        "@trezor/utils": "9.2.6",
+        "@trezor/utxo-lib": "2.2.6",
         "blakejs": "^1.2.1",
         "bs58": "^6.0.0",
         "bs58check": "^4.0.0",
@@ -9568,36 +10613,36 @@
       }
     },
     "node_modules/@trezor/connect-analytics": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.2.1.tgz",
-      "integrity": "sha512-zvnoyTop5rz4i3KkhAIG8rnOOn5TIUgZcBbOD2a8lya/zeAlMhMtGg2R3STZWbj91xhmouoIb76ipB5jShsfCg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.2.4.tgz",
+      "integrity": "sha512-x7cbQ/x+THMG6pBttRip9qySDU6SRnTiN0AHUKDLBpUrOV+85fRScxUaX5RddtmG26J96HgNEw7Ydms7tBOlSQ==",
       "dependencies": {
-        "@trezor/analytics": "1.2.1"
+        "@trezor/analytics": "1.2.5"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/connect-common": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.2.2.tgz",
-      "integrity": "sha512-evPjhDhV6RNv90OiLIFAXnWKMojwsSMltxyhsCrjzAO5e+xrP/ZykCLoJfO0MR7onFGNi41H91wpvD7LSXLvMQ==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.2.7.tgz",
+      "integrity": "sha512-m9gYDY0Elitofs4k3E4uAmzgi2DtJHneb47jQVbjBZSLpzROiV7fz49aDxBnz/oPCJnIVF9Gu2OUQEh2GDeZcA==",
       "dependencies": {
-        "@trezor/env-utils": "1.2.0",
-        "@trezor/utils": "9.2.1"
+        "@trezor/env-utils": "1.2.1",
+        "@trezor/utils": "9.2.6"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/connect-web": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.4.2.tgz",
-      "integrity": "sha512-nkqfNx7KZyHovteJsxRPqu/63u3Xp4Hi4BtJDkt/ialpIBC78Nheiyz0fY16mxPz+HKrlpswryimlfjDD59aWA==",
+      "version": "9.4.7",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.4.7.tgz",
+      "integrity": "sha512-mICiGnw1xt60LbELZd2OId+nXGG/NAiywQIXGp5rOY6116I/sqJMw4fuKQrkGJ5zpKzzX/G7Be9GcshICD1ZDg==",
       "dependencies": {
-        "@trezor/connect": "9.4.2",
-        "@trezor/connect-common": "0.2.2",
-        "@trezor/utils": "9.2.1"
+        "@trezor/connect": "9.4.7",
+        "@trezor/connect-common": "0.2.7",
+        "@trezor/utils": "9.2.6"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
@@ -9634,9 +10679,9 @@
       }
     },
     "node_modules/@trezor/env-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.2.0.tgz",
-      "integrity": "sha512-dbOR+PIeReZW4iooN+DQIMWloZAV92jMGOTzEdcY6NA63nCV8QUSxoNZwZtU9nVRPeJLrT6cVkVG80nZjlplow==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.2.1.tgz",
+      "integrity": "sha512-ESBV+/AWpfJA6qnHk7BgBYFbhNtUKjPZZzQr1LOUiePwFITbVu421b5BHjTSPFVjpbrWo6Ob0IG7u8saJi0G5A==",
       "dependencies": {
         "ua-parser-js": "^1.0.37"
       },
@@ -9659,57 +10704,29 @@
       }
     },
     "node_modules/@trezor/protobuf": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.2.2.tgz",
-      "integrity": "sha512-zEpyQHMXpG6LJC/f1lKyzRIsy+v+waor7MdSQ0Dh4ndBf/NkHdxAkCPmT6aehZ8UFZuSDMlp0plK8V+0p9pHNw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.2.6.tgz",
+      "integrity": "sha512-QN/1T0/NgZk3r5FVGtMVL41Q3UaUdjFsE4LSxWvzreLp9T5jsHp5bL0wT6TCkocNqmKK3ijH2Ro/Dh8VOSZDbQ==",
       "dependencies": {
-        "@trezor/schema-utils": "1.2.1",
+        "@trezor/schema-utils": "1.2.3",
         "protobufjs": "7.4.0"
       },
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@trezor/protobuf/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@trezor/protobuf/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@trezor/protocol": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.2.1.tgz",
-      "integrity": "sha512-KGRtlizHk4nz7owhHH/gP3XfTbOGvD1Co3As1KOvVAA4+J+YJsk4ri84heJG9vb1Mi30rY2fvQ0TrxOL7bgsWQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.2.2.tgz",
+      "integrity": "sha512-iXD+Wqpk0FpwJpQbAFKw+8AL6ipfDjQ7g+MYZ7lU1H7/gCxM2XqLI4eW7Il+FAwk7orepDuoSbJSVcsNJYKjOA==",
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/schema-utils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.2.1.tgz",
-      "integrity": "sha512-oMAxn8UWknstNHW0BHpT5uV3K74Sc71NMp84IDdvmgGJKu8szuynUEbwuLa399TWNT8w76dp4JY1antZ0/uQhw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.2.3.tgz",
+      "integrity": "sha512-+/GmaSTfUf8nEBSSWz/SV0W/0l37YQBfDMygAKXlKMbtXJI03PHqkEF/jQrt+BP2Gh24gjo5GNqCwx7EIlzZug==",
       "dependencies": {
         "@sinclair/typebox": "^0.33.7",
         "ts-mixer": "^6.0.3"
@@ -9719,13 +10736,13 @@
       }
     },
     "node_modules/@trezor/transport": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.3.2.tgz",
-      "integrity": "sha512-QeudU2AUfFFqORgb+Hg+T7Fy6Qusk45QESJmPI/sxqjQyqEV3kCbg6bPQppDvljasZLiz0Ofw5JAkDAELGkdew==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.3.7.tgz",
+      "integrity": "sha512-pxoPbgaDKUg5ElgyzW+vuQ1YLLX75W/bfAk0V6SdPGqpd3V+6NvJaNQVxAnmL6k3qzHheBFrqyhlkkkEdyuuSQ==",
       "dependencies": {
-        "@trezor/protobuf": "1.2.2",
-        "@trezor/protocol": "1.2.1",
-        "@trezor/utils": "9.2.1",
+        "@trezor/protobuf": "1.2.6",
+        "@trezor/protocol": "1.2.2",
+        "@trezor/utils": "9.2.6",
         "cross-fetch": "^4.0.0",
         "long": "^4.0.0",
         "protobufjs": "7.4.0",
@@ -9743,43 +10760,15 @@
         "node-fetch": "^2.6.12"
       }
     },
-    "node_modules/@trezor/transport/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@trezor/transport/node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
     "node_modules/@trezor/type-utils": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.1.0.tgz",
-      "integrity": "sha512-zoPN9ZmdYlr03WyCWEQY6xCHPfhsodENYHPcZMKObVsUlhtMh1Z7OSD/pzd/NzOPBAtSctNbldx4aFu9A88afw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.1.4.tgz",
+      "integrity": "sha512-pzrIdskmTZRocHellMZxCDPQ3IpmTr749qn1xdIN29pIKuI4ms0OfNUPk/rfR4Iug0kEiWt+n+Hw7+lIBzc2LA=="
     },
     "node_modules/@trezor/utils": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.1.tgz",
-      "integrity": "sha512-BKE/B4szVjdzbZ35Gg0x6l5o/HF3BShlGIQ0S7Ypw9puNriCKTEHBM7YoNYWxx90Byah8o6uxlkQDxPH86ppWA==",
+      "version": "9.2.6",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.6.tgz",
+      "integrity": "sha512-8kJYRcOm2uD9uAzktXFivY9Ctkub39MUQCo0TIFzL01erzSDt5i9f81meIgLANm8cgmg3PPVA6SWyitOKRkKpg==",
       "dependencies": {
         "bignumber.js": "^9.1.2"
       },
@@ -9788,11 +10777,11 @@
       }
     },
     "node_modules/@trezor/utxo-lib": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.2.1.tgz",
-      "integrity": "sha512-yBodbZ5kmZucSJFhWfO8WefAacm+d12wbKX8zgrRnQM5Hr4NfACvQh2yLh4UpgM/r3BGAbx8qnEXNpw6SwdOTg==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.2.6.tgz",
+      "integrity": "sha512-OAwN1d4CXU/7LhczatdL/xKaYcyjxWiURYfG5hOfscTvhaDZ+veFhxo6YHJ2fGGlpZwS+B14JRsmDoXAelIeeA==",
       "dependencies": {
-        "@trezor/utils": "9.2.1",
+        "@trezor/utils": "9.2.6",
         "bchaddrjs": "^0.5.2",
         "bech32": "^2.0.0",
         "bip66": "^2.0.0",
@@ -9818,11 +10807,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
       "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
-    },
-    "node_modules/@trezor/utxo-lib/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58": {
       "version": "6.0.0",
@@ -9853,9 +10837,9 @@
       "dev": true
     },
     "node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -9894,9 +10878,9 @@
       "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz",
-      "integrity": "sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -9928,17 +10912,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ=="
-    },
-    "node_modules/@types/lodash.values": {
-      "version": "4.3.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.values/-/lodash.values-4.3.9.tgz",
-      "integrity": "sha512-IJ20OEfqNwm3k8ENwoM3q0yOs4UMpgtD4GqxB4lwBHToGthHWqhyh5DdSgQjioocz0QK2SSBkJfCq95ZTV8BTw==",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -9951,17 +10927,17 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.16.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.16.11.tgz",
-      "integrity": "sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==",
+      "version": "20.17.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
+      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -9982,26 +10958,26 @@
       }
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.13",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
-      "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA=="
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.3.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
-      "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
+      "version": "18.3.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
+      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-infinite-scroller": {
@@ -10026,10 +11002,10 @@
       }
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.11",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.11.tgz",
-      "integrity": "sha512-RM05tAniPZ5DZPzzNFP+DmrcOdD0efDUxMy3145oljWSl3x9ZV5vhme98gTxFrj2lhXvmGNnUiuDyJgY9IKkNA==",
-      "dependencies": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "peerDependencies": {
         "@types/react": "*"
       }
     },
@@ -10076,9 +11052,9 @@
       "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
     },
     "node_modules/@types/web": {
-      "version": "0.0.162",
-      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.162.tgz",
-      "integrity": "sha512-uYssYXblX0BTDdpxllMQ84uDEk0EeU+dcfo8Whyl715cpfsYk5+msRQ6ul0TJGHbCr0XftFybVQGpy1eU262Aw=="
+      "version": "0.0.174",
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.174.tgz",
+      "integrity": "sha512-dT8gX38RUQjy+uruZg49EvloEa2S3gR0z2eRi557eTSFKqUSXkSCWYa0IY9uabX9MZPMGOu+1r8Qn6tsvJ1KnQ=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
@@ -10313,21 +11289,21 @@
       }
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
       "dev": true
     },
     "node_modules/@vitejs/plugin-react-swc": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.1.tgz",
-      "integrity": "sha512-vgWOY0i1EROUK0Ctg1hwhtC3SdcDjZcdit4Ups4aPkDcB1jYhmo+RMYWY87cmXMhvtD5uf8lV89j2w16vkdSVg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz",
+      "integrity": "sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==",
       "dev": true,
       "dependencies": {
         "@swc/core": "^1.7.26"
       },
       "peerDependencies": {
-        "vite": "^4 || ^5"
+        "vite": "^4 || ^5 || ^6"
       }
     },
     "node_modules/@vitest/expect": {
@@ -10436,52 +11412,52 @@
       }
     },
     "node_modules/@volar/language-core": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.6.tgz",
-      "integrity": "sha512-FxUfxaB8sCqvY46YjyAAV6c3mMIq/NWQMVvJ+uS4yxr1KzOvyg61gAuOnNvgCvO4TZ7HcLExBEsWcDu4+K4E8A==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
       "dev": true,
       "dependencies": {
-        "@volar/source-map": "2.4.6"
+        "@volar/source-map": "2.4.11"
       }
     },
     "node_modules/@volar/source-map": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.6.tgz",
-      "integrity": "sha512-Nsh7UW2ruK+uURIPzjJgF0YRGP5CX9nQHypA2OMqdM2FKy7rh+uv3XgPnWPw30JADbKvZ5HuBzG4gSbVDYVtiw==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
       "dev": true
     },
     "node_modules/@volar/typescript": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.6.tgz",
-      "integrity": "sha512-NMIrA7y5OOqddL9VtngPWYmdQU03htNKFtAYidbYfWA0TOhyGVd9tfcP4TsLWQ+RBWDZCbBqsr8xzU0ZOxYTCQ==",
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
+      "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "2.4.6",
+        "@volar/language-core": "2.4.11",
         "path-browserify": "^1.0.1",
         "vscode-uri": "^3.0.8"
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.11.tgz",
-      "integrity": "sha512-PwAdxs7/9Hc3ieBO12tXzmTD+Ln4qhT/56S+8DvrrZ4kLDn4Z/AMUr8tXJD0axiJBS0RKIoNaR0yMuQB9v9Udg==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.25.3",
-        "@vue/shared": "3.5.11",
+        "@vue/shared": "3.5.13",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.11.tgz",
-      "integrity": "sha512-pyGf8zdbDDRkBrEzf8p7BQlMKNNF5Fk/Cf/fQ6PiUz9at4OaUfyXW0dGJTo2Vl1f5U9jSLCNf0EZJEogLXoeew==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
       "dev": true,
       "dependencies": {
-        "@vue/compiler-core": "3.5.11",
-        "@vue/shared": "3.5.11"
+        "@vue/compiler-core": "3.5.13",
+        "@vue/shared": "3.5.13"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -10495,16 +11471,16 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.6.tgz",
-      "integrity": "sha512-MW569cSky9R/ooKMh6xa2g1D0AtRKbL56k83dzus/bx//RDJk24RHWkMzbAlXjMdDNyxAaagKPRquBIxkxlCkg==",
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
+      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
       "dev": true,
       "dependencies": {
-        "@volar/language-core": "~2.4.1",
-        "@vue/compiler-dom": "^3.4.0",
+        "@volar/language-core": "~2.4.8",
+        "@vue/compiler-dom": "^3.5.0",
         "@vue/compiler-vue2": "^2.7.16",
-        "@vue/shared": "^3.4.0",
-        "computeds": "^0.0.1",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^0.2.0",
         "minimatch": "^9.0.3",
         "muggle-string": "^0.4.1",
         "path-browserify": "^1.0.1"
@@ -10543,9 +11519,9 @@
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.11.tgz",
-      "integrity": "sha512-W8GgysJVnFo81FthhzurdRAWP/byq3q2qIw70e0JWblzVhjgOMiC2GyovXrZTFQJnFVryYaKGP3Tc9vYzYm6PQ==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
       "dev": true
     },
     "node_modules/@wagmi/connectors": {
@@ -10702,20 +11678,20 @@
       }
     },
     "node_modules/@wallet-standard/app": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.0.1.tgz",
-      "integrity": "sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
+      "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
-      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
       "engines": {
         "node": ">=16"
       }
@@ -10735,22 +11711,22 @@
       }
     },
     "node_modules/@wallet-standard/features": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.3.tgz",
-      "integrity": "sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/wallet": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.0.1.tgz",
-      "integrity": "sha512-qkhJeuQU2afQTZ02yMZE5SFc91Fo3hyFjFkpQglHudENNyiSG0oUKcIjky8X32xVSaumgTZSQUAzpXnCTWHzKQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=16"
@@ -10769,23 +11745,24 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-On+uSaCfWdsMIQsECwWHZBmUXfrnqmv6B8SXRRuTJgd8tUpEvBkLQH4X7XkSm3zW6ozEkQTCagZ2ox2YPn3kbw==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.3.tgz",
+      "integrity": "sha512-57uv0FW4L6H/tmkb1kS2nG41MDguyDgZbGR58nkDUd1TO/HydyiTByVOhFzIxgN331cnY/1G1rMaKqncgdnOFA==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
         "@walletconnect/jsonrpc-types": "1.0.4",
         "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.14",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.0",
-        "@walletconnect/utils": "2.17.0",
+        "@walletconnect/types": "2.17.3",
+        "@walletconnect/utils": "2.17.3",
+        "@walletconnect/window-getters": "1.0.1",
         "events": "3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "3.1.0"
@@ -10803,9 +11780,9 @@
       }
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.0.tgz",
-      "integrity": "sha512-i1pn9URpvt9bcjRDkabuAmpA9K7mzyKoLJlbsAujRVX7pfaG7wur7u9Jz0bk1HxvuABL5LHNncTnVKSXKQ5jZA==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -10813,6 +11790,14 @@
         "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/logger": "2.1.2",
         "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/core/node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "dependencies": {
+        "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/core/node_modules/tslib": {
@@ -10936,6 +11921,17 @@
         "tslib": "1.14.1"
       }
     },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
@@ -11021,6 +12017,26 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@walletconnect/events": {
       "version": "1.0.1",
@@ -11118,9 +12134,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
-      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -11140,6 +12156,26 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@walletconnect/keyvaluestorage": {
       "version": "1.1.1",
@@ -11253,20 +12289,6 @@
         "qrcode": "^1.5.1"
       }
     },
-    "node_modules/@walletconnect/legacy-modal/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/@walletconnect/legacy-modal/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11284,22 +12306,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -11371,9 +12377,9 @@
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/preact": {
-      "version": "10.24.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "version": "10.25.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
+      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -11420,11 +12426,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@walletconnect/legacy-modal/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/yargs": {
       "version": "15.4.1",
@@ -11603,20 +12604,6 @@
         "qrcode": "1.5.3"
       }
     },
-    "node_modules/@walletconnect/modal-ui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/@walletconnect/modal-ui/node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -11634,22 +12621,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
-    },
-    "node_modules/@walletconnect/modal-ui/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@walletconnect/modal-ui/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@walletconnect/modal-ui/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -11763,11 +12734,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@walletconnect/modal-ui/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
     "node_modules/@walletconnect/modal-ui/node_modules/yargs": {
       "version": "15.4.1",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -11871,25 +12837,25 @@
       "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.0.tgz",
-      "integrity": "sha512-sErYwvSSHQolNXni47L3Bm10ptJc1s1YoJvJd34s5E9h9+d3rj7PrhbiW9X82deN+Dm5oA8X9tC4xty1yIBrVg==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.3.tgz",
+      "integrity": "sha512-OzOWxRTfVGCHU3OOF6ibPkgPfDpivFJjuknfcOUt9PYWpTAv6YKOmT4cyfBPhc7llruyHpV44fYbykMcLIvEcg==",
       "dependencies": {
-        "@walletconnect/core": "2.17.0",
+        "@walletconnect/core": "2.17.3",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "2.1.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.0",
-        "@walletconnect/utils": "2.17.0",
+        "@walletconnect/types": "2.17.3",
+        "@walletconnect/utils": "2.17.3",
         "events": "3.3.0"
       }
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.0.tgz",
-      "integrity": "sha512-i1pn9URpvt9bcjRDkabuAmpA9K7mzyKoLJlbsAujRVX7pfaG7wur7u9Jz0bk1HxvuABL5LHNncTnVKSXKQ5jZA==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -11987,6 +12953,17 @@
         "tslib": "1.14.1"
       }
     },
+    "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
@@ -12073,25 +13050,49 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@walletconnect/universal-provider/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@walletconnect/utils": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.0.tgz",
-      "integrity": "sha512-1aeQvjwsXy4Yh9G6g2eGmXrEl+BzkNjHRdCrGdMYqFTFa8ROEJfTGsSH3pLsNDlOY94CoBUvJvM55q/PMoN/FQ==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.3.tgz",
+      "integrity": "sha512-tG77UpZNeLYgeOwViwWnifpyBatkPlpKSSayhN0gcjY1lZAUNqtYslpm4AdTxlrA3pL61MnyybXgWYT5eZjarw==",
       "dependencies": {
+        "@ethersproject/hash": "5.7.0",
+        "@ethersproject/transactions": "5.7.0",
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
         "@walletconnect/relay-api": "1.0.11",
         "@walletconnect/relay-auth": "1.0.4",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.17.0",
+        "@walletconnect/types": "2.17.3",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "detect-browser": "5.3.0",
-        "elliptic": "^6.5.7",
+        "elliptic": "6.6.1",
         "query-string": "7.1.3",
         "uint8arrays": "3.1.0"
       }
@@ -12105,9 +13106,9 @@
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.0.tgz",
-      "integrity": "sha512-i1pn9URpvt9bcjRDkabuAmpA9K7mzyKoLJlbsAujRVX7pfaG7wur7u9Jz0bk1HxvuABL5LHNncTnVKSXKQ5jZA==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -12161,6 +13162,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.4.3.tgz",
       "integrity": "sha512-7Z/sDe9RIYQ2k9ITcxgEa/u7FvlI76vcVVZn9UY4ISivefqrH4JAS3GX4JmVNUUlovwuiZdyqBv4llAQOMK6Rg==",
+      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
       "dependencies": {
         "buffer": "6.0.3",
         "valtio": "1.10.5"
@@ -12208,25 +13210,12 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.4.3.tgz",
       "integrity": "sha512-J989p8CdtEhI9gZHf/rZ/WFqYlrAHWw9GmAhFoiNODwjAp0BoG/uoaPiijJMchXdngihZOjLGCQwDXU16DHiKg==",
+      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
       "dependencies": {
         "@web3modal/core": "2.4.3",
         "lit": "2.7.5",
         "motion": "10.16.2",
         "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/@web3modal/ui/node_modules/camelcase": {
@@ -12246,22 +13235,6 @@
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
       }
-    },
-    "node_modules/@web3modal/ui/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@web3modal/ui/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -12384,11 +13357,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@web3modal/ui/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/@web3modal/ui/node_modules/yargs": {
       "version": "15.4.1",
@@ -12543,6 +13511,14 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/bip39": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
@@ -12576,6 +13552,19 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/@wormhole-foundation/sdk-aptos/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
       "version": "1.3.0-beta.3",
@@ -12630,253 +13619,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/cosmwasm-stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
-      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "pako": "^2.0.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-core/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
       "version": "1.3.0-beta.3",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.3.0-beta.3.tgz",
@@ -12894,253 +13636,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/cosmwasm-stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
-      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "pako": "^2.0.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
       "version": "1.3.0-beta.3",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.3.0-beta.3.tgz",
@@ -13153,500 +13648,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/cosmwasm-stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
-      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "pako": "^2.0.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/amino": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/cosmwasm-stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
-      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stargate": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "pako": "^2.0.2"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/json-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
-      "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/socket": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
-      "dependencies": {
-        "@cosmjs/stream": "^0.32.4",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stargate": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
-      "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/proto-signing": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/tendermint-rpc": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/stream": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/json-rpc": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/socket": "^0.32.4",
-        "@cosmjs/stream": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@cosmjs/utils": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/core-proto-ts": {
-      "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
-      "dependencies": {
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "google-protobuf": "^3.14.0",
-        "protobufjs": "^7.0.0",
-        "rxjs": "^7.4.0"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
-      "dependencies": {
-        "@apollo/client": "^3.11.10",
-        "@cosmjs/amino": "^0.32.3",
-        "@cosmjs/proto-signing": "^0.32.3",
-        "@cosmjs/stargate": "^0.32.3",
-        "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "1.13.4",
-        "@injectivelabs/exceptions": "^1.14.33",
-        "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
-        "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.13.3",
-        "@injectivelabs/mito-proto-ts": "1.13.0",
-        "@injectivelabs/networks": "^1.14.33",
-        "@injectivelabs/olp-proto-ts": "1.13.1",
-        "@injectivelabs/test-utils": "^1.14.33",
-        "@injectivelabs/ts-types": "^1.14.33",
-        "@injectivelabs/utils": "^1.14.33",
-        "@metamask/eth-sig-util": "^4.0.0",
-        "@noble/curves": "^1.4.0",
-        "axios": "^1.6.4",
-        "bech32": "^2.0.0",
-        "bip39": "^3.0.4",
-        "cosmjs-types": "^0.9.0",
-        "ethereumjs-util": "^7.1.4",
-        "ethers": "^6.5.1",
-        "google-protobuf": "^3.21.0",
-        "graphql": "^16.3.0",
-        "http-status-codes": "^2.2.0",
-        "js-sha3": "^0.8.0",
-        "jscrypto": "^1.0.3",
-        "keccak256": "^1.0.6",
-        "secp256k1": "^4.0.3",
-        "shx": "^0.3.2",
-        "snakecase-keys": "^5.4.1"
-      }
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/@injectivelabs/sdk-ts/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-    },
-    "node_modules/@wormhole-foundation/sdk-cosmwasm/node_modules/protobufjs": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
@@ -13710,7 +13711,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-ntt/-/sdk-evm-ntt-0.6.1.tgz",
       "integrity": "sha512-PT/05wur6iRGfmfy52QQb7NSoNtvhQ31DVtSl19ugYBGHM6rccAs+QstihwyQ1AfX2CNzOoxGschIQ2Q06CD+w==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "ethers": "^6.5.1"
@@ -13755,27 +13755,26 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.0.2.tgz",
-      "integrity": "sha512-Cdt4q1NcHEH10fsj37NPj/DSSeq8L0YBMnx3DETcJluZf53IM+RqAcGRHgJDOzxTCSH8tWq9aWX00p7tKz/gIQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.3.0.tgz",
+      "integrity": "sha512-yz2e8eVhG8+FN3GItiJDmFKjviz3O8hjNZZEsOJXQgy4DoQbvRz3gGSZTrHllQDkEIo7A4liSG2Qf7u1hzyV2Q==",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.0.2"
+        "@wormhole-foundation/sdk-base": "1.3.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons/node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.0.2.tgz",
-      "integrity": "sha512-5HIkquipfVDXu5EVvw1h9gclLVo+5PhQqlPN/ra3cT4iBJjjUcRSkRjTPi80G8pbynFS9ODP2hsBTuHdpbZgKg==",
-      "license": "Apache-2.0",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0.tgz",
+      "integrity": "sha512-/QpnDN6WBOOZC0mkeEmUWbUv/gLRY5aEl1U1mYXIInglSvIlARzFJtcFhxiuKMOZfufXM81j4G1XsZAWzff6lQ==",
       "dependencies": {
-        "@scure/base": "^1.1.3"
+        "@scure/base": "^1.1.3",
+        "binary-layout": "^1.0.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-route-ntt": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-route-ntt/-/sdk-route-ntt-0.6.1.tgz",
       "integrity": "sha512-nR/m7l9PePz9Dk7kXAosS+ei9SCXK0aqsSvyxm4wNwnxoCNU2OotwkPVmaIbAyr1BkZ1J2ii921sOTTWcInILg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "@wormhole-foundation/sdk-evm-ntt": "0.6.1",
@@ -13854,7 +13853,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-0.6.1.tgz",
       "integrity": "sha512-YSumolkZ9wKGvRLOzB12u+RgAzC4Yg1gzN2dUvdngWLsGeikfnDCGOz5fBqAdM5M5nK3ECHDShw8fnfTqNQaGQ==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13877,7 +13875,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.0.tgz",
       "integrity": "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -14000,11 +13997,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -14069,11 +14061,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
-    },
-    "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/bs58": {
       "version": "5.0.0",
@@ -14141,11 +14128,6 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
-    "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
-    },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -14197,11 +14179,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
-    },
-    "node_modules/@wormhole-foundation/sdk-sui/node_modules/bech32": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/bs58": {
       "version": "5.0.0",
@@ -14276,7 +14253,6 @@
       "version": "0.0.1-alpha.22",
       "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.22.tgz",
       "integrity": "sha512-NzFm0nTSH5KR4pxEY8r8b9BdlT8Q95r0YfiEScERqpowWeYYGP/pZA/x+/iEEF2vpAbINLXz+pwcwGT/5r1xhA==",
-      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
@@ -14290,7 +14266,6 @@
       "version": "0.0.2-alpha.5",
       "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-evm/-/wallet-aggregator-evm-0.0.2-alpha.5.tgz",
       "integrity": "sha512-ZWVN9OT5SxHDhtCodMgznJ4jxcPQD4qD4pFySzlNghPBMMLXGCZsXh20WuUnI2MUS/yMvdSBM5PEMnR3MNyH0g==",
-      "license": "MIT",
       "dependencies": {
         "@binance/w3w-ethereum-provider": "1.1.8-alpha.0",
         "@binance/w3w-utils": "^1.1.6",
@@ -14351,9 +14326,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14491,16 +14466,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/alien-signals": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
+      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
+      "dev": true
+    },
     "node_modules/ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^1.0.2"
+        "type-fest": "^0.21.3"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14515,14 +14496,17 @@
       }
     },
     "node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
-        "color-convert": "^1.9.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -14540,6 +14524,17 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/aptos": {
@@ -14569,6 +14564,14 @@
         }
       ]
     },
+    "node_modules/aptos/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/aptos/node_modules/@scure/bip39": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
@@ -14591,6 +14594,19 @@
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/aptos/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/arg": {
@@ -14624,9 +14640,9 @@
       }
     },
     "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/assert": {
       "version": "2.1.0",
@@ -14685,9 +14701,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -14709,13 +14725,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.11.tgz",
-      "integrity": "sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==",
+      "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
-        "@babel/helper-define-polyfill-provider": "^0.6.2",
+        "@babel/helper-define-polyfill-provider": "^0.6.3",
         "semver": "^6.3.1"
       },
       "peerDependencies": {
@@ -14736,12 +14752,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.2.tgz",
-      "integrity": "sha512-2R25rQZWP63nGwaAswvDazbPXfrM3HwVoBXK6HcqeKrSrL/JqcC/rDcf95l4r7LXLyxDXc8uQDa064GubtCABg==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.6.2"
+        "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -14802,9 +14818,9 @@
       }
     },
     "node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
@@ -15082,9 +15098,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
-      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "funding": [
         {
           "type": "opencollective",
@@ -15100,10 +15116,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001663",
-        "electron-to-chromium": "^1.5.28",
-        "node-releases": "^2.0.18",
-        "update-browserslist-db": "^1.1.0"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -15283,15 +15299,41 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
       },
       "engines": {
         "node": ">= 0.4"
@@ -15328,9 +15370,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001667",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
-      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -15378,24 +15420,19 @@
       }
     },
     "node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/check-error": {
@@ -15433,24 +15470,16 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+    "node_modules/cipher-base": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "node": ">= 0.10"
       }
     },
     "node_modules/citty": {
@@ -15565,6 +15594,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clipboardy/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/clipboardy/node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -15577,85 +15631,95 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cliui/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "color-convert": "^1.9.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/cliui/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/cliui/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
       }
     },
     "node_modules/cliui/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=6"
       }
     },
     "node_modules/clone-response": {
@@ -15678,17 +15742,20 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
-        "color-name": "1.1.3"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -15708,23 +15775,18 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "engines": {
-        "node": ">=18"
+        "node": ">= 12"
       }
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true
-    },
-    "node_modules/computeds": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
-      "integrity": "sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==",
       "dev": true
     },
     "node_modules/concat-map": {
@@ -15776,31 +15838,13 @@
         "toggle-selection": "^1.0.6"
       }
     },
-    "node_modules/copyfiles": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
-      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
-      "dependencies": {
-        "glob": "^7.0.5",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^1.0.4",
-        "noms": "0.0.0",
-        "through2": "^2.0.1",
-        "untildify": "^4.0.0",
-        "yargs": "^16.1.0"
-      },
-      "bin": {
-        "copyfiles": "copyfiles",
-        "copyup": "copyfiles"
-      }
-    },
     "node_modules/core-js-compat": {
-      "version": "3.38.1",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
-      "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
+      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.23.3"
+        "browserslist": "^4.24.2"
       },
       "funding": {
         "type": "opencollective",
@@ -15884,9 +15928,9 @@
       }
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -15928,9 +15972,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -15949,24 +15993,28 @@
       }
     },
     "node_modules/crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
       "dependencies": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
+        "browserify-cipher": "^1.0.1",
+        "browserify-sign": "^4.2.3",
+        "create-ecdh": "^4.0.4",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "diffie-hellman": "^5.0.3",
+        "hash-base": "~3.0.4",
+        "inherits": "^2.0.4",
+        "pbkdf2": "^3.1.2",
+        "public-encrypt": "^4.0.3",
+        "randombytes": "^2.1.0",
+        "randomfill": "^1.0.4"
       },
       "engines": {
-        "node": "*"
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/crypto-hash": {
@@ -16014,9 +16062,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -16221,9 +16269,9 @@
       }
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -16269,9 +16317,9 @@
       }
     },
     "node_modules/domain-browser": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.23.0.tgz",
-      "integrity": "sha512-ArzcM/II1wCCujdCNyQjXrAFwS4mrLh4C7DZWlaI8mdh7h3BfKdNd3bKXITfl2PT9FtfQqaGvhi1vPRQPimjGA==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -16298,18 +16346,17 @@
         "unidragger": "^3.0.0"
       }
     },
-    "node_modules/drbg.js": {
+    "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha512-F4wZ06PvqxYLFEZKkFxTDcns9oFNk34hvmJSEwdzsxVQ8YI5YaxtACgQatkYgv2VI2CFkUd2Y+xosPQnHv809g==",
-      "optional": true,
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dependencies": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
       },
       "engines": {
-        "node": ">=0.10"
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer": {
@@ -16334,80 +16381,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
-    "node_modules/eccrypto": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/eccrypto/-/eccrypto-1.1.6.tgz",
-      "integrity": "sha512-d78ivVEzu7Tn0ZphUUaL43+jVPKTMPFGtmgtz1D0LrFn7cY3K8CdrvibuLz2AAkHBLKZtR8DMbB2ukRYFk987A==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "acorn": "7.1.1",
-        "elliptic": "6.5.4",
-        "es6-promise": "4.2.8",
-        "nan": "2.14.0"
-      },
-      "optionalDependencies": {
-        "secp256k1": "3.7.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/acorn": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/eccrypto/node_modules/bip66": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
-      "integrity": "sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/eccrypto/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/eccrypto/node_modules/secp256k1": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
-      "integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "bip66": "^1.1.5",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "drbg.js": "^1.0.1",
-        "elliptic": "^6.4.1",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/eip1193-provider": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
@@ -16418,14 +16391,14 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.33",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.33.tgz",
-      "integrity": "sha512-+cYTcFB1QqD4j4LegwLfpCNxifb6dDFUAwk6RsLusCwIaZI6or2f+q8rs5tTB2YC53HhOlIbEaqHMAAC8IOIwA=="
+      "version": "1.5.74",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
+      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.7",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
-      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -16437,9 +16410,9 @@
       }
     },
     "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -16460,15 +16433,31 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.1.tgz",
-      "integrity": "sha512-aYuoak7I+R83M/BBPIOs2to51BmFIpC1wZe6zZzMrT2llVsHy5cvcmdsJgP2Qz6smHu+sD9oexiSUAVd8OfBPw==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.2.tgz",
+      "integrity": "sha512-TAr+NKeoVTjEVW8P3iHguO1LO6RlUz9O5Y8o7EY0fU+gY1NYqas7NN3slpFtbXEsLMHk0h90fJMfKjRkQ0qUIw==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
         "engine.io-parser": "~5.2.1",
         "ws": "~8.17.1",
         "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/engine.io-client/node_modules/ws": {
@@ -16545,12 +16534,9 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
@@ -16559,6 +16545,17 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -16702,9 +16699,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0.tgz",
-      "integrity": "sha512-hIOwI+5hYGpJEc4uPRmz2ulCjAGD/N13Lukkh8cLV0i2IRk/bdZDYjgLVHj+U9Z704kLIdIO6iueGvxNur0sgw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -16738,55 +16735,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/eslint/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -16812,6 +16760,18 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.24.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -16825,27 +16785,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/type-fest": {
@@ -17015,123 +16954,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/eth-crypto": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/eth-crypto/-/eth-crypto-2.6.0.tgz",
-      "integrity": "sha512-GCX4ffFYRUGgnuWR5qxcZIRQJ1KEqPFiyXU9yVy7s6dtXIMlUXZQ2h+5ID6rFaOHWbpJbjfkC6YdhwtwRYCnug==",
-      "dependencies": {
-        "@babel/runtime": "7.20.13",
-        "@ethereumjs/tx": "3.5.2",
-        "@types/bn.js": "5.1.1",
-        "eccrypto": "1.1.6",
-        "ethereumjs-util": "7.1.5",
-        "ethers": "5.7.2",
-        "secp256k1": "5.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/pubkey"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@babel/runtime": {
-      "version": "7.20.13",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
-      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethereumjs/common": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.6.5.tgz",
-      "integrity": "sha512-lRyVQOeCDaIVtgfbowla32pzeDv2Obr8oR8Put5RdUBNRGr1VGPGQNGP6elWIpgK3YdpzqTOh4GyUGOureVeeA==",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.5"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/@ethereumjs/tx": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.5.2.tgz",
-      "integrity": "sha512-gQDNJWKrSDGu2w7w0PzVXVBNMzb7wwdDOmOqczmhNjqFxFuIbhVJDwiGEnxFNC2/b8ifcZzY7MLcluizohRzNw==",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.4",
-        "ethereumjs-util": "^7.1.5"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
-    "node_modules/eth-crypto/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-    },
-    "node_modules/eth-crypto/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
-    },
-    "node_modules/eth-crypto/node_modules/secp256k1": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.0.tgz",
-      "integrity": "sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/eth-json-rpc-filters": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-6.0.1.tgz",
@@ -17216,6 +17038,14 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ethereum-cryptography/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip32": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
@@ -17245,6 +17075,7 @@
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "deprecated": "This library has been deprecated and usage is discouraged.",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -17259,9 +17090,9 @@
       }
     },
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/ethereumjs-abi/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
@@ -17337,9 +17168,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.3.tgz",
-      "integrity": "sha512-/DzbZOLVtoO4fKvvQwpEucHAQgIwBGWuRvBdwE/lMXgXvvHHTSkn7XqAQ2b+gjJzZDJjWA9OD05bVceVOsBHbg==",
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
+      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
       "funding": [
         {
           "type": "individual",
@@ -17354,9 +17185,9 @@
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
         "@noble/hashes": "1.3.2",
-        "@types/node": "18.15.13",
+        "@types/node": "22.7.5",
         "aes-js": "4.0.0-beta.5",
-        "tslib": "2.4.0",
+        "tslib": "2.7.0",
         "ws": "8.17.1"
       },
       "engines": {
@@ -17386,9 +17217,12 @@
       }
     },
     "node_modules/ethers/node_modules/@types/node": {
-      "version": "18.15.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
     },
     "node_modules/ethers/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
@@ -17396,9 +17230,9 @@
       "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/ethers/node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
@@ -17503,6 +17337,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/execa/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
@@ -17548,17 +17409,6 @@
         "node": ">=8.6.0"
       }
     },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -17590,9 +17440,9 @@
       "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "node_modules/fast-uri": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
-      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
       "dev": true
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
@@ -17681,9 +17531,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
       "dev": true
     },
     "node_modules/follow-redirects": {
@@ -17740,9 +17590,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -17819,15 +17669,20 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "dunder-proto": "^1.0.0",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -17879,14 +17734,14 @@
       }
     },
     "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": {
-        "is-glob": "^4.0.3"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">= 6"
       }
     },
     "node_modules/globals": {
@@ -17938,11 +17793,11 @@
       "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18003,9 +17858,9 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
-      "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -18057,11 +17912,12 @@
       }
     },
     "node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
@@ -18075,21 +17931,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -18112,15 +17957,15 @@
       }
     },
     "node_modules/hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha512-EeeoJKjTyt868liAlVmcv2ZsUfGHlE3Q+BICOXcZiwN3osr5Q/zFGYmTJpoIzuaSTAwndFy+GqhEwlU4L3j4Ow==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">= 0.10"
       }
     },
     "node_modules/hash.js": {
@@ -18391,12 +18236,9 @@
       "integrity": "sha512-qNq5wy4qX4uWHcVFOEU+RqZkoVG65FhvGkyDWbuBxILMjK6A1LFf5A1mgXZkD4nRx5FCorD81X/XvPKp/zVfPA=="
     },
     "node_modules/int64-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.0.1.tgz",
-      "integrity": "sha512-+3azY4pXrjAupJHU1V9uGERWlhoqNswJNji6aD/02xac7oxol508AsMC5lxKhEqyZeDFy3enq5OGWXF4u75hiw==",
-      "engines": {
-        "node": ">= 4.5.0"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -18427,12 +18269,12 @@
       }
     },
     "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18469,9 +18311,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
-      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -18611,11 +18453,11 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -18731,9 +18573,9 @@
       }
     },
     "node_modules/jayson": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.2.tgz",
-      "integrity": "sha512-5nzMWDHy6f+koZOuYsArh2AXs73NfWYVlFyJJuCedr93GpY+Ku8qq10ropSXVfHK+H0T6paA88ww+/dV+1fBNA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -18765,10 +18607,30 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jiti": {
-      "version": "1.21.6",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-      "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -18835,9 +18697,9 @@
       }
     },
     "node_modules/jsesc": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -18903,11 +18765,12 @@
       "dev": true
     },
     "node_modules/json-stable-stringify": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.1.1.tgz",
-      "integrity": "sha512-SU/971Kt5qVQfJpyDveVhQ/vya+5hvrjClFOcr8c0Fq5aODJjMwutrOfCU+eCnVD5gpx1Q3fEqkyom77zH1iIg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.0.tgz",
+      "integrity": "sha512-ex8jk9BZHBolvbd5cRnAgwyaYcYB0qZldy1e+LCOdcF6+AUmVZ6LcGUMzsRTW83QMeu+GxZGrcLqxqrgfXGvIw==",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "isarray": "^2.0.5",
         "jsonify": "^0.0.1",
         "object-keys": "^1.1.1"
@@ -18971,9 +18834,9 @@
       ]
     },
     "node_modules/jsonschema": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
-      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
       "engines": {
         "node": "*"
       }
@@ -19059,23 +18922,10 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/libsodium": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.15.tgz",
-      "integrity": "sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw=="
-    },
     "node_modules/libsodium-sumo": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.15.tgz",
       "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw=="
-    },
-    "node_modules/libsodium-wrappers": {
-      "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.15.tgz",
-      "integrity": "sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==",
-      "dependencies": {
-        "libsodium": "^0.7.15"
-      }
     },
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.15",
@@ -19089,6 +18939,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
       "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -19097,20 +18948,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
-    },
-    "node_modules/link-module-alias": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/link-module-alias/-/link-module-alias-1.2.0.tgz",
-      "integrity": "sha512-ahPjXepbSVKbahTB6LxR//VHm8HPfI+QQygCH+E82spBY4HR5VPJTvlhKBc9F7muVxnS6C1rRfoPOXAbWO/fyw==",
-      "dependencies": {
-        "chalk": "^2.4.1"
-      },
-      "bin": {
-        "link-module-alias": "index.js"
-      },
-      "engines": {
-        "node": "> 8.0.0"
-      }
     },
     "node_modules/lint-staged": {
       "version": "13.3.0",
@@ -19196,6 +19033,18 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/lint-staged/node_modules/yaml": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
@@ -19235,9 +19084,9 @@
       }
     },
     "node_modules/listhen/node_modules/jiti": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.3.3.tgz",
-      "integrity": "sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -19302,13 +19151,13 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
-      "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
       "dev": true,
       "dependencies": {
-        "mlly": "^1.4.2",
-        "pkg-types": "^1.0.3"
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -19358,11 +19207,6 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
-    "node_modules/lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha512-r0RwvdCv8id9TUblb/O7rYPwVy6lerCbcawrfdo9iC/1t1wsNMJknO79WNBgwkH0hIeJ08jmvvESbFpNb4jH0Q=="
-    },
     "node_modules/log-update": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
@@ -19377,6 +19221,21 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-escapes": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -19407,6 +19266,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/loglevel": {
@@ -19479,9 +19350,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.11",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
-      "integrity": "sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -19504,13 +19375,12 @@
       }
     },
     "node_modules/material-ui-popup-state": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.3.1.tgz",
-      "integrity": "sha512-mmx1DsQwF/2cmcpHvS/QkUwOQG2oAM+cDEQU0DaZVYnvwKyTB3AFgu8l1/E+LQFausmzpSJoljwQSZXkNvt7eA==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.3.3.tgz",
+      "integrity": "sha512-eaoA4y965neZw1/iPYZ7haCGO369m5QXJT35e0RStzHd4lgrd6PC+UYkYTIRGTrNt+8Vbx8qtYUFDzRjjAGwnw==",
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@types/prop-types": "^15.7.3",
-        "@types/react": "^18.0.26",
         "classnames": "^2.2.6",
         "prop-types": "^15.7.2"
       },
@@ -19519,7 +19389,21 @@
       },
       "peerDependencies": {
         "@mui/material": "^5.0.0 || ^6.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17 || ^18 || ^19",
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/md5.js": {
@@ -19562,6 +19446,17 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
@@ -19575,9 +19470,9 @@
       }
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -19670,25 +19565,14 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/mlly": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.2.tgz",
-      "integrity": "sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
+      "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
       "dependencies": {
-        "acorn": "^8.12.1",
+        "acorn": "^8.14.0",
         "pathe": "^1.1.2",
-        "pkg-types": "^1.2.0",
+        "pkg-types": "^1.2.1",
         "ufo": "^1.5.4"
       }
     },
@@ -19703,14 +19587,6 @@
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
         "@motionone/vue": "^10.16.2"
-      }
-    },
-    "node_modules/mri": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
-      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mrmime": {
@@ -19758,14 +19634,14 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -19838,9 +19714,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.2.tgz",
-      "integrity": "sha512-IRUxE4BVsHWXkV/SFOut4qTlagw2aM8T5/vnTsmrHJvVoKueJHRc/JaFND7QDDc61kLYUJ6qlZM3sqTSyx2dTw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -19848,14 +19724,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.18",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.18.tgz",
-      "integrity": "sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
     "node_modules/node-stdlib-browser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.2.1.tgz",
-      "integrity": "sha512-dZezG3D88Lg22DwyjsDuUs7cCT/XGr8WwJgg/S3ZnkcWuPet2Tt/W1d2Eytb1Z73JpZv+XVCDI5TWv6UMRq0Gg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.0.tgz",
+      "integrity": "sha512-g/koYzOr9Fb1Jc+tHUHlFd5gODjGn48tHexUK8q6iqOVriEgSnd3/1T7myBYc+0KBVze/7F7n65ec9rW6OD7xw==",
       "dev": true,
       "dependencies": {
         "assert": "^2.0.0",
@@ -19866,7 +19742,7 @@
         "constants-browserify": "^1.0.0",
         "create-require": "^1.1.1",
         "crypto-browserify": "^3.11.0",
-        "domain-browser": "^4.22.0",
+        "domain-browser": "4.22.0",
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "isomorphic-timers-promises": "^1.0.1",
@@ -19914,36 +19790,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/noms": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
-      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "~1.0.31"
-      }
-    },
-    "node_modules/noms/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
-    "node_modules/noms/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/noms/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -19964,28 +19810,15 @@
       }
     },
     "node_modules/npm-run-path": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
       "dependencies": {
-        "path-key": "^4.0.0"
+        "path-key": "^3.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/object-assign": {
@@ -20005,9 +19838,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -20040,13 +19873,15 @@
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
-      "integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dependencies": {
-        "call-bind": "^1.0.5",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "define-properties": "^1.2.1",
-        "has-symbols": "^1.0.3",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -20157,25 +19992,14 @@
       }
     },
     "node_modules/optimism": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.0.tgz",
-      "integrity": "sha512-tGn8+REwLRNFnb9WmcY5IfpOqeX2kpaYJ1s6Ae3mn12AeydLkR3j+jSCmVQFoXqU8D41PAJ1RG1rCRNWmNZVmQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
       "dependencies": {
         "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.0",
-        "@wry/trie": "^0.4.3",
+        "@wry/trie": "^0.5.0",
         "tslib": "^2.3.0"
-      }
-    },
-    "node_modules/optimism/node_modules/@wry/trie": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.4.3.tgz",
-      "integrity": "sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/optionator": {
@@ -20200,6 +20024,59 @@
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
       "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
       "dev": true
+    },
+    "node_modules/ox": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
+      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/abitype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -20394,16 +20271,17 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
-      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -20519,9 +20397,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.47",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
-      "integrity": "sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==",
+      "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -20538,7 +20416,7 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.1.0",
+        "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
@@ -20614,9 +20492,9 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/lilconfig": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-      "integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "engines": {
         "node": ">=14"
       },
@@ -20625,9 +20503,9 @@
       }
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
-      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -20735,6 +20613,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -20769,9 +20653,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protobufjs": {
-      "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -20784,14 +20668,17 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+      "engines": {
+        "node": ">=12.0.0"
       }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/proxy-compare": {
       "version": "2.5.1",
@@ -20817,9 +20704,9 @@
       }
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/pump": {
       "version": "3.0.2",
@@ -20877,14 +20764,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/qrcode/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/qrcode/node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -20908,165 +20787,10 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/qrcode/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-      "dependencies": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      }
-    },
-    "node_modules/qrcode/node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
-    "node_modules/qrcode/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/qrcode/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/qrcode/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/qrcode/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dependencies": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qrcode/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
-    },
-    "node_modules/qrcode/node_modules/yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-      "dependencies": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      }
-    },
-    "node_modules/qrcode/node_modules/yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
-    },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.6"
@@ -21195,9 +20919,9 @@
       }
     },
     "node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -21205,21 +20929,18 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-modal": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.1.tgz",
-      "integrity": "sha512-VStHgI3BVcGo7OXczvnJN7yT2TWHJPDXZWyI/a0ssFNhGZWsPmB8cF0z33ewDXq4VfYMO1vXgiv/g8Nj9NDyWg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^4.0.3"
       },
-      "engines": {
-        "node": ">=8"
-      },
       "peerDependencies": {
-        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
-        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-redux": {
@@ -21260,10 +20981,15 @@
         }
       }
     },
+    "node_modules/react-redux/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+    },
     "node_modules/react-timer-hook": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.7.tgz",
-      "integrity": "sha512-ATpNcU+PQRxxfNBPVqce2+REtjGAlwmfoNQfcEBMZFxPj0r3GYdKhyPHdStvqrejejEi0QvqaJZjy2lBlFvAsA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.8.tgz",
+      "integrity": "sha512-bi2e7DhPBU1MRPU4ZHaVqBmgM9e2HK0ae8O2AIqwqjcPo4/qR7lVGQonOQLAKOZPQCJSYfV8F5aBWzOLXElzqQ==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
@@ -21321,6 +21047,17 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/readonly-date": {
@@ -21396,15 +21133,15 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.1.1.tgz",
-      "integrity": "sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
       "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
         "regjsgen": "^0.8.0",
-        "regjsparser": "^0.11.0",
+        "regjsparser": "^0.12.0",
         "unicode-match-property-ecmascript": "^2.0.0",
         "unicode-match-property-value-ecmascript": "^2.1.0"
       },
@@ -21419,15 +21156,27 @@
       "dev": true
     },
     "node_modules/regjsparser": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.11.1.tgz",
-      "integrity": "sha512-1DHODs4B8p/mQHU9kr+jv8+wIC9mtG4eBHxWxIq5mhjE3D5oORhCc6deRKzTjs9DcfRFmj9BHSDguZklqCGFWQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
       "dev": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
       "bin": {
         "regjsparser": "bin/parser"
+      }
+    },
+    "node_modules/regjsparser/node_modules/jsesc": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "dev": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/rehackt": {
@@ -21475,11 +21224,11 @@
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "version": "1.22.9",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
+      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
       "dependencies": {
-        "is-core-module": "^2.13.0",
+        "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -21685,12 +21434,24 @@
         "lodash": "^4.17.15"
       }
     },
-    "node_modules/ripple-lib/node_modules/jsonschema": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+    "node_modules/ripple-lib/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
-        "node": "*"
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/rlp": {
@@ -21705,9 +21466,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.24.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.24.0.tgz",
-      "integrity": "sha512-DOmrlGSXNk1DM0ljiQA+i+o0rSLhtii1je5wgk60j49d1jHT5YYttBv1iWOnYSTG+fZZESUOSNiAl89SIet+Cg==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -21720,22 +21481,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.24.0",
-        "@rollup/rollup-android-arm64": "4.24.0",
-        "@rollup/rollup-darwin-arm64": "4.24.0",
-        "@rollup/rollup-darwin-x64": "4.24.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.24.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.24.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.24.0",
-        "@rollup/rollup-linux-arm64-musl": "4.24.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.24.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.24.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-gnu": "4.24.0",
-        "@rollup/rollup-linux-x64-musl": "4.24.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.24.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.24.0",
-        "@rollup/rollup-win32-x64-msvc": "4.24.0",
+        "@rollup/rollup-android-arm-eabi": "4.28.1",
+        "@rollup/rollup-android-arm64": "4.28.1",
+        "@rollup/rollup-darwin-arm64": "4.28.1",
+        "@rollup/rollup-darwin-x64": "4.28.1",
+        "@rollup/rollup-freebsd-arm64": "4.28.1",
+        "@rollup/rollup-freebsd-x64": "4.28.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.28.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.28.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.28.1",
+        "@rollup/rollup-linux-arm64-musl": "4.28.1",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.28.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.28.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-gnu": "4.28.1",
+        "@rollup/rollup-linux-x64-musl": "4.28.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.28.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.28.1",
+        "@rollup/rollup-win32-x64-msvc": "4.28.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -21765,21 +21529,6 @@
         }
       }
     },
-    "node_modules/rollup-plugin-visualizer/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -21794,24 +21543,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/rollup-plugin-visualizer/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/rollup-plugin-visualizer/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
     "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -21825,6 +21556,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
@@ -21865,6 +21608,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
@@ -21912,26 +21664,6 @@
         "utf-8-validate": "^5.0.2"
       }
     },
-    "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/rtcpeerconnection-shim": {
       "version": "1.2.15",
       "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
@@ -21967,12 +21699,20 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dependencies": {
-        "tslib": "^2.1.0"
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
       }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -22037,23 +21777,23 @@
       "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
     },
     "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "hasInstallScript": true,
       "dependencies": {
-        "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
+        "elliptic": "^6.5.7",
+        "node-addon-api": "^5.0.0",
         "node-gyp-build": "^4.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/secp256k1/node_modules/node-addon-api": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -22160,15 +21900,69 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -22283,9 +22077,9 @@
       }
     },
     "node_modules/socket.io-client": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.0.tgz",
-      "integrity": "sha512-C0jdhD5yQahMws9alf/yvtsMGTaIDBnZ8Rb5HU56svyq0l5LIrGzIDZZD5pHQlmzxLuU91Gz+VpQMKgCTNYtkw==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -22294,6 +22088,22 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/socket.io-parser": {
@@ -22306,6 +22116,22 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/socks": {
@@ -22322,16 +22148,24 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.1.1.tgz",
-      "integrity": "sha512-t8J0kG3csjA4g6FTbsMOWws+7R7vuRC8aQ/wy3/1OWmsgwA68zs/+cExQ0koSitUDXqhufF/YJr9wtNMZHw5Ew==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "dependencies": {
-        "agent-base": "^6.0.2",
-        "debug": "^4.3.1",
-        "socks": "^2.6.1"
+        "agent-base": "^7.1.1",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 14"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -22386,9 +22220,9 @@
       "dev": true
     },
     "node_modules/std-env": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
-      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
     },
     "node_modules/store2": {
       "version": "2.14.3",
@@ -22587,21 +22421,21 @@
       }
     },
     "node_modules/strip-literal": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.0.tgz",
-      "integrity": "sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
       "dev": true,
       "dependencies": {
-        "js-tokens": "^9.0.0"
+        "js-tokens": "^9.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.0.tgz",
-      "integrity": "sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true
     },
     "node_modules/stylis": {
@@ -22685,14 +22519,15 @@
       "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
-        "has-flag": "^3.0.0"
+        "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -22726,32 +22561,32 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.13",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.13.tgz",
-      "integrity": "sha512-KqjHOJKogOUt5Bs752ykCeiwvi0fKVkr5oqsFNt/8px/tA8scFPIlkygsf6jXrfCqGHz7VflA6+yytWuM+XhFw==",
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
+        "chokidar": "^3.6.0",
         "didyoumean": "^1.2.2",
         "dlv": "^1.1.3",
-        "fast-glob": "^3.3.0",
+        "fast-glob": "^3.3.2",
         "glob-parent": "^6.0.2",
         "is-glob": "^4.0.3",
-        "jiti": "^1.21.0",
-        "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
+        "jiti": "^1.21.6",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
         "postcss-import": "^15.1.0",
         "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
+        "postcss-load-config": "^4.0.2",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
       },
       "bin": {
         "tailwind": "lib/cli.js",
@@ -22759,6 +22594,28 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
       }
     },
     "node_modules/text-encoding-utf-8": {
@@ -22804,47 +22661,6 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
@@ -22864,9 +22680,9 @@
       "dev": true
     },
     "node_modules/tiny-secp256k1": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
-      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.3.0",
@@ -22880,9 +22696,9 @@
       }
     },
     "node_modules/tiny-secp256k1/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -22915,14 +22731,6 @@
       "dev": true,
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -23038,76 +22846,6 @@
         }
       }
     },
-    "node_modules/ts-unused-exports/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/ts-unused-exports/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/ts-unused-exports/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/ts-unused-exports/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/ts-unused-exports/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ts-unused-exports/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -23133,14 +22871,14 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tss-react": {
-      "version": "4.9.13",
-      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.13.tgz",
-      "integrity": "sha512-Gu19qqPH8/SAyKVIgDE5qHygirEDnNIQcXhiEc+l4Q9T7C1sfvUnbVWs+yBpmN26/wyk4FTOupjYS2wq4vH0yA==",
+      "version": "4.9.14",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.14.tgz",
+      "integrity": "sha512-nAj4RCQk3ADzrmtxmTcmN1B9EKxPMIxuCfJ3ll964CksndJ2/ZImF6rAMo2Kud5yE3ENXHpPIBHCyuMtgptMvw==",
       "dependencies": {
         "@emotion/cache": "*",
         "@emotion/serialize": "*",
@@ -23150,7 +22888,8 @@
         "@emotion/react": "^11.4.1",
         "@emotion/server": "^11.4.0",
         "@mui/material": "^5.0.0 || ^6.0.0",
-        "react": "^16.8.0 || ^17.0.2 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.2 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@emotion/server": {
@@ -23220,9 +22959,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -23245,9 +22984,9 @@
       "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23395,35 +23134,40 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.12.0.tgz",
-      "integrity": "sha512-ARZYTXiC+e8z3lRM7/qY9oyaOkaozCeNd2xoz7sYK9fv7OLGhVsf+BZbmASqiK/HTZ7T6eAlnVq9JynZppyk3w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.0.tgz",
+      "integrity": "sha512-FjkD8JSdZyktjzPUR9KbR1Pc2tD9b+rEMMNMyvrlpBwQCftL9WgU7iAvb95QDBi5wDL75SQyTovQASBPzt3a9g==",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.6.0",
+        "citty": "^0.1.6",
         "destr": "^2.0.3",
-        "h3": "^1.12.0",
-        "listhen": "^1.7.2",
+        "h3": "^1.13.0",
+        "listhen": "^1.9.0",
         "lru-cache": "^10.4.3",
-        "mri": "^1.2.0",
         "node-fetch-native": "^1.6.4",
-        "ofetch": "^1.3.4",
+        "ofetch": "^1.4.1",
         "ufo": "^1.5.4"
       },
       "peerDependencies": {
-        "@azure/app-configuration": "^1.7.0",
-        "@azure/cosmos": "^4.1.1",
-        "@azure/data-tables": "^13.2.2",
-        "@azure/identity": "^4.4.1",
-        "@azure/keyvault-secrets": "^4.8.0",
-        "@azure/storage-blob": "^12.24.0",
-        "@capacitor/preferences": "^6.0.2",
-        "@netlify/blobs": "^6.5.0 || ^7.0.0",
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.5.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6.0.3",
+        "@deno/kv": ">=0.8.4",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0",
         "@planetscale/database": "^1.19.0",
-        "@upstash/redis": "^1.34.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.0",
         "@vercel/kv": "^1.0.1",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
         "idb-keyval": "^6.2.1",
-        "ioredis": "^5.4.1"
+        "ioredis": "^5.4.1",
+        "uploadthing": "^7.4.1"
       },
       "peerDependenciesMeta": {
         "@azure/app-configuration": {
@@ -23447,6 +23191,9 @@
         "@capacitor/preferences": {
           "optional": true
         },
+        "@deno/kv": {
+          "optional": true
+        },
         "@netlify/blobs": {
           "optional": true
         },
@@ -23456,13 +23203,25 @@
         "@upstash/redis": {
           "optional": true
         },
+        "@vercel/blob": {
+          "optional": true
+        },
         "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
           "optional": true
         },
         "idb-keyval": {
           "optional": true
         },
         "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
           "optional": true
         }
       }
@@ -23471,14 +23230,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
-    },
-    "node_modules/untildify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/untun": {
       "version": "0.1.3",
@@ -23573,9 +23324,9 @@
       }
     },
     "node_modules/usb/node_modules/node-addon-api": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
-      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
@@ -23592,11 +23343,11 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf-8-validate": {
@@ -23641,6 +23392,7 @@
       "version": "6.2.13",
       "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
       "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@types/uuid": "8.3.4",
         "uuid": "8.3.2"
@@ -23761,6 +23513,14 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/viem/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/viem/node_modules/@scure/bip32": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
@@ -23830,9 +23590,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.8.tgz",
-      "integrity": "sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==",
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.21.3",
@@ -23929,20 +23689,20 @@
       }
     },
     "node_modules/vite-plugin-dts": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.2.3.tgz",
-      "integrity": "sha512-O5NalzHANQRwVw1xj8KQun3Bv8OSDAlNJXrnqoAz10BOuW8FVvY5g4ygj+DlJZL5mtSPuMu9vd3OfrdW5d4k6w==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.4.0.tgz",
+      "integrity": "sha512-CJ6phvnnPLF+aFk8Jz2ZcMBLleJ4gKJOXb9We5Kzmsp5bPuD+uMDeVefjFNYSXZ+wdcqnf+Yp2P7oA5hBKQTlQ==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor": "7.47.7",
-        "@rollup/pluginutils": "^5.1.0",
-        "@volar/typescript": "^2.4.4",
-        "@vue/language-core": "2.1.6",
+        "@microsoft/api-extractor": "^7.48.1",
+        "@rollup/pluginutils": "^5.1.4",
+        "@volar/typescript": "^2.4.11",
+        "@vue/language-core": "2.1.10",
         "compare-versions": "^6.1.1",
-        "debug": "^4.3.6",
+        "debug": "^4.4.0",
         "kolorist": "^1.8.0",
-        "local-pkg": "^0.5.0",
-        "magic-string": "^0.30.11"
+        "local-pkg": "^0.5.1",
+        "magic-string": "^0.30.17"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -24073,6 +23833,33 @@
       "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -24283,6 +24070,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webrtc-adapter": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
@@ -24330,14 +24138,15 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
         "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {
@@ -24435,36 +24244,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -24533,15 +24312,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -24553,9 +24332,9 @@
       }
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.1.tgz",
-      "integrity": "sha512-ptjR8YSJIXoA3Mbv5po7RtSYHO6mZr8s7i5VGmEk7QY2pQWyT1o0N+W1gKbOyJPUCGXGnuw0wqe8f0L6Y0ny7g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -24586,12 +24365,9 @@
       }
     },
     "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -24607,54 +24383,138 @@
       }
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs-parser/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
-        "node": ">=10"
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "engines": {
-        "node": ">=8"
+        "node": ">=4"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/yargs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -24707,6 +24567,14 @@
         "react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zustand/node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     }
   }

--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -91,8 +91,7 @@
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.12.tgz",
-      "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -104,8 +103,7 @@
     },
     "node_modules/@0no-co/graphqlsp": {
       "version": "1.12.16",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
-      "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
+      "license": "MIT",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
@@ -117,13 +115,11 @@
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -133,8 +129,7 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -146,8 +141,7 @@
     },
     "node_modules/@apollo/client": {
       "version": "3.12.3",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.3.tgz",
-      "integrity": "sha512-KZ5zymRdb8bMbGUb1wP2U04ff7qIGgaC1BCdCVC+IPFiXkxEhHBc5fDEQOwAUT+vUo9KbBh3g7QK/JCOswn59w==",
+      "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -188,8 +182,7 @@
     },
     "node_modules/@aptos-labs/aptos-client": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.1.tgz",
-      "integrity": "sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "axios": "1.7.4",
         "got": "^11.8.6"
@@ -200,9 +193,8 @@
     },
     "node_modules/@artursapek/vite-plugin-checker": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@artursapek/vite-plugin-checker/-/vite-plugin-checker-0.7.4.tgz",
-      "integrity": "sha512-W00hk2C9BoPwVcANYRiNwhEqRwkdY6EekL7ipOj2ap6RW1ymYBcLsKyiw6H08ziozeBYjcUwX2bTo7YTGwaR2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "ansi-escapes": "^4.3.0",
@@ -266,8 +258,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -279,16 +270,14 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
-      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -317,8 +306,7 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.26.3",
         "@babel/types": "^7.26.3",
@@ -332,8 +320,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
-      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -343,8 +330,7 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -358,8 +344,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
-      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -378,9 +363,8 @@
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
-      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "regexpu-core": "^6.2.0",
@@ -395,9 +379,8 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
-      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -411,8 +394,7 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
-      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -423,8 +405,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -435,8 +416,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -451,8 +431,7 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
-      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -462,17 +441,15 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
-      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
-      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-wrap-function": "^7.25.9",
@@ -487,8 +464,7 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
-      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -503,8 +479,7 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
-      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -515,33 +490,29 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
-      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/traverse": "^7.25.9",
@@ -553,8 +524,7 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
@@ -566,8 +536,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.26.3"
       },
@@ -580,9 +549,8 @@
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
-      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -596,9 +564,8 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
-      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -611,9 +578,8 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
-      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -626,9 +592,8 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
-      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
@@ -643,9 +608,8 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
-      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -659,10 +623,8 @@
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.11",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
-      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -678,9 +640,8 @@
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
-      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -693,9 +654,8 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -708,8 +668,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -722,9 +681,8 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -737,8 +695,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -751,9 +708,8 @@
     },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
-      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -767,9 +723,8 @@
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
-      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -782,9 +737,8 @@
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
-      "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
@@ -799,9 +753,8 @@
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
-      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -816,9 +769,8 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
-      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -831,9 +783,8 @@
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
-      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -846,9 +797,8 @@
     },
     "node_modules/@babel/plugin-transform-class-properties": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
-      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -862,9 +812,8 @@
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
-      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -878,9 +827,8 @@
     },
     "node_modules/@babel/plugin-transform-classes": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
-      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -898,9 +846,8 @@
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
-      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/template": "^7.25.9"
@@ -914,9 +861,8 @@
     },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
-      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -929,9 +875,8 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
-      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -945,9 +890,8 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
-      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -960,9 +904,8 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
-      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -976,9 +919,8 @@
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
-      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -991,9 +933,8 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
-      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1006,9 +947,8 @@
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
-      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1021,9 +961,8 @@
     },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
-      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1037,9 +976,8 @@
     },
     "node_modules/@babel/plugin-transform-function-name": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
-      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1054,9 +992,8 @@
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
-      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1069,9 +1006,8 @@
     },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
-      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1084,9 +1020,8 @@
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
-      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1099,9 +1034,8 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
-      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1114,9 +1048,8 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
-      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1130,8 +1063,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
-      "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.26.0",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1145,9 +1077,8 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1163,9 +1094,8 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
-      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1179,9 +1109,8 @@
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
-      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1195,9 +1124,8 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
-      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1210,9 +1138,8 @@
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
-      "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1225,9 +1152,8 @@
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
-      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1240,9 +1166,8 @@
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
-      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1257,9 +1182,8 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
-      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-replace-supers": "^7.25.9"
@@ -1273,9 +1197,8 @@
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
-      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1288,9 +1211,8 @@
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
-      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1304,9 +1226,8 @@
     },
     "node_modules/@babel/plugin-transform-parameters": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
-      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1319,9 +1240,8 @@
     },
     "node_modules/@babel/plugin-transform-private-methods": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
-      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1335,9 +1255,8 @@
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
-      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1352,9 +1271,8 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
-      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1367,9 +1285,8 @@
     },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
-      "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
@@ -1383,9 +1300,8 @@
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
-      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1399,9 +1315,8 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
-      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1414,9 +1329,8 @@
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
-      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1429,9 +1343,8 @@
     },
     "node_modules/@babel/plugin-transform-spread": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
-      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1445,9 +1358,8 @@
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
-      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1460,9 +1372,8 @@
     },
     "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
-      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1475,9 +1386,8 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
-      "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1490,8 +1400,7 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
-      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1508,9 +1417,8 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
-      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1523,9 +1431,8 @@
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
-      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1539,9 +1446,8 @@
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
-      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1555,9 +1461,8 @@
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
-      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1571,9 +1476,8 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
-      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.26.0",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -1654,9 +1558,8 @@
     },
     "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1666,9 +1569,8 @@
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
-      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
-      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1680,8 +1582,7 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
-      "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -1698,8 +1599,7 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1709,8 +1609,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
         "@babel/parser": "^7.25.9",
@@ -1722,8 +1621,7 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.26.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/generator": "^7.26.3",
@@ -1739,8 +1637,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.26.3",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1751,8 +1648,7 @@
     },
     "node_modules/@binance/w3w-core": {
       "version": "1.1.8-alpha.0",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-core/-/w3w-core-1.1.8-alpha.0.tgz",
-      "integrity": "sha512-fLTBqF4Yb7s4zFMhzHnmurQqszbiE9c8ZdmbELSkWgSwEHtEO7DAOAV61X9mCLLeCLpQkwz3sLULg/Agjr5iXA==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-qrcode-modal": "1.1.5",
         "@binance/w3w-socket-transport": "1.1.4",
@@ -1765,8 +1661,7 @@
     },
     "node_modules/@binance/w3w-core/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1776,13 +1671,11 @@
     },
     "node_modules/@binance/w3w-core/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-ethereum-provider": {
       "version": "1.1.8-alpha.0",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-ethereum-provider/-/w3w-ethereum-provider-1.1.8-alpha.0.tgz",
-      "integrity": "sha512-pmJWrv1npmqYYz1M3wtaXVY4rSJh2GYjNgRXoFb9SUJOklO8zHqKUjRoPWcHtWQTnEHmwzE4e/dIzE3tecRAjg==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-http-client": "1.1.4",
         "@binance/w3w-sign-client": "1.1.8-alpha.0",
@@ -1794,8 +1687,7 @@
     },
     "node_modules/@binance/w3w-ethereum-provider/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1805,13 +1697,11 @@
     },
     "node_modules/@binance/w3w-ethereum-provider/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-http-client": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-http-client/-/w3w-http-client-1.1.4.tgz",
-      "integrity": "sha512-dovohLZThYNY2DNbM0XILjLsgo+ZMdMRRTkbdewrLcj1KkXwUn36K2tFsi/aDZXTBjWcNlziaGQYHmbuLEXTpw==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -1821,8 +1711,7 @@
     },
     "node_modules/@binance/w3w-http-client/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1832,13 +1721,11 @@
     },
     "node_modules/@binance/w3w-http-client/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-qrcode-modal": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-qrcode-modal/-/w3w-qrcode-modal-1.1.5.tgz",
-      "integrity": "sha512-SFwA9PeCAlPBjfgLf9chLoia3D5pWpDjDZOZ6wD3G3Xspd4XKrtQl4UvFpAm6hkrgw6fShtI2zis9PQYAxQjiA==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -1851,8 +1738,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1862,16 +1748,14 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/cliui": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1880,18 +1764,15 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -1902,16 +1783,14 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -1921,8 +1800,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -1935,8 +1813,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -1946,16 +1823,14 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/pngjs": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/qrcode": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
-      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "pngjs": "^5.0.0",
@@ -1970,8 +1845,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/react": {
       "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1981,8 +1855,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/react-dom": {
       "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -1993,8 +1866,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2006,8 +1878,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2019,8 +1890,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/yargs": {
       "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -2040,8 +1910,7 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -2052,8 +1921,7 @@
     },
     "node_modules/@binance/w3w-sign-client": {
       "version": "1.1.8-alpha.0",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-sign-client/-/w3w-sign-client-1.1.8-alpha.0.tgz",
-      "integrity": "sha512-p/p/aN6bwCko6X6SGvHGIEW/8ePx/2FWecnAwZaqWmglOdc3u632MWYgTj814Vn6tM36kntY5GoYbGVPMPtQ2w==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-core": "1.1.8-alpha.0",
         "@binance/w3w-types": "1.1.4",
@@ -2062,8 +1930,7 @@
     },
     "node_modules/@binance/w3w-sign-client/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -2073,13 +1940,11 @@
     },
     "node_modules/@binance/w3w-sign-client/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-socket-transport": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-socket-transport/-/w3w-socket-transport-1.1.4.tgz",
-      "integrity": "sha512-SFHknzRM74CMam95bcpcyGeYVHfET3vrANU6XROAVYTa+kCP2O6/tIZVO+WC5HyEJf2uNcJJAV1PVn3gq/3kKQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -2088,8 +1953,7 @@
     },
     "node_modules/@binance/w3w-socket-transport/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -2099,26 +1963,22 @@
     },
     "node_modules/@binance/w3w-socket-transport/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-types": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-types/-/w3w-types-1.1.4.tgz",
-      "integrity": "sha512-CCnneapNTVY1+RseZNIhExVp3ux8LihcXRkGwmvJtZTTJJIC7xQlTWy9olkAsz+opqWK+heAcyYGmt4RUt1M5g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
     },
     "node_modules/@binance/w3w-types/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-utils": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.6.tgz",
-      "integrity": "sha512-NGT629vS9tRlbigtNn9wHtTYNB00oyDcsajO/kpAcDiQn4ktYs7+oTIr/qLvjP8Z3opTXpbooqMPITDY7DI0IA==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -2128,13 +1988,11 @@
     },
     "node_modules/@binance/w3w-utils/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@binance/w3w-wagmi-connector": {
       "version": "1.2.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-wagmi-connector/-/w3w-wagmi-connector-1.2.2-alpha.0.tgz",
-      "integrity": "sha512-Eq2DYib3FBDht5Zn+mQsq4seQyDdZOXBo6hS0TznYiS4SYG08G7paydNhgEAX7aoue5rwR1ZOYzCTvstB/6lFQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-ethereum-provider": "1.1.8-alpha.0",
         "@binance/w3w-utils": "1.1.4"
@@ -2146,8 +2004,7 @@
     },
     "node_modules/@binance/w3w-wagmi-connector/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
-      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
+      "license": "ISC",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -2157,13 +2014,11 @@
     },
     "node_modules/@binance/w3w-wagmi-connector/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@blocto/sdk": {
       "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.6.tgz",
-      "integrity": "sha512-hbsc9eC1EL9wJ+8nXUp3POkC84qt46FPRqX3tYzxeQn72Zvhew6T81wKvzXZsuLmmoo8FBzPiXkb0QMWJkpOLw==",
+      "license": "MIT",
       "dependencies": {
         "bs58": "^4.0.1",
         "buffer": "^6.0.3",
@@ -2185,8 +2040,7 @@
     },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.9.3.tgz",
-      "integrity": "sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.1",
         "buffer": "^6.0.3",
@@ -2201,21 +2055,18 @@
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/clsx": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/preact": {
       "version": "10.25.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
-      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2223,8 +2074,7 @@
     },
     "node_modules/@confio/ics23": {
       "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
-      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "protobufjs": "^6.8.8"
@@ -2232,9 +2082,8 @@
     },
     "node_modules/@confio/ics23/node_modules/protobufjs": {
       "version": "6.11.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
-      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2257,8 +2106,7 @@
     },
     "node_modules/@coral-xyz/anchor": {
       "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
-      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@coral-xyz/borsh": "^0.29.0",
         "@noble/hashes": "^1.3.1",
@@ -2281,8 +2129,7 @@
     },
     "node_modules/@coral-xyz/borsh": {
       "version": "0.29.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
-      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -2296,8 +2143,7 @@
     },
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
-      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -2307,8 +2153,7 @@
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
-      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -2324,8 +2169,7 @@
     },
     "node_modules/@cosmjs/crypto": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
@@ -2338,8 +2182,7 @@
     },
     "node_modules/@cosmjs/encoding": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -2348,13 +2191,11 @@
     },
     "node_modules/@cosmjs/encoding/node_modules/bech32": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+      "license": "MIT"
     },
     "node_modules/@cosmjs/json-rpc": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
-      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "xstream": "^11.14.0"
@@ -2362,16 +2203,14 @@
     },
     "node_modules/@cosmjs/math": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -2383,8 +2222,7 @@
     },
     "node_modules/@cosmjs/socket": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
-      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "isomorphic-ws": "^4.0.1",
@@ -2394,8 +2232,7 @@
     },
     "node_modules/@cosmjs/socket/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -2414,8 +2251,7 @@
     },
     "node_modules/@cosmjs/stargate": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
-      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.32.4",
@@ -2431,16 +2267,14 @@
     },
     "node_modules/@cosmjs/stream": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
-      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
-      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -2454,24 +2288,31 @@
         "xstream": "^11.14.0"
       }
     },
+    "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
-      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
+      "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
-      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -2488,13 +2329,11 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+      "license": "MIT"
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2505,26 +2344,22 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
-      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
+      "license": "MIT"
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2546,8 +2381,7 @@
     },
     "node_modules/@emotion/serialize": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
@@ -2558,13 +2392,11 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
+      "license": "MIT"
     },
     "node_modules/@emotion/styled": {
       "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
-      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2585,400 +2417,41 @@
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
+      "license": "MIT"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
+      "license": "MIT"
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+      "license": "MIT"
     },
     "node_modules/@emurgo/cardano-serialization-lib-browser": {
       "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-11.5.0.tgz",
-      "integrity": "sha512-qchOJ9NYDUz10tzs5r5QhP9hK0p+ZOlRiBwPdTAxqAYLw/8emYBkQQLaS8T1DF6EkeudyrgS00ym5Trw1fo4iA=="
+      "license": "MIT"
     },
     "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
       "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-11.5.0.tgz",
-      "integrity": "sha512-IlVABlRgo9XaTR1NunwZpWcxnfEv04ba2l1vkUz4S1W7Jt36F4CtffP+jPeqBZGnAe+fnUwo0XjIJC3ZTNToNQ=="
-    },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
+      "license": "MIT"
     },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -2986,9 +2459,8 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -3004,18 +2476,16 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -3036,9 +2506,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -3051,9 +2520,8 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -3063,25 +2531,22 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@ethereumjs/common": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-4.4.0.tgz",
-      "integrity": "sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0"
       }
     },
     "node_modules/@ethereumjs/common/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -3091,8 +2556,7 @@
     },
     "node_modules/@ethereumjs/common/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -3103,8 +2567,7 @@
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
-      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -3114,8 +2577,7 @@
     },
     "node_modules/@ethereumjs/tx": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-5.4.0.tgz",
-      "integrity": "sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
@@ -3128,8 +2590,7 @@
     },
     "node_modules/@ethereumjs/tx/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
+      "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -3139,8 +2600,7 @@
     },
     "node_modules/@ethereumjs/tx/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -3151,8 +2611,7 @@
     },
     "node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
-      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^2.0.0",
@@ -3164,8 +2623,6 @@
     },
     "node_modules/@ethersproject/abi": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
-      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "funding": [
         {
           "type": "individual",
@@ -3176,6 +2633,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3190,8 +2648,6 @@
     },
     "node_modules/@ethersproject/abstract-provider": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
-      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "funding": [
         {
           "type": "individual",
@@ -3202,6 +2658,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3214,8 +2671,6 @@
     },
     "node_modules/@ethersproject/abstract-signer": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
-      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -3226,6 +2681,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3236,8 +2692,6 @@
     },
     "node_modules/@ethersproject/address": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
-      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "funding": [
         {
           "type": "individual",
@@ -3248,6 +2702,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3258,8 +2713,6 @@
     },
     "node_modules/@ethersproject/base64": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
-      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "funding": [
         {
           "type": "individual",
@@ -3270,14 +2723,13 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
-      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -3288,6 +2740,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -3296,8 +2749,6 @@
     },
     "node_modules/@ethersproject/bytes": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
-      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -3308,14 +2759,13 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
-      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "funding": [
         {
           "type": "individual",
@@ -3326,14 +2776,13 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
-      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -3344,6 +2793,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -3358,8 +2808,6 @@
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
-      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "funding": [
         {
           "type": "individual",
@@ -3370,6 +2818,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
@@ -3377,23 +2826,6 @@
     },
     "node_modules/@ethersproject/logger": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
-      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ]
-    },
-    "node_modules/@ethersproject/networks": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
-      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "funding": [
         {
           "type": "individual",
@@ -3404,14 +2836,27 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/networks": {
+      "version": "5.7.1",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
-      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "funding": [
         {
           "type": "individual",
@@ -3422,14 +2867,13 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
-      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "funding": [
         {
           "type": "individual",
@@ -3440,6 +2884,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -3447,8 +2892,6 @@
     },
     "node_modules/@ethersproject/signing-key": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
-      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "funding": [
         {
           "type": "individual",
@@ -3459,6 +2902,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -3470,8 +2914,7 @@
     },
     "node_modules/@ethersproject/signing-key/node_modules/elliptic": {
       "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -3484,13 +2927,10 @@
     },
     "node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/@ethersproject/strings": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
-      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "funding": [
         {
           "type": "individual",
@@ -3501,6 +2941,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -3509,8 +2950,6 @@
     },
     "node_modules/@ethersproject/transactions": {
       "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -3521,6 +2960,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3535,8 +2975,6 @@
     },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
-      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "funding": [
         {
           "type": "individual",
@@ -3547,6 +2985,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -3557,8 +2996,7 @@
     },
     "node_modules/@fewcha/web3": {
       "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@fewcha/web3/-/web3-0.1.32.tgz",
-      "integrity": "sha512-5QrBit4XlDpg4b8UMmDHNxDL/or+1/mk688IbZZ6JSEnvFs15/FW60TTPBTzt9sQKLC+0fq7uMCi3JH/EoMZYg==",
+      "license": "MIT",
       "dependencies": {
         "aptos": "^1.3.14",
         "buffer": "^6.0.3"
@@ -3566,8 +3004,7 @@
     },
     "node_modules/@fivebinaries/coin-selection": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-2.2.1.tgz",
-      "integrity": "sha512-iYFsYr7RY7TEvTqP9NKR4p/yf3Iybf9abUDR7lRjzanGsrLwVsREvIuyE05iRYFrvqarlk+gWRPsdR1N2hUBrg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@emurgo/cardano-serialization-lib-browser": "^11.5.0",
         "@emurgo/cardano-serialization-lib-nodejs": "11.5.0"
@@ -3575,8 +3012,7 @@
     },
     "node_modules/@fractalwagmi/popup-connection": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.1.1.tgz",
-      "integrity": "sha512-hYL+45iYwNbwjvP2DxP3YzVsrAGtj/RV9LOgMpJyCxsfNoyyOoi2+YrnywKkiANingiG2kJ1nKsizbu1Bd4zZw==",
+      "license": "ISC",
       "peerDependencies": {
         "react": "^17.0.2 || ^18",
         "react-dom": "^17.0.2 || ^18"
@@ -3584,8 +3020,7 @@
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/solana-wallet-adapter/-/solana-wallet-adapter-0.1.1.tgz",
-      "integrity": "sha512-oTZLEuD+zLKXyhZC5tDRMPKPj8iaxKLxXiCjqRfOo4xmSbS2izGRWLJbKMYYsJysn/OI3UJ3P6CWP8WUWi0dZg==",
+      "license": "ISC",
       "dependencies": {
         "@fractalwagmi/popup-connection": "^1.0.18",
         "@solana/wallet-adapter-base": "^0.9.17",
@@ -3594,21 +3029,18 @@
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@gql.tada/cli-utils": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
-      "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
+      "license": "MIT",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
         "@gql.tada/internal": "1.0.8",
@@ -3632,8 +3064,7 @@
     },
     "node_modules/@gql.tada/internal": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
-      "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
+      "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5"
       },
@@ -3644,18 +3075,15 @@
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -3667,9 +3095,8 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -3680,15 +3107,12 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@injectivelabs/core-proto-ts": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
-      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
+      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3698,16 +3122,14 @@
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/exceptions": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.33.tgz",
-      "integrity": "sha512-2c8YzLgwTOOsyc1WheqdM8jEfgGBhVrXN4cZ0jsikFVsLF619IDRn3hjIYqTeNERaEpeRPiuJGfZDu0DomwFrQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3717,8 +3139,7 @@
     },
     "node_modules/@injectivelabs/grpc-web": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
-      "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -3728,24 +3149,21 @@
     },
     "node_modules/@injectivelabs/grpc-web-node-http-transport": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.0.2.tgz",
-      "integrity": "sha512-rpyhXLiGY/UMs6v6YmgWHJHiO9l0AgDyVNv+jcutNVt4tQrmNvnpvz2wCAGOFtq5LuX/E9ChtTVpk3gWGqXcGA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
     },
     "node_modules/@injectivelabs/grpc-web-react-native-transport": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-react-native-transport/-/grpc-web-react-native-transport-0.0.2.tgz",
-      "integrity": "sha512-mk+aukQXnYNgPsPnu3KBi+FD0ZHQpazIlaBZ2jNZG7QAVmxTWtv3R66Zoq99Wx2dnE946NsZBYAoa0K5oSjnow==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts": {
       "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
-      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
+      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3755,16 +3173,14 @@
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/mito-proto-ts": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
-      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
+      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3774,16 +3190,14 @@
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/networks": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
-      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3793,8 +3207,7 @@
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
       "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/olp-proto-ts/-/olp-proto-ts-1.13.1.tgz",
-      "integrity": "sha512-dKxse7mZpmvRhm00Wn8Yy93EVEvFD7FPWeWFfxga0Patow3HK0D7k43VV7fE5kX9CDM1bxTatEVQ7WYGq4w0Eg==",
+      "license": "MIT",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3804,16 +3217,14 @@
     },
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
-      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.11.10",
         "@cosmjs/amino": "^0.32.3",
@@ -3853,8 +3264,7 @@
     },
     "node_modules/@injectivelabs/test-utils": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.33.tgz",
-      "integrity": "sha512-1SfIRsMnWcJAYNrrpY+ZUWmbD62lWWdIvD6c+FYmFKS14zU3yDIK9NXe9g1lTM/GdUVkVKQgGg2QAYZ5f2G/xA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/networks": "^1.14.33",
@@ -3867,18 +3277,26 @@
         "store2": "^2.12.0"
       }
     },
+    "node_modules/@injectivelabs/test-utils/node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@injectivelabs/ts-types": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.33.tgz",
-      "integrity": "sha512-sJZzMNJtZFFZoPKZ91G09bxrZqQ5aS9omoTjQWy+7OxfiRAakzhsarTueX47hm6oTaN0XeBgD3wkMukkWUaobw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/utils": {
       "version": "1.14.33",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
-      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3890,10 +3308,19 @@
         "store2": "^2.12.0"
       }
     },
+    "node_modules/@injectivelabs/utils/node_modules/axios": {
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -3908,8 +3335,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -3919,8 +3345,7 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -3933,9 +3358,8 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -3945,14 +3369,12 @@
     },
     "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jnwng/walletconnect-solana": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@jnwng/walletconnect-solana/-/walletconnect-solana-0.2.0.tgz",
-      "integrity": "sha512-nyRq0xLEj9i2J4UXQ0Mr4KzsooTMbLu0ewHOqdQV7iZE0PfbtKa8poTSF4ZBAQD8hoMHEx+I7zGFCNMI9BTrTA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/qrcode-modal": "^1.8.0",
         "@walletconnect/sign-client": "^2.7.2",
@@ -3965,21 +3387,18 @@
     },
     "node_modules/@jnwng/walletconnect-solana/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@jnwng/walletconnect-solana/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3991,29 +3410,25 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -4021,9 +3436,7 @@
     },
     "node_modules/@json-rpc-tools/provider": {
       "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
-      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "@json-rpc-tools/utils": "^1.7.6",
         "axios": "^0.21.0",
@@ -4033,8 +3446,7 @@
     },
     "node_modules/@json-rpc-tools/provider/node_modules/axios": {
       "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -4042,8 +3454,7 @@
     },
     "node_modules/@json-rpc-tools/provider/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4062,18 +3473,14 @@
     },
     "node_modules/@json-rpc-tools/types": {
       "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
-      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "node_modules/@json-rpc-tools/utils": {
       "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
-      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "@json-rpc-tools/types": "^1.7.6",
         "@pedrouid/environment": "^1.0.1"
@@ -4081,9 +3488,8 @@
     },
     "node_modules/@kev1n-peters/vite-plugin-node-polyfills": {
       "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@kev1n-peters/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.17.4.tgz",
-      "integrity": "sha512-B87rIZFB6IMseeXCK73gfDBVDVxcOUVL7GB43eJuH8UWOUL3OACr7DLsrd/ncU6sSAlf6H5kuphVtrga5WSKTg==",
       "dev": true,
+      "license": "MIT",
       "workspaces": [
         "."
       ],
@@ -4102,21 +3508,18 @@
     },
     "node_modules/@keystonehq/alias-sampling": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@keystonehq/alias-sampling/-/alias-sampling-0.1.2.tgz",
-      "integrity": "sha512-5ukLB3bcgltgaFfQfYKYwHDUbwHicekYo53fSEa7xhVkAEqsA74kxdIwoBIURmGUtXe3EVIRm4SYlgcrt2Ri0w=="
+      "license": "MIT"
     },
     "node_modules/@keystonehq/aptossnap-adapter": {
       "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@keystonehq/aptossnap-adapter/-/aptossnap-adapter-0.2.8.tgz",
-      "integrity": "sha512-1+YuptOjNysM6pTRqn9PiF8cjGwLEiG/tXxo0HqglDHsq+tBnJaOxe+Zk15JO8pEC8yLr0o17qoFrW1qo3kySQ==",
+      "license": "(Apache-2.0 AND MIT)",
       "dependencies": {
         "aptos": "^1.3.14"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry": {
       "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.5.tgz",
-      "integrity": "sha512-PoclPHf0OhpIKLfLwzymsu+CjkWf5ZKvaVjpkq3HUalcI4KW8wLk0m8qI2kBVv6F0BQ0ERPqW8OfjLTVqIgWLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
         "bs58check": "^2.1.2",
@@ -4125,8 +3528,7 @@
     },
     "node_modules/@keystonehq/bc-ur-registry-sol": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sol/-/bc-ur-registry-sol-0.3.1.tgz",
-      "integrity": "sha512-Okr5hwPxBZxB4EKLK1GSC9vsrh/tFMQ5dvs3EQ9NCOmCn7CXdXIMSeafrpGCHk484Jf5c6X0Wq0yf0VqY2A/8Q==",
+      "license": "ISC",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.5.0",
         "bs58check": "^2.1.2",
@@ -4135,8 +3537,7 @@
     },
     "node_modules/@keystonehq/sdk": {
       "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@keystonehq/sdk/-/sdk-0.13.1.tgz",
-      "integrity": "sha512-545l83TE5t1cyUZUaNqZOAh15ibWOg9QbK/YeLwnrxt+GOod+ATk3j9SpN6yTSLO8DNl2/x6dKRIFVtTEkZDAg==",
+      "license": "ISC",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.0.0",
         "qrcode.react": "^1.0.1",
@@ -4150,8 +3551,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/qrcode.react": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-1.0.1.tgz",
-      "integrity": "sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==",
+      "license": "ISC",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.0",
@@ -4163,8 +3563,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
-      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -4176,8 +3575,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react-dom": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
-      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -4190,8 +3588,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react-qr-reader": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-2.2.1.tgz",
-      "integrity": "sha512-EL5JEj53u2yAOgtpAKAVBzD/SiKWn0Bl7AZy6ZrSf1lub7xHwtaXe6XSx36Wbhl1VMGmvmrwYMRwO1aSCT2fwA==",
+      "license": "MIT",
       "dependencies": {
         "jsqr": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -4204,8 +3601,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/scheduler": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -4213,8 +3609,7 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/typescript": {
       "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4225,8 +3620,7 @@
     },
     "node_modules/@keystonehq/sol-keyring": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@keystonehq/sol-keyring/-/sol-keyring-0.3.1.tgz",
-      "integrity": "sha512-RU6I3HQrQ9NpRDP9TwlBIy5DftVcNcyk0NWfhkPy/YanhMcCB0cRPw68iQl1rMnR6n1G2+YrBHMxm6swCW+B4Q==",
+      "license": "ISC",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.5.0",
         "@keystonehq/bc-ur-registry-sol": "^0.3.1",
@@ -4238,21 +3632,18 @@
     },
     "node_modules/@keystonehq/sol-keyring/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@keystonehq/sol-keyring/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@kunalabs-io/sui-snap-wallet/-/sui-snap-wallet-0.4.3.tgz",
-      "integrity": "sha512-cmSbuxTwwif0jmh5M/famqiG/A7hF6TokUXcy6/VA46Wun8pix9839JVr+vp1iLh5T3PvG+KgchSEgJ9vn5Usg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@metamask/detect-provider": "^2.0.0",
         "@metamask/providers": "^15.0.0",
@@ -4264,17 +3655,14 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -4295,8 +3683,7 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/wallet-standard": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.10.3.tgz",
-      "integrity": "sha512-StEMbJ7YkdjxoScmOJJjt9JaNgoRLD3FgU4LGFrKFtMXOhPu1Z4WF3qgfYBr+C3UgDh+JNiDIfN9TiGeM/Ahpw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "0.50.1",
         "@wallet-standard/core": "1.0.3"
@@ -4304,29 +3691,25 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@ledgerhq/devices": {
       "version": "6.27.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.27.1.tgz",
-      "integrity": "sha512-jX++oy89jtv7Dp2X6gwt3MMkoajel80JFWcdc0HCouwDsV1mVJ3SQdwl/bQU0zd8HI6KebvUP95QTwbQLLK/RQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/logs": "^6.10.0",
@@ -4336,8 +3719,7 @@
     },
     "node_modules/@ledgerhq/devices/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4347,13 +3729,11 @@
     },
     "node_modules/@ledgerhq/errors": {
       "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.2.tgz",
-      "integrity": "sha512-iMfEJPWaan8QaZw87WMUnFFRJqveE3FpU2ObTE0ydTJLPJNOUJjjurGBklqdWM/j5BIQvpi3byGKFChfNg8CaQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/@ledgerhq/hw-transport": {
       "version": "6.27.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.1.tgz",
-      "integrity": "sha512-hnE4/Fq1YzQI4PA1W0H8tCkI99R3UWDb3pJeZd6/Xs4Qw/q1uiQO+vNLC6KIPPhK0IajUfuI/P2jk0qWcMsuAQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -4362,8 +3742,7 @@
     },
     "node_modules/@ledgerhq/hw-transport-webhid": {
       "version": "6.27.1",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.1.tgz",
-      "integrity": "sha512-u74rBYlibpbyGblSn74fRs2pMM19gEAkYhfVibq0RE1GNFjxDMFC1n7Sb+93Jqmz8flyfB4UFJsxs8/l1tm2Kw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -4373,27 +3752,21 @@
     },
     "node_modules/@ledgerhq/logs": {
       "version": "6.12.0",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
-      "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
+      "license": "Apache-2.0"
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
-      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@manahippo/aptos-wallet-adapter": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@manahippo/aptos-wallet-adapter/-/aptos-wallet-adapter-1.0.10.tgz",
-      "integrity": "sha512-3i3OinlnoFlYEOw0ixjsRQQWFVSdecIBhxJqxHdN4kV+Vda/St+NAB7zzVZ9Mp0gY80UbWTRp9/IcRrfdpcKFg==",
-      "deprecated": "No longer maintained. Consider using https://github.com/aptos-labs/aptos-wallet-adapter instead",
       "dependencies": {
         "@blocto/sdk": "^0.3.1",
         "@fewcha/web3": "0.1.32",
@@ -4411,8 +3784,7 @@
     },
     "node_modules/@mayanfinance/swap-sdk": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-9.3.0.tgz",
-      "integrity": "sha512-Pm+lYqaEZl3JTTFYF74KqD0ncEaKu416u+AehgqKWKfBbSw5clASfrgFceT6+tB/Vrft2pincok/iSJ98g1s4Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/buffer-layout": "^4 || ^3",
         "@solana/web3.js": "^1.87.6",
@@ -4424,8 +3796,7 @@
     },
     "node_modules/@mayanfinance/wormhole-sdk-route": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mayanfinance/wormhole-sdk-route/-/wormhole-sdk-route-1.1.0.tgz",
-      "integrity": "sha512-gYOVK2Ky0dFliU7ltBFvLLZqrx72djFiYMaTQjzQeXwsXsVa+bbBdYgHPF8Rm99qF2Oh2Swm/RwnhdspfIVzNw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mayanfinance/swap-sdk": "9.3.0",
         "axios": "^1.4.0"
@@ -4443,16 +3814,13 @@
     },
     "node_modules/@metamask/detect-provider": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
-      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-json-rpc-provider/-/eth-json-rpc-provider-1.0.1.tgz",
-      "integrity": "sha512-whiUMPlAOrVGmX8aKYVPvlKyG4CpQXiNNyt74vE1xb5sPvmx5oA7B/kOi/JdBvhGQq97U1/AVdXEdk2zkP8qyA==",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.0.0",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -4464,8 +3832,7 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -4473,8 +3840,7 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -4487,8 +3853,7 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
-      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -4502,8 +3867,7 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4513,16 +3877,14 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
-      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "license": "ISC",
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -4536,21 +3898,18 @@
     },
     "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
       "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -4571,8 +3930,7 @@
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -4585,8 +3943,7 @@
     },
     "node_modules/@metamask/json-rpc-engine": {
       "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-7.3.3.tgz",
-      "integrity": "sha512-dwZPq8wx9yV3IX2caLi9q9xZBw2XeIoYqdyihDDDpuHVCEiqadJLwqM3zy+uwf6F1QYQ65A8aOMQg1Uw7LMLNg==",
+      "license": "ISC",
       "dependencies": {
         "@metamask/rpc-errors": "^6.2.1",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -4598,8 +3955,7 @@
     },
     "node_modules/@metamask/json-rpc-middleware-stream": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-6.0.2.tgz",
-      "integrity": "sha512-jtyx3PRfc1kqoLpYveIVQNwsxYKefc64/LCl9h9Da1m3nUKEvypbYuXSIwi237qvOjKmNHQKsDOZg6f4uBf62Q==",
+      "license": "ISC",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.3.2",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -4612,8 +3968,7 @@
     },
     "node_modules/@metamask/object-multiplex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-2.1.0.tgz",
-      "integrity": "sha512-4vKIiv0DQxljcXwfpnbsXcfa5glMj5Zg9mqn4xpIWqkv6uJ2ma5/GtUfLFSxhlxnR8asRMv8dDmWya1Tc1sDFA==",
+      "license": "ISC",
       "dependencies": {
         "once": "^1.4.0",
         "readable-stream": "^3.6.2"
@@ -4624,8 +3979,7 @@
     },
     "node_modules/@metamask/providers": {
       "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-15.0.0.tgz",
-      "integrity": "sha512-FXvL1NQNl6I7fMOJTfQYcBlBZ33vSlm6w80cMpmn8sJh0Lb7wcBpe02UwBsNlARnI+Qsr26XeDs6WHUHQh8CuA==",
+      "license": "MIT",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.3.2",
         "@metamask/json-rpc-middleware-stream": "^6.0.2",
@@ -4646,8 +4000,7 @@
     },
     "node_modules/@metamask/rpc-errors": {
       "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
-      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
+      "license": "MIT",
       "dependencies": {
         "@metamask/utils": "^9.0.0",
         "fast-safe-stringify": "^2.0.6"
@@ -4658,8 +4011,7 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -4667,8 +4019,7 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -4681,8 +4032,7 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
-      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.1.0",
@@ -4700,8 +4050,7 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4711,36 +4060,32 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.2.tgz",
-      "integrity": "sha512-5yb2gMI1BDm0JybZezeoX/3XhPDOtTbcFvpTXM9kxsoZjPZFh4XciqRbpD6N86HYZqWDhEaKUDuOyR0sQHEjMA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@metamask/superstruct": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/superstruct/-/superstruct-3.1.0.tgz",
-      "integrity": "sha512-N08M56HdOgBfRKkrgCMZvQppkZGcArEop3kixNEtVbJKm6P9Cfg0YkI6X0s1g78sNrj2fWUwvJADdZuzJgFttA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@metamask/utils": {
       "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-I6bkduevXb72TIM9q2LRO63JSsF9EXduh3sBr9oybNX2hNNpr/j1tEjXrsG0Uabm4MJ1xkGAQEMwifvKZIkyxQ==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.0.0",
@@ -4758,8 +4103,7 @@
     },
     "node_modules/@metamask/utils/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -4767,8 +4111,7 @@
     },
     "node_modules/@metamask/utils/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -4781,8 +4124,7 @@
     },
     "node_modules/@metamask/utils/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4792,21 +4134,19 @@
     },
     "node_modules/@metamask/utils/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.48.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.48.1.tgz",
-      "integrity": "sha512-HN9Osa1WxqLM66RaqB5nPAadx+nTIQmY/XtkFdaJvusjG8Tus++QqZtD7KPZDSkhEMGHsYeSyeU8qUzCDUXPjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.30.1",
         "@microsoft/tsdoc": "~0.15.1",
@@ -4828,9 +4168,8 @@
     },
     "node_modules/@microsoft/api-extractor-model": {
       "version": "7.30.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.1.tgz",
-      "integrity": "sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
@@ -4839,9 +4178,8 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4851,9 +4189,8 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
-      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4863,9 +4200,8 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4878,18 +4214,16 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
-      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4900,21 +4234,18 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
-      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
       "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
-      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.15.1",
         "ajv": "~8.12.0",
@@ -4924,9 +4255,8 @@
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
       "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4940,22 +4270,19 @@
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@mobily/ts-belt": {
       "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
-      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.*"
       }
     },
     "node_modules/@motionone/animation": {
       "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
-      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
         "@motionone/types": "^10.17.1",
@@ -4965,8 +4292,7 @@
     },
     "node_modules/@motionone/dom": {
       "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
-      "integrity": "sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/animation": "^10.18.0",
         "@motionone/generators": "^10.18.0",
@@ -4978,8 +4304,7 @@
     },
     "node_modules/@motionone/easing": {
       "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
-      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/utils": "^10.18.0",
         "tslib": "^2.3.1"
@@ -4987,8 +4312,7 @@
     },
     "node_modules/@motionone/generators": {
       "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
-      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/types": "^10.17.1",
         "@motionone/utils": "^10.18.0",
@@ -4997,8 +4321,7 @@
     },
     "node_modules/@motionone/svelte": {
       "version": "10.16.4",
-      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
-      "integrity": "sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
@@ -5006,13 +4329,11 @@
     },
     "node_modules/@motionone/types": {
       "version": "10.17.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
-      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A=="
+      "license": "MIT"
     },
     "node_modules/@motionone/utils": {
       "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
-      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/types": "^10.17.1",
         "hey-listen": "^1.0.8",
@@ -5021,9 +4342,7 @@
     },
     "node_modules/@motionone/vue": {
       "version": "10.16.4",
-      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
-      "integrity": "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==",
-      "deprecated": "Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion",
+      "license": "MIT",
       "dependencies": {
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
@@ -5031,8 +4350,7 @@
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.12.tgz",
-      "integrity": "sha512-rkN+bPpe2Xn8h4ZLqKy5JsZt3nzMyTJ2ySdyLHHf0IL+PrxS46dxOIC1i66R8qi14kJBHfy7Byqv1yUvpwf0iw==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -5040,8 +4358,7 @@
     },
     "node_modules/@mui/icons-material": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.12.tgz",
-      "integrity": "sha512-4Ocmbl1uzkWxAdYYARCLySJNqALgrJ+Fdr95FLpKZV7zMZxyoJRdPTO/CgUxjFjlj9Sy2Gi7j3HX4f5HS2GLeQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -5065,8 +4382,7 @@
     },
     "node_modules/@mui/material": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.12.tgz",
-      "integrity": "sha512-+M0UPy0xa9xGo8TV1vp9Mmf85TNUqpk7OoSiw+BaZf3D584S3aqfl+CL+EBTt9t52A97GnCjVNvXTO7hmLqhHw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.16.12",
@@ -5109,8 +4425,7 @@
     },
     "node_modules/@mui/private-theming": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.12.tgz",
-      "integrity": "sha512-hhLTSZxsazwZZ4bUAKgFcbsnfCrwizSnJI7/bXf/R9/tZkZBy+bKY05/Au/bIgGKzuZ4KTlKlPn+U/uufEXrNw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/utils": "^5.16.12",
@@ -5135,8 +4450,7 @@
     },
     "node_modules/@mui/styled-engine": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.12.tgz",
-      "integrity": "sha512-TMf3SN19rkJPh1hQZTjoY8UsJa5qExfr78owwCuEZLjIhsajAYiWmbJzJ8mM3grEWLiP3MziDA4zy4LFNri12Q==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
@@ -5166,8 +4480,7 @@
     },
     "node_modules/@mui/system": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.12.tgz",
-      "integrity": "sha512-rDsndVl0ug0Ex2rZt8x0WIF3Zc0EMFT2TmRVWP4jzk38aLS6WsxryXAZUQa0BKEnB3vfx1pSP/xa44TdKQ94dg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.16.12",
@@ -5205,8 +4518,7 @@
     },
     "node_modules/@mui/types": {
       "version": "7.2.20",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
-      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -5218,8 +4530,7 @@
     },
     "node_modules/@mui/utils": {
       "version": "5.16.12",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.12.tgz",
-      "integrity": "sha512-p3JAq7nA0ur8M/zLnBvR6ZeAjM8mD4LnPdKfsJAYPS26w4eDQjQzl55XvoOmch2MeXhmWaO4Pkvs/xurrISNBw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "^7.2.15",
@@ -5247,30 +4558,25 @@
     },
     "node_modules/@mysten/bcs": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.1.tgz",
-      "integrity": "sha512-wFPb8bkhwrbiStfZMV5rFM7J+umpke59/dNjDp+UYJKykNlW23LCk2ePyEUvGdb62HGJM1jyOJ8g4egE3OmdKA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/bcs/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@mysten/bcs/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/sui.js": {
       "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.32.2.tgz",
-      "integrity": "sha512-/Hm4xkGolJhqj8FvQr7QSHDTlxIvL52mtbOao9f75YjrBh7y1Uh9kbJSY7xiTF1NY9sv6p5hUVlYRJuM0Hvn9A==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/bcs": "0.7.1",
         "@noble/curves": "^1.0.0",
@@ -5289,17 +4595,14 @@
     },
     "node_modules/@mysten/sui.js/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@mysten/wallet-adapter-base/-/wallet-adapter-base-0.9.0.tgz",
-      "integrity": "sha512-Obcfd30AC0Tcyvqc9+h0vvjrRB6Td2PNWhxRlTq/hSxDY66M3XqTLgoO8wDBtz+91oga4obAYvM02m7xV7X0Zw==",
-      "deprecated": "Wallet adapters have been deprecated in favor of the Wallet Standard. Please upgrade to the latest Wallet Kit versions.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "0.40.0",
         "@mysten/wallet-standard": "0.6.0"
@@ -5307,17 +4610,14 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/bcs": {
       "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.3.tgz",
-      "integrity": "sha512-fbusBfsyc2MpTACi72H5edWJ670T84va+qn9jSPpb5BzZ+pzUM1Q0ApPrF5OT+mB1o5Ng+mxPQpBCZQkfiV2TA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/sui.js": {
       "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.40.0.tgz",
-      "integrity": "sha512-PEGdMe+QgpIdDIpyO4/yb+CK4x3Hki+kYPbQ5n3DVsWyb2ztFwB+5oYdc7qG3QkniO1lnCrlSHqZ5mN+x3RzrQ==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/bcs": "0.7.3",
         "@noble/curves": "^1.1.0",
@@ -5336,8 +4636,7 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/wallet-standard": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.6.0.tgz",
-      "integrity": "sha512-xE/OijN9zIPoTjTWuxlYMHtp7kXPcAR8dDAbxOIH5h7EZCTk+G6p+SzDp8jV5magf50VcYP0cVjS4CQLx1wQuQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "0.40.0",
         "@wallet-standard/core": "1.0.3"
@@ -5345,29 +4644,25 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard": {
       "version": "0.5.14",
-      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.5.14.tgz",
-      "integrity": "sha512-O4pBU5nO5zBMuhIpOiMkJinxUo68M1m4ca4AQNM5gYLMpuHipcHDNPpCINIyIsCsff61ilGDzPhZU4R8+zZ/2A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "0.39.0",
         "@wallet-standard/core": "1.0.3"
@@ -5375,17 +4670,14 @@
     },
     "node_modules/@mysten/wallet-standard/node_modules/@mysten/bcs": {
       "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.3.tgz",
-      "integrity": "sha512-fbusBfsyc2MpTACi72H5edWJ670T84va+qn9jSPpb5BzZ+pzUM1Q0ApPrF5OT+mB1o5Ng+mxPQpBCZQkfiV2TA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard/node_modules/@mysten/sui.js": {
       "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.39.0.tgz",
-      "integrity": "sha512-fJu6k7+Qb1z2h9i5Jai0sTWmaGP1UT6d/JIXhEwMZ6cz+13GT/8zRp8kUhP7Oq9Z2hxmwfy1ROptbsrv/x9V8A==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/bcs": "0.7.3",
         "@noble/curves": "^1.1.0",
@@ -5404,29 +4696,25 @@
     },
     "node_modules/@mysten/wallet-standard/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@mysten/wallet-standard/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@ngraveio/bc-ur": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@ngraveio/bc-ur/-/bc-ur-1.1.13.tgz",
-      "integrity": "sha512-j73akJMV4+vLR2yQ4AphPIT5HZmxVjn/LxpL7YHoINnXoH6ccc90Zzck6/n6a3bCXOVZwBxq+YHwbAKRV+P8Zg==",
+      "license": "MIT",
       "dependencies": {
         "@keystonehq/alias-sampling": "^0.1.1",
         "assert": "^2.0.0",
@@ -5439,8 +4727,7 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
-      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -5453,8 +4740,7 @@
     },
     "node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
-      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5464,8 +4750,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
-      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5475,8 +4760,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -5487,16 +4771,14 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -5507,8 +4789,7 @@
     },
     "node_modules/@open-rpc/client-js": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@open-rpc/client-js/-/client-js-1.8.1.tgz",
-      "integrity": "sha512-vV+Hetl688nY/oWI9IFY0iKDrWuLdYhf7OIKI6U1DcnJV7r4gAgwRJjEr1QVYszUc0gjkHoQJzqevmXMGLyA0g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
         "isomorphic-ws": "^5.0.0",
@@ -5518,16 +4799,14 @@
     },
     "node_modules/@open-rpc/client-js/node_modules/isomorphic-ws": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/@open-rpc/client-js/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -5546,8 +4825,7 @@
     },
     "node_modules/@openblockhq/dappsdk": {
       "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@openblockhq/dappsdk/-/dappsdk-5.0.15.tgz",
-      "integrity": "sha512-AtoswQtRRDOoryR0pXFYVphS+3ad4H7T8M0ItRTlIQ4SdEyPunKeb8mxN6EOkm0veicUM+mWOeh9ReCc+MI2KA==",
+      "license": "MIT",
       "dependencies": {
         "@mysten/sui.js": "^0.32.1",
         "@mysten/wallet-standard": "^0.5.3",
@@ -5565,22 +4843,19 @@
     },
     "node_modules/@openblockhq/dappsdk/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@openblockhq/dappsdk/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
-      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -5610,187 +4885,15 @@
         "@parcel/watcher-win32-x64": "2.5.0"
       }
     },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
-      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
-      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
-      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
-      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
-      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
-      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
-      "cpu": [
-        "arm"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
-      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
-      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
-      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
-      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
       ],
       "engines": {
         "node": ">= 10.0.0"
@@ -5802,11 +4905,10 @@
     },
     "node_modules/@parcel/watcher-wasm": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.0.tgz",
-      "integrity": "sha512-Z4ouuR8Pfggk1EYYbTaIoxc+Yv4o7cGQnH0Xy8+pQ+HbiW+ZnwhcD2LPf/prfq1nIWpAxjOkQ8uSMFWMtBLiVQ==",
       "bundleDependencies": [
         "napi-wasm"
       ],
+      "license": "MIT",
       "dependencies": {
         "is-glob": "^4.0.3",
         "micromatch": "^4.0.5",
@@ -5825,72 +4927,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
-      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
-      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
-      "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
+      "license": "MIT"
     },
     "node_modules/@particle-network/analytics": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@particle-network/analytics/-/analytics-1.0.2.tgz",
-      "integrity": "sha512-E4EpTRYcfNOkxj+bgNdQydBrvdLGo4HfVStZCuOr3967dYek30r6L7Nkaa9zJXRE2eGT4lPvcAXDV2WxDZl/Xg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "hash.js": "^1.1.7",
         "uuidv4": "^6.2.13"
@@ -5898,8 +4941,7 @@
     },
     "node_modules/@particle-network/auth": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@particle-network/auth/-/auth-1.3.1.tgz",
-      "integrity": "sha512-hu6ie5RjjN4X+6y/vfjyCsSX3pQuS8k8ZoMb61QWwhWsnZXKzpBUVeAEk55aGfxxXY+KfBkSmZosyaZHGoHnfw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@particle-network/analytics": "^1.0.1",
         "@particle-network/chains": "*",
@@ -5910,13 +4952,11 @@
     },
     "node_modules/@particle-network/chains": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@particle-network/chains/-/chains-1.8.0.tgz",
-      "integrity": "sha512-Mh96ihIdfI9KoZ5/HBayMdV46caO4dVH40R6KcBHUiFU8eq91iIxItAdZETlCt4HuHX57DUYVAj+B7u3sXXgnQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/@particle-network/crypto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@particle-network/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-GgvHmHcFiNkCLZdcJOgctSbgvs251yp+EAdUydOE3gSoIxN6KEr/Snu9DebENhd/nFb7FDk5ap0Hg49P7pj1fg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "crypto-js": "^4.1.1",
         "uuidv4": "^6.2.13"
@@ -5924,8 +4964,7 @@
     },
     "node_modules/@particle-network/solana-wallet": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@particle-network/solana-wallet/-/solana-wallet-1.3.2.tgz",
-      "integrity": "sha512-KviKVP87OtWq813y8IumM3rIQMNkTjHBaQmCUbTWGebz3csFOv54JIoy1r+3J3NnA+mBxBdZeRedZ5g+07v75w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@particle-network/auth": "^1.3.1"
       },
@@ -5936,13 +4975,11 @@
     },
     "node_modules/@pedrouid/environment": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -5950,14 +4987,12 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.28",
-      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
-      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5965,8 +5000,7 @@
     },
     "node_modules/@project-serum/anchor": {
       "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.26.0.tgz",
-      "integrity": "sha512-Nq+COIjE1135T7qfnOHEn7E0q39bQTgXLFk837/rgFe6Hkew9WML7eHsS+lSYD2p3OJaTiUOHTAq1lHy36oIqQ==",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@coral-xyz/borsh": "^0.26.0",
         "@solana/web3.js": "^1.68.0",
@@ -5990,8 +5024,7 @@
     },
     "node_modules/@project-serum/anchor/node_modules/@coral-xyz/borsh": {
       "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
-      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -6005,8 +5038,7 @@
     },
     "node_modules/@project-serum/sol-wallet-adapter": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@project-serum/sol-wallet-adapter/-/sol-wallet-adapter-0.2.6.tgz",
-      "integrity": "sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^4.0.1",
         "eventemitter3": "^4.0.7"
@@ -6020,28 +5052,23 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -6049,33 +5076,27 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
-      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
+      "license": "MIT",
       "dependencies": {
         "immer": "^9.0.21",
         "redux": "^4.2.1",
@@ -6097,9 +5118,8 @@
     },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
-      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "estree-walker": "^2.0.2",
@@ -6119,9 +5139,8 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
-      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -6139,258 +5158,22 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
-      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
-      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
-      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
-      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
-      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
-      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
-      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
-      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
-      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
-      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
-      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
-      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
-      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
-      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
-      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
-      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
-      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
-      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
-      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ]
     },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.1.tgz",
-      "integrity": "sha512-BSb/KcyBHmUQwINrgtzo6jiH0HlGFmrUy33vO6unmceuVKTEyL2q+P0fQq2oB5hvXVWOEUhxB2QvlkZluvUEmg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "~8.13.0",
         "ajv-draft-04": "~1.0.0",
@@ -6412,9 +5195,8 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -6428,9 +5210,8 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
-      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
       },
@@ -6442,9 +5223,8 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6456,24 +5236,21 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
+      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6483,9 +5260,8 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/semver": {
       "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6498,24 +5274,21 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/universalify": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
-      "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
@@ -6523,9 +5296,8 @@
     },
     "node_modules/@rushstack/terminal": {
       "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.4.tgz",
-      "integrity": "sha512-NxACqERW0PHq8Rpq1V6v5iTHEwkRGxenjEW+VWqRYQ8T9puUzgmGHmEZUaUEDHAe9Qyvp0/Ew04sAiQw9XjhJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rushstack/node-core-library": "5.10.1",
         "supports-color": "~8.1.1"
@@ -6541,9 +5313,8 @@
     },
     "node_modules/@rushstack/terminal/node_modules/supports-color": {
       "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6556,9 +5327,8 @@
     },
     "node_modules/@rushstack/ts-command-line": {
       "version": "4.23.2",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.2.tgz",
-      "integrity": "sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rushstack/terminal": "0.14.4",
         "@types/argparse": "1.0.38",
@@ -6568,23 +5338,20 @@
     },
     "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@rushstack/ts-command-line/node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@safe-global/safe-apps-provider": {
       "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.5.tgz",
-      "integrity": "sha512-9v9wjBi3TwLsEJ3C2ujYoexp3pFJ0omDLH/GX91e2QB+uwCKTBYyhxFSrTQ9qzoyQd+bfsk4gjOGW87QcJhf7g==",
+      "license": "MIT",
       "dependencies": {
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "events": "^3.3.0"
@@ -6592,8 +5359,7 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
-      "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
+      "license": "MIT",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^2.1.1"
@@ -6601,8 +5367,7 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/abitype": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
-      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -6621,28 +5386,26 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/isows": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
-      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/viem": {
       "version": "2.21.55",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.55.tgz",
-      "integrity": "sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.7.0",
         "@noble/hashes": "1.6.1",
@@ -6665,8 +5428,7 @@
     },
     "node_modules/@safe-global/safe-apps-sdk": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz",
-      "integrity": "sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==",
+      "license": "MIT",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^1.0.0"
@@ -6674,24 +5436,21 @@
     },
     "node_modules/@safe-global/safe-gateway-typescript-sdk": {
       "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4.tgz",
-      "integrity": "sha512-Z7Z8w3GEJdJ/paF+NK23VN4AwqWPadq0AeRYjYLjIBiPWpRB2UO/FKq7ONABEq0YFgNPklazIV4IExQU1gavXA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@scure/base": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
-      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
-      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0",
@@ -6703,8 +5462,7 @@
     },
     "node_modules/@scure/bip39": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
-      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.6.0",
         "@scure/base": "~1.2.1"
@@ -6715,13 +5473,11 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.33.22",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
-      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ=="
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -6731,13 +5487,11 @@
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
-      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+      "license": "MIT"
     },
     "node_modules/@solana/accounts": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0.tgz",
-      "integrity": "sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -6755,8 +5509,7 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6769,8 +5522,7 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6784,8 +5536,7 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6801,8 +5552,7 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6819,8 +5569,7 @@
     },
     "node_modules/@solana/accounts/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6830,16 +5579,14 @@
     },
     "node_modules/@solana/accounts/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/addresses": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0.tgz",
-      "integrity": "sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/assertions": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -6855,8 +5602,7 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6869,8 +5615,7 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6884,8 +5629,7 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6901,8 +5645,7 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6919,8 +5662,7 @@
     },
     "node_modules/@solana/addresses/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6930,16 +5672,14 @@
     },
     "node_modules/@solana/addresses/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/assertions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0.tgz",
-      "integrity": "sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6952,8 +5692,7 @@
     },
     "node_modules/@solana/assertions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6970,8 +5709,7 @@
     },
     "node_modules/@solana/assertions/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6981,16 +5719,14 @@
     },
     "node_modules/@solana/assertions/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
-      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -7000,8 +5736,7 @@
     },
     "node_modules/@solana/buffer-layout-utils": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
-      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/web3.js": "^1.32.0",
@@ -7014,8 +5749,7 @@
     },
     "node_modules/@solana/codecs": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-data-structures": "2.0.0-rc.1",
@@ -7029,8 +5763,7 @@
     },
     "node_modules/@solana/codecs-core": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0-rc.1"
       },
@@ -7040,8 +5773,7 @@
     },
     "node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
-      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-numbers": "2.0.0-rc.1",
@@ -7053,8 +5785,7 @@
     },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/errors": "2.0.0-rc.1"
@@ -7065,8 +5796,7 @@
     },
     "node_modules/@solana/codecs-strings": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-numbers": "2.0.0-rc.1",
@@ -7079,8 +5809,7 @@
     },
     "node_modules/@solana/errors": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7094,8 +5823,7 @@
     },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7105,16 +5833,14 @@
     },
     "node_modules/@solana/errors/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/fast-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0.tgz",
-      "integrity": "sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -7124,8 +5850,7 @@
     },
     "node_modules/@solana/functional": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0.tgz",
-      "integrity": "sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -7135,8 +5860,7 @@
     },
     "node_modules/@solana/instructions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0.tgz",
-      "integrity": "sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7149,8 +5873,7 @@
     },
     "node_modules/@solana/instructions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7167,8 +5890,7 @@
     },
     "node_modules/@solana/instructions/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7178,16 +5900,14 @@
     },
     "node_modules/@solana/instructions/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0.tgz",
-      "integrity": "sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==",
+      "license": "MIT",
       "dependencies": {
         "@solana/assertions": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -7203,8 +5923,7 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7217,8 +5936,7 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7232,8 +5950,7 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7249,8 +5966,7 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7267,8 +5983,7 @@
     },
     "node_modules/@solana/keys/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7278,16 +5993,14 @@
     },
     "node_modules/@solana/keys/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/options": {
       "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
-      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-data-structures": "2.0.0-rc.1",
@@ -7301,8 +6014,7 @@
     },
     "node_modules/@solana/programs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0.tgz",
-      "integrity": "sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7316,8 +6028,7 @@
     },
     "node_modules/@solana/programs/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7334,8 +6045,7 @@
     },
     "node_modules/@solana/programs/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7345,16 +6055,14 @@
     },
     "node_modules/@solana/programs/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/promises": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0.tgz",
-      "integrity": "sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -7364,8 +6072,7 @@
     },
     "node_modules/@solana/rpc": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0.tgz",
-      "integrity": "sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/fast-stable-stringify": "2.0.0",
@@ -7386,8 +6093,7 @@
     },
     "node_modules/@solana/rpc-api": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0.tgz",
-      "integrity": "sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -7410,8 +6116,7 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7424,8 +6129,7 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7439,8 +6143,7 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7456,8 +6159,7 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7474,8 +6176,7 @@
     },
     "node_modules/@solana/rpc-api/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7485,16 +6186,14 @@
     },
     "node_modules/@solana/rpc-api/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-parsed-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0.tgz",
-      "integrity": "sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -7504,8 +6203,7 @@
     },
     "node_modules/@solana/rpc-spec": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0.tgz",
-      "integrity": "sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/rpc-spec-types": "2.0.0"
@@ -7519,8 +6217,7 @@
     },
     "node_modules/@solana/rpc-spec-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0.tgz",
-      "integrity": "sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==",
+      "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -7530,8 +6227,7 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7548,8 +6244,7 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7559,16 +6254,14 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0.tgz",
-      "integrity": "sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/fast-stable-stringify": "2.0.0",
@@ -7591,8 +6284,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-api": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0.tgz",
-      "integrity": "sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/keys": "2.0.0",
@@ -7611,8 +6303,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.0.0.tgz",
-      "integrity": "sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/functional": "2.0.0",
@@ -7629,8 +6320,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7647,8 +6337,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7658,16 +6347,14 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0.tgz",
-      "integrity": "sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/promises": "2.0.0",
@@ -7683,8 +6370,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7701,8 +6387,7 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7712,16 +6397,14 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7738,8 +6421,7 @@
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7749,16 +6431,14 @@
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transformers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0.tgz",
-      "integrity": "sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/functional": "2.0.0",
@@ -7774,8 +6454,7 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7792,8 +6471,7 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7803,16 +6481,14 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transport-http": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0.tgz",
-      "integrity": "sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/rpc-spec": "2.0.0",
@@ -7828,8 +6504,7 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7846,8 +6521,7 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7857,21 +6531,18 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+      "license": "MIT"
     },
     "node_modules/@solana/rpc-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0.tgz",
-      "integrity": "sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -7888,8 +6559,7 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7902,8 +6572,7 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7917,8 +6586,7 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7934,8 +6602,7 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7952,8 +6619,7 @@
     },
     "node_modules/@solana/rpc-types/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7963,16 +6629,14 @@
     },
     "node_modules/@solana/rpc-types/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7989,8 +6653,7 @@
     },
     "node_modules/@solana/rpc/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8000,16 +6663,14 @@
     },
     "node_modules/@solana/rpc/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/signers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0.tgz",
-      "integrity": "sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -8028,8 +6689,7 @@
     },
     "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8042,8 +6702,7 @@
     },
     "node_modules/@solana/signers/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8060,8 +6719,7 @@
     },
     "node_modules/@solana/signers/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8071,16 +6729,14 @@
     },
     "node_modules/@solana/signers/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/spl-token": {
       "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
-      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -8096,8 +6752,7 @@
     },
     "node_modules/@solana/spl-token-metadata": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
-      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
       },
@@ -8110,8 +6765,7 @@
     },
     "node_modules/@solana/subscribable": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.0.0.tgz",
-      "integrity": "sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8124,8 +6778,7 @@
     },
     "node_modules/@solana/subscribable/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8142,8 +6795,7 @@
     },
     "node_modules/@solana/subscribable/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8153,16 +6805,14 @@
     },
     "node_modules/@solana/subscribable/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/sysvars": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0.tgz",
-      "integrity": "sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/codecs": "2.0.0",
@@ -8178,8 +6828,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
-      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8196,8 +6845,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8210,8 +6858,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
-      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8226,8 +6873,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8241,8 +6887,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8258,8 +6903,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8276,8 +6920,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/options": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
-      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8294,8 +6937,7 @@
     },
     "node_modules/@solana/sysvars/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8305,16 +6947,14 @@
     },
     "node_modules/@solana/sysvars/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transaction-confirmation": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0.tgz",
-      "integrity": "sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-strings": "2.0.0",
@@ -8336,8 +6976,7 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8350,8 +6989,7 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8365,8 +7003,7 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8382,8 +7019,7 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8400,8 +7036,7 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8411,16 +7046,14 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transaction-messages": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0.tgz",
-      "integrity": "sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -8440,8 +7073,7 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8454,8 +7086,7 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
-      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8470,8 +7101,7 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8485,8 +7115,7 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8503,8 +7132,7 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8514,16 +7142,14 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transactions": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0.tgz",
-      "integrity": "sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==",
+      "license": "MIT",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -8546,8 +7172,7 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8560,8 +7185,7 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
-      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8576,8 +7200,7 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8591,8 +7214,7 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8608,8 +7230,7 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8626,8 +7247,7 @@
     },
     "node_modules/@solana/transactions/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8637,16 +7257,14 @@
     },
     "node_modules/@solana/transactions/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/wallet-adapter-alpha": {
       "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-alpha/-/wallet-adapter-alpha-0.1.10.tgz",
-      "integrity": "sha512-TOUhDyUNSmp8bqeUueN0LPmurTAEmYm3PTrPGSnsq6JFeTzwTv5xZRygtCvULpBzCPZu/7AfIqh/TSoz4P92aw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8659,8 +7277,7 @@
     },
     "node_modules/@solana/wallet-adapter-avana": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-avana/-/wallet-adapter-avana-0.1.13.tgz",
-      "integrity": "sha512-dvKDzaFo9KgfNh0ohI6qOBTnOU2f6cHKPiDxdtLfXVubdic1mUYzuA2PcrBZQuRc5EBcvHbGCpr3Ds90cGB+xQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8673,8 +7290,7 @@
     },
     "node_modules/@solana/wallet-adapter-base": {
       "version": "0.9.23",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.23.tgz",
-      "integrity": "sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-standard-features": "^1.1.0",
         "@wallet-standard/base": "^1.0.1",
@@ -8690,8 +7306,7 @@
     },
     "node_modules/@solana/wallet-adapter-bitkeep": {
       "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-bitkeep/-/wallet-adapter-bitkeep-0.3.20.tgz",
-      "integrity": "sha512-v6Jd13CZOPNIAX0nFlopAJ3HDvC+MhiB4sde3C8sSnNbjVi9h1WLHBmaUfgqU6mAyhDjWUZjKt4zYlMhLdp/bg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8704,8 +7319,7 @@
     },
     "node_modules/@solana/wallet-adapter-bitpie": {
       "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-bitpie/-/wallet-adapter-bitpie-0.5.18.tgz",
-      "integrity": "sha512-gEflEwAyUbfmU4NEmsoDYt1JNFyoBQGm99BBvrvXdJsDdExvT6PwHNi5YlQKp1A4EAqjqaEj+nQzr6ygUpmCBQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8718,8 +7332,7 @@
     },
     "node_modules/@solana/wallet-adapter-clover": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-clover/-/wallet-adapter-clover-0.4.19.tgz",
-      "integrity": "sha512-48PoaPte/SRYeU25bvOSmSEqoKCcyOBH9CXebsDcXkrgf+g46KRlAlsY605q1ebzr+iaFEONtTdxW8LthvJtbA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8732,8 +7345,7 @@
     },
     "node_modules/@solana/wallet-adapter-coin98": {
       "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coin98/-/wallet-adapter-coin98-0.5.20.tgz",
-      "integrity": "sha512-gnDFNsFq4IeB6jtQj6fZOUthuuQpvtomCkwkwsOWARNhl8nhnsfbuNs3r4XaT4Q79my07ogNQUBPGKY/8CqjiA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "bs58": "^4.0.1"
@@ -8747,8 +7359,7 @@
     },
     "node_modules/@solana/wallet-adapter-coinbase": {
       "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coinbase/-/wallet-adapter-coinbase-0.1.19.tgz",
-      "integrity": "sha512-hcf9ieAbQxD2g8/5glXVAt67w+3iixpjMMZC7lT7Wa8SJZsq6lmISC9AtZctDEQcWSVV0IkedZp3bg6bp22kng==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8761,8 +7372,7 @@
     },
     "node_modules/@solana/wallet-adapter-coinhub": {
       "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coinhub/-/wallet-adapter-coinhub-0.3.18.tgz",
-      "integrity": "sha512-yeJo+cHVlUBlH16Q+knnFDJrH9wzEB3zvSq57PXfqvlWSjySm4PkkK7srRoAwfNOxL/eArSJWfBwRprsymttJQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8775,8 +7385,7 @@
     },
     "node_modules/@solana/wallet-adapter-fractal": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-fractal/-/wallet-adapter-fractal-0.1.8.tgz",
-      "integrity": "sha512-lV/rXOMQSR7sBIEDx8g0jwvXP/fT2Vw/47CSj9BaVYC5LGphhuoYbcI4ko1y0Zv+dJu8JVRTeKbnaiRBjht5DA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@fractalwagmi/solana-wallet-adapter": "^0.1.1",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -8790,8 +7399,7 @@
     },
     "node_modules/@solana/wallet-adapter-huobi": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-huobi/-/wallet-adapter-huobi-0.1.15.tgz",
-      "integrity": "sha512-VKwlK0fE7v97NEWwP86iBY/xgnB3fQJv2/RYaw8ODAcfJqVQZAV6EhDR8fo6++jdS1KkcWc2GcHdBMrqPli3yQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8804,8 +7412,7 @@
     },
     "node_modules/@solana/wallet-adapter-hyperpay": {
       "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-hyperpay/-/wallet-adapter-hyperpay-0.1.14.tgz",
-      "integrity": "sha512-K0qMVpPHbeIVAvhwnn+2GR8jjBe/a5EP514TL/10SQQ8vTLd7ggNWZdTRCjUkHRlsbTOK7yYWAOHu3gx7429rw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8818,8 +7425,7 @@
     },
     "node_modules/@solana/wallet-adapter-keystone": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-keystone/-/wallet-adapter-keystone-0.1.15.tgz",
-      "integrity": "sha512-2A31/vuDRAfASOEyWvJ2YjtwCQohwim3/K+KzhPfvG20C4wr6agDbMXi1T2lDWwrd13kyP+dIgOzPfuLn09tWw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@keystonehq/sol-keyring": "^0.3.1",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -8833,8 +7439,7 @@
     },
     "node_modules/@solana/wallet-adapter-krystal": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-krystal/-/wallet-adapter-krystal-0.1.12.tgz",
-      "integrity": "sha512-umQV9cbLZcqJFkcjpdOgPvTeDvUjcivRSzWgbx27drmeQ9bi4w9bYH5XkFmbj9iD98q+fjrYQUOK772IHZqrkQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8847,8 +7452,7 @@
     },
     "node_modules/@solana/wallet-adapter-ledger": {
       "version": "0.9.25",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-ledger/-/wallet-adapter-ledger-0.9.25.tgz",
-      "integrity": "sha512-59yD3aveLwlzXqk4zBCaPLobeqAhmtMxPizfUBOjzwRKyepi1Nnnt9AC9Af3JrweU2x4qySRxAaZfU/iNqJ3rQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/devices": "6.27.1",
         "@ledgerhq/hw-transport": "6.27.1",
@@ -8865,8 +7469,7 @@
     },
     "node_modules/@solana/wallet-adapter-mathwallet": {
       "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-mathwallet/-/wallet-adapter-mathwallet-0.9.18.tgz",
-      "integrity": "sha512-sleBX+wB8Wahu2lLBCWihkFtnl64DMJgla/kgsf75PCNmNA93+WLA4gYOK+fFKeBkU12a/Hp5oZKEQsQGFPSOA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8879,8 +7482,7 @@
     },
     "node_modules/@solana/wallet-adapter-neko": {
       "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-neko/-/wallet-adapter-neko-0.2.12.tgz",
-      "integrity": "sha512-ei1QoQZhiYMuH/qm3bnXlueT0jQmH4tZfQvEwudFB8+a0fLtSA8lZU+CYI1jd1YLDjkUEIiXV6R/u32nlCuYDA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8893,8 +7495,7 @@
     },
     "node_modules/@solana/wallet-adapter-nightly": {
       "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-nightly/-/wallet-adapter-nightly-0.1.16.tgz",
-      "integrity": "sha512-JaPzT8R4HHUqGn/QdElx9iRW98h0NaANBt0j3CZZYWlqsdG0f8fFfy2xofILA+qnDL6NaRI9AzQ4NcQGuVZsVQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8907,8 +7508,7 @@
     },
     "node_modules/@solana/wallet-adapter-nufi": {
       "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-nufi/-/wallet-adapter-nufi-0.1.17.tgz",
-      "integrity": "sha512-ggTZKvYPJS3m/9hsMaGSH0F8kqumPqP0WdY7WNihWR6O4Pr401kDBdgXPXNSGorIahdPrRBzp5UrahnrlodvTQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8921,8 +7521,7 @@
     },
     "node_modules/@solana/wallet-adapter-onto": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-onto/-/wallet-adapter-onto-0.1.7.tgz",
-      "integrity": "sha512-WS4LY0Z0J+NcyEkjdjkD11uKURkRQ/RHMYSFE59U+MuBHggEpXJFZuJzUE9SZbG1ltlLTh13hS5ZuiEz7F+faA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8935,8 +7534,7 @@
     },
     "node_modules/@solana/wallet-adapter-particle": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-particle/-/wallet-adapter-particle-0.1.12.tgz",
-      "integrity": "sha512-6tD5pbyuyCRDswDVD5LCakVQ/vIwjO2lXlVvJFDLdhGa6MinbjTHigLmE58nkTgKATRScyS8FuCCzGmYcXGbow==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@particle-network/solana-wallet": "^1.3.2",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -8950,8 +7548,7 @@
     },
     "node_modules/@solana/wallet-adapter-phantom": {
       "version": "0.9.24",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-phantom/-/wallet-adapter-phantom-0.9.24.tgz",
-      "integrity": "sha512-D24AxRHmRJ4AYoRvijbiuUb9LmC4xLGKLMSJS2ly+zGxVmaPASPM/ThaY/DlYTDL31QvkYtl8RzSR4yIU1gpLg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8964,8 +7561,7 @@
     },
     "node_modules/@solana/wallet-adapter-safepal": {
       "version": "0.5.18",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-safepal/-/wallet-adapter-safepal-0.5.18.tgz",
-      "integrity": "sha512-E/EIO5j+f0FS9Yj5o5JLJ/qHh3Se/9jP2KdHKhooWTlXWbQDzrxMjV88qIKKl5sgWEndqRYDuDbAdW+2dhw6hw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8978,8 +7574,7 @@
     },
     "node_modules/@solana/wallet-adapter-saifu": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-saifu/-/wallet-adapter-saifu-0.1.15.tgz",
-      "integrity": "sha512-4nrziKQ+4QInh+COsICpNNUlUt456EJ60SZLxvG/z1AOGpatuzT0gN1+RdMcwHGUtiPBPCkEneUVhFZhhbMJlg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -8992,8 +7587,7 @@
     },
     "node_modules/@solana/wallet-adapter-salmon": {
       "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-salmon/-/wallet-adapter-salmon-0.1.14.tgz",
-      "integrity": "sha512-CMXdbhaj3prloCJwvxO7e1wfAyRd58QiPB8pjvB4GBbznyoSnHbFXmpxZrKX1Dk6FoJOGBgjB71xnreGcc6oMw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "salmon-adapter-sdk": "^1.1.1"
@@ -9007,8 +7601,7 @@
     },
     "node_modules/@solana/wallet-adapter-sky": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-sky/-/wallet-adapter-sky-0.1.15.tgz",
-      "integrity": "sha512-1vlk1/jnlOC/WfDDgDoUk3XtEhB3hq1fKtUb+xj0pVuSOg2Db+8ka9vPPYlVaKHoGvjm30iGGfr3ZrCxVfG6OQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9021,8 +7614,7 @@
     },
     "node_modules/@solana/wallet-adapter-solflare": {
       "version": "0.6.28",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-solflare/-/wallet-adapter-solflare-0.6.28.tgz",
-      "integrity": "sha512-iiUQtuXp8p4OdruDawsm1dRRnzUCcsu+lKo8OezESskHtbmZw2Ifej0P99AbJbBAcBw7q4GPI6987Vh05Si5rw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -9039,8 +7631,7 @@
     },
     "node_modules/@solana/wallet-adapter-solong": {
       "version": "0.9.18",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-solong/-/wallet-adapter-solong-0.9.18.tgz",
-      "integrity": "sha512-n40eemFUbJlOP+FKvn8rgq+YAOW51lEsn7uVz5ZjmiaW6MnRQniId9KkGYPPOUjytFyM+6/4x6IXI+QJknlSqA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9053,8 +7644,7 @@
     },
     "node_modules/@solana/wallet-adapter-spot": {
       "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-spot/-/wallet-adapter-spot-0.1.15.tgz",
-      "integrity": "sha512-daU2iBTSJp1RGfQrB2uV06+2WHfeyW0uhjoJ3zTkz24kXqv5/ycoPHr8Gi2jkDSGMFkewnjWF8g0KMEzq2VYug==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9067,8 +7657,7 @@
     },
     "node_modules/@solana/wallet-adapter-tokenary": {
       "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-tokenary/-/wallet-adapter-tokenary-0.1.12.tgz",
-      "integrity": "sha512-iIsOzzEHfRfDUiwYy2BAVGeMl+xBUu92qYK1yAKeKxQPF5McJrnjS3FXwT/onBU5WMdxI6dWm0HKZUiDwefN6A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9081,8 +7670,7 @@
     },
     "node_modules/@solana/wallet-adapter-tokenpocket": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-tokenpocket/-/wallet-adapter-tokenpocket-0.4.19.tgz",
-      "integrity": "sha512-zKXTN+tuKIr/stSxUeG9XPBks9iqeliBWS9JF8eq+8u/Qb/bIDbNSQmd8Z5u1x2lf0puiStc9/iUu/+MLaOSVg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9095,8 +7683,7 @@
     },
     "node_modules/@solana/wallet-adapter-torus": {
       "version": "0.11.28",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-torus/-/wallet-adapter-torus-0.11.28.tgz",
-      "integrity": "sha512-bu1oJQ+AoIZICxz8J1lVcdL+iBBrdbynnEs5N6dxwoM/cMGLbX7PGYqaH0J1dEXisA+1H5AzGAnW4UU05VBmLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@toruslabs/solana-embed": "^0.3.4",
@@ -9114,8 +7701,7 @@
     },
     "node_modules/@solana/wallet-adapter-trezor": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-trezor/-/wallet-adapter-trezor-0.1.2.tgz",
-      "integrity": "sha512-x4nXntYi1SIv63ZdXWX/Rq/VKwguByKu67WpyUXsu8kOdviksb20bQMuAR7Ue41oJ9zSnLlTxAxA1SuWNkFRBg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@trezor/connect-web": "^9.2.1",
@@ -9130,8 +7716,7 @@
     },
     "node_modules/@solana/wallet-adapter-trust": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-trust/-/wallet-adapter-trust-0.1.13.tgz",
-      "integrity": "sha512-lkmPfNdyRgx+z0K7i2cDa3a6SOKXpi3FiaYSo8Zozoxkp+Ga/NXVWxlXtMca4GAc/MnJMVp7yF/31kyFIee+3A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9144,8 +7729,7 @@
     },
     "node_modules/@solana/wallet-adapter-unsafe-burner": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-unsafe-burner/-/wallet-adapter-unsafe-burner-0.1.7.tgz",
-      "integrity": "sha512-SuBVqQxA1NNUwP4Lo70rLPaM8aWkV1EFAlxkRoRLtwyw/gM8bxTO6+9EVyKCv+ix3yw1rCGIF3B0idXx0i37eQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.1.0",
         "@solana/wallet-adapter-base": "^0.9.23",
@@ -9161,8 +7745,7 @@
     },
     "node_modules/@solana/wallet-adapter-walletconnect": {
       "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-walletconnect/-/wallet-adapter-walletconnect-0.1.16.tgz",
-      "integrity": "sha512-jNaQwSho8hT7gF1ifePE8TJc1FULx8jCF16KX3fZPtzXDxKrj0R4VUpHMGcw4MlDknrnZNLOJAVvyiawAkPCRQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@jnwng/walletconnect-solana": "^0.2.0",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -9176,8 +7759,7 @@
     },
     "node_modules/@solana/wallet-adapter-wallets": {
       "version": "0.19.32",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-wallets/-/wallet-adapter-wallets-0.19.32.tgz",
-      "integrity": "sha512-voZYQiIy1yXuKvm7x7YpnQ53eiJC7NpIYSQjzApOUiswiBRVeYcnPO4O/MMPUwsGkS7iZKqKZjo5CnOaN44n+g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-alpha": "^0.1.10",
         "@solana/wallet-adapter-avana": "^0.1.13",
@@ -9225,8 +7807,7 @@
     },
     "node_modules/@solana/wallet-adapter-xdefi": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-xdefi/-/wallet-adapter-xdefi-0.1.7.tgz",
-      "integrity": "sha512-d0icfBOQyaY8kpsdU/wQwaBIahZZPzkXkXfBjpMGwjixD8oeZUFfsg8LC7T1rOIUObeczlocaR/lwtEqWpnaeg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -9239,8 +7820,7 @@
     },
     "node_modules/@solana/wallet-standard-chains": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.0.tgz",
-      "integrity": "sha512-IRJHf94UZM8AaRRmY18d34xCJiVPJej1XVwXiTjihHnmwD0cxdQbc/CKjrawyqFyQAKJx7raE5g9mnJsAdspTg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.0.1"
       },
@@ -9250,8 +7830,7 @@
     },
     "node_modules/@solana/wallet-standard-features": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.2.0.tgz",
-      "integrity": "sha512-tUd9srDLkRpe1BYg7we+c4UhRQkq+XQWswsr/L1xfGmoRDF47BPSXf4zE7ZU2GRBGvxtGt7lwJVAufQyQYhxTQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3"
@@ -9262,8 +7841,7 @@
     },
     "node_modules/@solana/wallet-standard-util": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.1.tgz",
-      "integrity": "sha512-dPObl4ntmfOc0VAGGyyFvrqhL8UkHXmVsgbj0K9RcznKV4KB3MgjGwzo8CTSX5El5lkb0rDeEzFqvToJXRz3dw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.1.0",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -9275,8 +7853,7 @@
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-base": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.2.tgz",
-      "integrity": "sha512-DqhzYbgh3disHMgcz6Du7fmpG29BYVapNEEiL+JoVMa+bU9d4P1wfwXUNyJyRpGGNXtwhyZjIk2umWbe5ZBNaQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -9297,8 +7874,7 @@
     },
     "node_modules/@solana/web3.js": {
       "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
-      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -9319,21 +7895,18 @@
     },
     "node_modules/@solana/web3.js/node_modules/@types/ws": {
       "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
-      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@solana/web3.js/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.4.tgz",
-      "integrity": "sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==",
+      "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/uuid": "^8.3.4",
@@ -9354,16 +7927,14 @@
     },
     "node_modules/@solana/web3.js/node_modules/superstruct": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
-      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@solflare-wallet/metamask-sdk": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@solflare-wallet/metamask-sdk/-/metamask-sdk-1.0.3.tgz",
-      "integrity": "sha512-os5Px5PTMYKGS5tzOoyjDxtOtj0jZKnbI1Uwt8+Jsw1HHIA+Ib2UACCGNhQ/un2f8sIbTfLD1WuucNMOy8KZpQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/wallet-standard-features": "^1.1.0",
         "@wallet-standard/base": "^1.0.1",
@@ -9377,38 +7948,33 @@
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@solflare-wallet/sdk": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@solflare-wallet/sdk/-/sdk-1.4.2.tgz",
-      "integrity": "sha512-jrseNWipwl9xXZgrzwZF3hhL0eIVxuEtoZOSLmuPuef7FgHjstuTtNJAeT4icA7pzdDV4hZvu54pI2r2f7SmrQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0",
         "eventemitter3": "^5.0.1",
@@ -9420,56 +7986,48 @@
     },
     "node_modules/@solflare-wallet/sdk/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@solflare-wallet/sdk/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@solflare-wallet/sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@solflare-wallet/sdk/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@stablelib/aead": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
-      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/binary": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
-      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/int": "^1.0.1"
       }
     },
     "node_modules/@stablelib/bytes": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/chacha": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
-      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -9477,8 +8035,7 @@
     },
     "node_modules/@stablelib/chacha20poly1305": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
-      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/aead": "^1.0.1",
         "@stablelib/binary": "^1.0.1",
@@ -9490,13 +8047,11 @@
     },
     "node_modules/@stablelib/constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/ed25519": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
-      "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha512": "^1.0.1",
@@ -9505,13 +8060,11 @@
     },
     "node_modules/@stablelib/hash": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/hkdf": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
-      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/hash": "^1.0.1",
         "@stablelib/hmac": "^1.0.1",
@@ -9520,8 +8073,7 @@
     },
     "node_modules/@stablelib/hmac": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
-      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/constant-time": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -9530,21 +8082,18 @@
     },
     "node_modules/@stablelib/int": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/keyagreement": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
-      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/bytes": "^1.0.1"
       }
     },
     "node_modules/@stablelib/poly1305": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
-      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -9552,8 +8101,7 @@
     },
     "node_modules/@stablelib/random": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
-      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -9561,8 +8109,7 @@
     },
     "node_modules/@stablelib/sha256": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
-      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -9571,8 +8118,7 @@
     },
     "node_modules/@stablelib/sha512": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
-      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -9581,13 +8127,11 @@
     },
     "node_modules/@stablelib/wipe": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
+      "license": "MIT"
     },
     "node_modules/@stablelib/x25519": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
-      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/keyagreement": "^1.0.1",
         "@stablelib/random": "^1.0.2",
@@ -9596,15 +8140,13 @@
     },
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
-      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
+      "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-rQ4dS6GAdmtzKiCRt3LFVxl37FaY1cgL9kSUTnhQ2xc3fmHOd7jdJK/V4pSZMG1ruGTd0bsi34O2R0Olg9Zo/w==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -9639,159 +8181,14 @@
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.1.tgz",
-      "integrity": "sha512-NyELPp8EsVZtxH/mEqvzSyWpfPJ1lugpTQcSlMduZLj1EASLO4sC8wt8hmL1aizRlsbjCX+r0PyL+l0xQ64/6Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.1.tgz",
-      "integrity": "sha512-L4BNt1fdQ5ZZhAk5qoDfUnXRabDOXKnXBxMDJ+PWLSxOGBbWE6aJTnu4zbGjJvtot0KM46m2LPAPY8ttknqaZA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.1.tgz",
-      "integrity": "sha512-Y1u9OqCHgvVp2tYQAJ7hcU9qO5brDMIrA5R31rwWQIAKDkJKtv3IlTHF0hrbWk1wPR0ZdngkQSJZple7G+Grvw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.1.tgz",
-      "integrity": "sha512-tNQHO/UKdtnqjc7o04iRXng1wTUXPgVd8Y6LI4qIbHVoVPwksZydISjMcilKNLKIwOoUQAkxyJ16SlOAeADzhQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.1.tgz",
-      "integrity": "sha512-x0L2Pd9weQ6n8dI1z1Isq00VHFvpBClwQJvrt3NHzmR+1wCT/gcYl1tp9P5xHh3ldM8Cn4UjWCw+7PaUgg8FcQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.1.tgz",
-      "integrity": "sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.1.tgz",
-      "integrity": "sha512-tcaS43Ydd7Fk7sW5ROpaf2Kq1zR+sI5K0RM+0qYLYYurvsJruj3GhBCaiN3gkzd8m/8wkqNqtVklWaQYSDsyqA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.1.tgz",
-      "integrity": "sha512-D3Qo1voA7AkbOzQ2UGuKNHfYGKL6eejN8VWOoQYtGHHQi1p5KK/Q7V1ku55oxXBsj79Ny5FRMqiRJpVGad7bjQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.1.tgz",
-      "integrity": "sha512-WalYdFoU3454Og+sDKHM1MrjvxUGwA2oralknXkXL8S0I/8RkWZOB++p3pLaGbTvOO++T+6znFbQdR8KRaa7DA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.1.tgz",
-      "integrity": "sha512-JWobfQDbTnoqaIwPKQ3DVSywihVXlQMbDuwik/dDWlj33A8oEHcjPOGs4OqcA3RHv24i+lfCQpM3Mn4FAMfacA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -9799,31 +8196,27 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
       "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -9833,8 +8226,7 @@
     },
     "node_modules/@tanstack/query-core": {
       "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
-      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
+      "license": "MIT",
       "peer": true,
       "funding": {
         "type": "github",
@@ -9843,8 +8235,7 @@
     },
     "node_modules/@tanstack/query-persist-client-core": {
       "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.36.1.tgz",
-      "integrity": "sha512-eocgCeI7D7TRv1IUUBMfVwOI0wdSmMkBIbkKhqEdTrnUHUQEeOaYac8oeZk2cumAWJdycu6P/wB+WqGynTnzXg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.36.1"
@@ -9856,8 +8247,7 @@
     },
     "node_modules/@tanstack/query-sync-storage-persister": {
       "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.36.1.tgz",
-      "integrity": "sha512-yMEt5hWe2+1eclf1agMtXHnPIkxEida0lYWkfdhR8U6KXk/lO4Vca6piJmhKI85t0NHlx3l/z6zX+t/Fn5O9NA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-persist-client-core": "4.36.1"
@@ -9869,8 +8259,7 @@
     },
     "node_modules/@tanstack/react-query": {
       "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
-      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.36.1",
@@ -9896,8 +8285,7 @@
     },
     "node_modules/@tanstack/react-query-persist-client": {
       "version": "4.36.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.36.1.tgz",
-      "integrity": "sha512-32I5b9aAu4NCiXZ7Te/KEQLfHbYeTNriVPrKYcvEThnZ9tlW01vLcSoxpUIsMYRsembvJUUAkzYBAiZHLOd6pQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-persist-client-core": "4.36.1"
@@ -9912,8 +8300,7 @@
     },
     "node_modules/@toruslabs/base-controllers": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/base-controllers/-/base-controllers-2.9.0.tgz",
-      "integrity": "sha512-rKc+bR4QB/wdbH0CxLZC5e2PUZcIgkr9yY7TMd3oIffDklaYBnsuC5ES2/rgK1aRUDRWz+qWbTwLqsY6PlT37Q==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/util": "^8.0.6",
         "@toruslabs/broadcast-channel": "^6.2.0",
@@ -9933,8 +8320,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -9942,8 +8328,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -9956,8 +8341,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@metamask/rpc-errors": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-5.1.1.tgz",
-      "integrity": "sha512-JjZnDi2y2CfvbohhBl+FOQRzmFlJpybcQlIk37zEX8B96eVSPbH/T8S0p7cSF8IE33IWx6JkD8Ycsd+2TXFxCw==",
+      "license": "MIT",
       "dependencies": {
         "@metamask/utils": "^5.0.0",
         "fast-safe-stringify": "^2.0.6"
@@ -9968,8 +8352,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
-      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -9983,8 +8366,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@toruslabs/openlogin-jrpc": {
       "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.2.tgz",
-      "integrity": "sha512-9Eb0cPc0lPuS6v2YkQlgzfbRnZ6fLez9Ike5wznoHSFA2/JVu1onwuI56EV1HwswdDrOWPPQEyzI1j9NriZ0ew==",
+      "license": "ISC",
       "dependencies": {
         "@metamask/rpc-errors": "^5.1.1",
         "@toruslabs/openlogin-utils": "^4.7.0",
@@ -10005,8 +8387,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@toruslabs/openlogin-utils": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-utils/-/openlogin-utils-4.7.0.tgz",
-      "integrity": "sha512-w6XkHs4WKuufsf/zzteBzs4EJuOknrUmJ+iv5FZ8HzIpMQeL/984CP8HYaFSEYkbGCP4ydAnhY4Uh0QAhpDbPg==",
+      "license": "ISC",
       "dependencies": {
         "base64url": "^3.0.1"
       },
@@ -10020,8 +8401,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/readable-stream": {
       "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.6.0.tgz",
-      "integrity": "sha512-cbAdYt0VcnpN2Bekq7PU+k363ZRsPwJoEEJOEtSJQlJXzwaxt3FIo/uL+KeDSGIjJqtkwyge4KQgD2S2kd+CQw==",
+      "license": "MIT",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -10035,8 +8415,7 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -10046,16 +8425,14 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@toruslabs/broadcast-channel": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@toruslabs/broadcast-channel/-/broadcast-channel-6.3.1.tgz",
-      "integrity": "sha512-BEtJQ+9bMfFoGuCsp5NmxyY+C980Ho+3BZIKSiYwRtl5qymJ+jMX5lsoCppoQblcb34dP6FwEjeFw80Y9QC/rw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@toruslabs/eccrypto": "^2.1.1",
@@ -10069,16 +8446,14 @@
     },
     "node_modules/@toruslabs/eccrypto": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-2.2.1.tgz",
-      "integrity": "sha512-7sviL0wLYsfA5ogEAOIdb0tu/QAOFXfHc9B8ONYtF04x4Mg3Nr89LL35FhjaEm055q8Ru7cUQhEFSiqJqm9GCw==",
+      "license": "CC0-1.0",
       "dependencies": {
         "elliptic": "^6.5.4"
       }
     },
     "node_modules/@toruslabs/http-helpers": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-3.4.0.tgz",
-      "integrity": "sha512-CoeJSL32mpp0gmYjxv48odu6pfjHk/rbJHDwCtYPcMHAl+qUQ/DTpVOOn9U0fGkD+fYZrQmZbRkXFgLhiT0ajQ==",
+      "license": "MIT",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -10099,8 +8474,7 @@
     },
     "node_modules/@toruslabs/metadata-helpers": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/metadata-helpers/-/metadata-helpers-3.2.0.tgz",
-      "integrity": "sha512-2bCc6PNKd9y+aWfZQ1FXd47QmfyT4NmmqPGfsqk+sQS2o+MlxIyLuh9uh7deMgXo4b4qBDX+RQGbIKM1zVk56w==",
+      "license": "MIT",
       "dependencies": {
         "@toruslabs/eccrypto": "^2.1.1",
         "@toruslabs/http-helpers": "^3.4.0",
@@ -10118,9 +8492,7 @@
     },
     "node_modules/@toruslabs/openlogin-jrpc": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-3.2.0.tgz",
-      "integrity": "sha512-G+K0EHyVUaAEyeD4xGsnAZRpn/ner8lQ2HC2+pGKg6oGmzKI2wGMDcw2KMH6+HKlfBGVJ5/VR9AQfC/tZlLDmQ==",
-      "deprecated": "Not supported. Pls upgrade",
+      "license": "ISC",
       "dependencies": {
         "@toruslabs/openlogin-utils": "^3.0.0",
         "end-of-stream": "^1.4.4",
@@ -10137,9 +8509,7 @@
     },
     "node_modules/@toruslabs/openlogin-utils": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-utils/-/openlogin-utils-3.0.0.tgz",
-      "integrity": "sha512-T5t29/AIFqXc84x4OoAkZWjd0uoP2Lk6iaFndnIIMzCPu+BwwV0spX/jd/3YYNjZ8Po8D+faEnwAhiqemYeK2w==",
-      "deprecated": "Not supported. Pls upgrade",
+      "license": "ISC",
       "dependencies": {
         "base64url": "^3.0.1",
         "keccak": "^3.0.3",
@@ -10151,8 +8521,7 @@
     },
     "node_modules/@toruslabs/solana-embed": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@toruslabs/solana-embed/-/solana-embed-0.3.4.tgz",
-      "integrity": "sha512-yj+aBJoBAneap7Jlu9/OOp7irWNuC5CqAhyhVcmb0IjWrCUFnioLdL0U7UfGaqVm/5O0leJh7/Z5Ll+3toWJBg==",
+      "license": "ISC",
       "dependencies": {
         "@solana/web3.js": "^1.63.1",
         "@toruslabs/base-controllers": "^2.8.0",
@@ -10175,8 +8544,7 @@
     },
     "node_modules/@trezor/analytics": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.2.5.tgz",
-      "integrity": "sha512-+6DnjUj1XHD9wHffilPYXIPGmIwPNlYJLlS98FhAv5tOVr9rWvomqtXx2GWwtiv2B3oR/h6oMiYGmS/yjpM2cA==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@trezor/env-utils": "1.2.1",
         "@trezor/utils": "9.2.5"
@@ -10187,8 +8555,7 @@
     },
     "node_modules/@trezor/analytics/node_modules/@trezor/utils": {
       "version": "9.2.5",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.5.tgz",
-      "integrity": "sha512-FaGKQxwvivcWOa8vK4qQPdyvUm/AcjH0xOKfcvjNfaBhf+TVDzKn2ORKnioQb2Sgjncb8B2ubqrUI3MIc+RKKw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "bignumber.js": "^9.1.2"
       },
@@ -10198,8 +8565,7 @@
     },
     "node_modules/@trezor/blockchain-link": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.3.6.tgz",
-      "integrity": "sha512-cuqGJr5d5iTwGNbTAKDskE+m7yL/4RQsagNwA64793tli1fDWeeGT/B2mCvFwpUmIo9dVFDkYb++ZiltUIGZ3w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@solana-program/token": "^0.4.1",
         "@solana/web3.js": "^2.0.0",
@@ -10220,8 +8586,7 @@
     },
     "node_modules/@trezor/blockchain-link-types": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.2.5.tgz",
-      "integrity": "sha512-aGxLNGxhQqre4cCYDboy1s1gHAi92tTszLYl3GMhGmtB6EuAl049eO8ngCcMcuOZLTvFYA/1e/3mZoPIMBkeng==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@solana/web3.js": "^2.0.0",
         "@trezor/type-utils": "1.1.4",
@@ -10233,8 +8598,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
-      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -10251,8 +8615,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -10265,8 +8628,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
-      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -10281,8 +8643,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -10296,8 +8657,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -10313,8 +8673,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -10331,8 +8690,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/options": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
-      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -10349,8 +8707,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/web3.js": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
-      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
+      "license": "MIT",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/addresses": "2.0.0",
@@ -10380,8 +8737,7 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -10391,16 +8747,14 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@trezor/blockchain-link-utils": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.2.6.tgz",
-      "integrity": "sha512-6ExuAyKxGH79aZhT3eA6xng9ljYixiE9EBC635BLPc+lafpin2+Aplb0q2zA6f/S5ksl9ges63W627pb7IFgGw==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@trezor/env-utils": "1.2.1",
@@ -10412,16 +8766,14 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.4.1.tgz",
-      "integrity": "sha512-eSYmjsapzE9jXT2J9xydlMj/zsangMEIZAy9dy75VCXM6kgDCSnH5R7+HsIoKOTvb2VggU7GojC+YhMwWGCIBw==",
+      "license": "Apache-2.0",
       "peerDependencies": {
         "@solana/web3.js": "^2.0.0"
       }
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
-      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -10438,8 +8790,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
-      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -10452,8 +8803,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
-      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -10468,8 +8818,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
-      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -10483,8 +8832,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
-      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -10500,8 +8848,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
-      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -10518,8 +8865,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/options": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
-      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
+      "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -10536,8 +8882,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/web3.js": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
-      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
+      "license": "MIT",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/addresses": "2.0.0",
@@ -10567,8 +8912,7 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/chalk": {
       "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
-      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -10578,16 +8922,14 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@trezor/connect": {
       "version": "9.4.7",
-      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.4.7.tgz",
-      "integrity": "sha512-Ky8AMWxhq0ieOCNgZtaIKTQie5qaQjK3uuv+TriUZXuxDqSoJcD8T50TAEY1Lxo1xl8Yv3wT0m6LQkmBn3T+xQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
         "@ethereumjs/common": "^4.4.0",
@@ -10614,8 +8956,7 @@
     },
     "node_modules/@trezor/connect-analytics": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.2.4.tgz",
-      "integrity": "sha512-x7cbQ/x+THMG6pBttRip9qySDU6SRnTiN0AHUKDLBpUrOV+85fRScxUaX5RddtmG26J96HgNEw7Ydms7tBOlSQ==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@trezor/analytics": "1.2.5"
       },
@@ -10625,8 +8966,7 @@
     },
     "node_modules/@trezor/connect-common": {
       "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.2.7.tgz",
-      "integrity": "sha512-m9gYDY0Elitofs4k3E4uAmzgi2DtJHneb47jQVbjBZSLpzROiV7fz49aDxBnz/oPCJnIVF9Gu2OUQEh2GDeZcA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@trezor/env-utils": "1.2.1",
         "@trezor/utils": "9.2.6"
@@ -10637,8 +8977,7 @@
     },
     "node_modules/@trezor/connect-web": {
       "version": "9.4.7",
-      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.4.7.tgz",
-      "integrity": "sha512-mICiGnw1xt60LbELZd2OId+nXGG/NAiywQIXGp5rOY6116I/sqJMw4fuKQrkGJ5zpKzzX/G7Be9GcshICD1ZDg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@trezor/connect": "9.4.7",
         "@trezor/connect-common": "0.2.7",
@@ -10650,21 +8989,18 @@
     },
     "node_modules/@trezor/connect/node_modules/base-x": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "license": "MIT"
     },
     "node_modules/@trezor/connect/node_modules/bs58": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/@trezor/connect/node_modules/bs58check": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
-      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -10672,16 +9008,14 @@
     },
     "node_modules/@trezor/connect/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/@trezor/env-utils": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.2.1.tgz",
-      "integrity": "sha512-ESBV+/AWpfJA6qnHk7BgBYFbhNtUKjPZZzQr1LOUiePwFITbVu421b5BHjTSPFVjpbrWo6Ob0IG7u8saJi0G5A==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "ua-parser-js": "^1.0.37"
       },
@@ -10705,8 +9039,7 @@
     },
     "node_modules/@trezor/protobuf": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.2.6.tgz",
-      "integrity": "sha512-QN/1T0/NgZk3r5FVGtMVL41Q3UaUdjFsE4LSxWvzreLp9T5jsHp5bL0wT6TCkocNqmKK3ijH2Ro/Dh8VOSZDbQ==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@trezor/schema-utils": "1.2.3",
         "protobufjs": "7.4.0"
@@ -10717,16 +9050,14 @@
     },
     "node_modules/@trezor/protocol": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.2.2.tgz",
-      "integrity": "sha512-iXD+Wqpk0FpwJpQbAFKw+8AL6ipfDjQ7g+MYZ7lU1H7/gCxM2XqLI4eW7Il+FAwk7orepDuoSbJSVcsNJYKjOA==",
+      "license": "See LICENSE.md in repo root",
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/schema-utils": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.2.3.tgz",
-      "integrity": "sha512-+/GmaSTfUf8nEBSSWz/SV0W/0l37YQBfDMygAKXlKMbtXJI03PHqkEF/jQrt+BP2Gh24gjo5GNqCwx7EIlzZug==",
+      "license": "See LICENSE.md in repo root",
       "dependencies": {
         "@sinclair/typebox": "^0.33.7",
         "ts-mixer": "^6.0.3"
@@ -10737,8 +9068,7 @@
     },
     "node_modules/@trezor/transport": {
       "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.3.7.tgz",
-      "integrity": "sha512-pxoPbgaDKUg5ElgyzW+vuQ1YLLX75W/bfAk0V6SdPGqpd3V+6NvJaNQVxAnmL6k3qzHheBFrqyhlkkkEdyuuSQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@trezor/protobuf": "1.2.6",
         "@trezor/protocol": "1.2.2",
@@ -10754,21 +9084,18 @@
     },
     "node_modules/@trezor/transport/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/@trezor/type-utils": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.1.4.tgz",
-      "integrity": "sha512-pzrIdskmTZRocHellMZxCDPQ3IpmTr749qn1xdIN29pIKuI4ms0OfNUPk/rfR4Iug0kEiWt+n+Hw7+lIBzc2LA=="
+      "license": "See LICENSE.md in repo root"
     },
     "node_modules/@trezor/utils": {
       "version": "9.2.6",
-      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.6.tgz",
-      "integrity": "sha512-8kJYRcOm2uD9uAzktXFivY9Ctkub39MUQCo0TIFzL01erzSDt5i9f81meIgLANm8cgmg3PPVA6SWyitOKRkKpg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "bignumber.js": "^9.1.2"
       },
@@ -10778,8 +9105,7 @@
     },
     "node_modules/@trezor/utxo-lib": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.2.6.tgz",
-      "integrity": "sha512-OAwN1d4CXU/7LhczatdL/xKaYcyjxWiURYfG5hOfscTvhaDZ+veFhxo6YHJ2fGGlpZwS+B14JRsmDoXAelIeeA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@trezor/utils": "9.2.6",
         "bchaddrjs": "^0.5.2",
@@ -10805,21 +9131,18 @@
     },
     "node_modules/@trezor/utxo-lib/node_modules/base-x": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "license": "MIT"
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58check": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
-      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -10827,27 +9150,23 @@
     },
     "node_modules/@tronweb3/google-protobuf": {
       "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/@tronweb3/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-IVcT2GfWX3K6tHUVhs14NP5uzKhQt4KeDya1g9ACxuZsUzsaoGUIGzceK2Ltu7xp1YV94AaHOf4yxLAivlvEkQ=="
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
-      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
-      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -10857,30 +9176,26 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
-      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -10888,57 +9203,48 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/lodash": {
       "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
+      "license": "MIT"
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
-      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.17.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
-      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -10946,26 +9252,22 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+      "license": "MIT"
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.17",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
-      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -10973,27 +9275,24 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-infinite-scroller": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/@types/react-infinite-scroller/-/react-infinite-scroller-1.2.5.tgz",
-      "integrity": "sha512-fJU1jhMgoL6NJFrqTM0Ob7tnd2sQWGxe2ESwiU6FZWbJK/VO/Er5+AOhc+e2zbT0dk5pLygqctsulOLJ8xnSzw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/react-redux": {
       "version": "7.1.34",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
-      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -11003,72 +9302,61 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
-      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
+      "license": "MIT"
     },
     "node_modules/@types/w3c-web-usb": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
-      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
+      "license": "MIT"
     },
     "node_modules/@types/web": {
       "version": "0.0.174",
-      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.174.tgz",
-      "integrity": "sha512-dT8gX38RUQjy+uruZg49EvloEa2S3gR0z2eRi557eTSFKqUSXkSCWYa0IY9uabX9MZPMGOu+1r8Qn6tsvJ1KnQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
-      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -11100,9 +9388,8 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11112,9 +9399,8 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -11139,9 +9425,8 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
@@ -11156,9 +9441,8 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
-      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
@@ -11183,9 +9467,8 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -11196,9 +9479,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -11223,9 +9505,8 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11235,9 +9516,8 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
-      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -11261,9 +9541,8 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11273,9 +9552,8 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -11290,15 +9568,13 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
-      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz",
-      "integrity": "sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.7.26"
       },
@@ -11308,9 +9584,8 @@
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
-      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "1.6.0",
         "@vitest/utils": "1.6.0",
@@ -11322,9 +9597,8 @@
     },
     "node_modules/@vitest/runner": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
-      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "1.6.0",
         "p-limit": "^5.0.0",
@@ -11336,9 +9610,8 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
-      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -11351,9 +9624,8 @@
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
-      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -11363,9 +9635,8 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
-      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.5",
         "pathe": "^1.1.1",
@@ -11377,9 +9648,8 @@
     },
     "node_modules/@vitest/spy": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
-      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.2.0"
       },
@@ -11389,9 +9659,8 @@
     },
     "node_modules/@vitest/utils": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
-      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.6.3",
         "estree-walker": "^3.0.3",
@@ -11404,33 +9673,29 @@
     },
     "node_modules/@vitest/utils/node_modules/estree-walker": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
-      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.11"
       }
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
-      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
-      "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.11",
         "path-browserify": "^1.0.1",
@@ -11439,9 +9704,8 @@
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
-      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/shared": "3.5.13",
@@ -11452,9 +9716,8 @@
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
-      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -11462,9 +9725,8 @@
     },
     "node_modules/@vue/compiler-vue2": {
       "version": "2.7.16",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
-      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
@@ -11472,9 +9734,8 @@
     },
     "node_modules/@vue/language-core": {
       "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
-      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "~2.4.8",
         "@vue/compiler-dom": "^3.5.0",
@@ -11496,18 +9757,16 @@
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vue/language-core/node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -11520,14 +9779,11 @@
     },
     "node_modules/@vue/shared": {
       "version": "3.5.13",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
-      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wagmi/connectors": {
       "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-3.1.11.tgz",
-      "integrity": "sha512-wzxp9f9PtSUFjDUP/QDjc1t7HON4D8wrVKsw35ejdO8hToDpx1gU9lwH/47Zo/1zExGezQc392sjoHSszYd7OA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -11538,6 +9794,7 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.6.6",
         "@safe-global/safe-apps-provider": "^0.18.1",
@@ -11561,8 +9818,7 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
-      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -11571,8 +9827,7 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
-      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+      "license": "MIT",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -11580,16 +9835,14 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -11601,8 +9854,7 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -11622,16 +9874,14 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -11639,18 +9889,14 @@
     },
     "node_modules/@wagmi/connectors/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@wagmi/connectors/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@wagmi/core": {
       "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-1.4.13.tgz",
-      "integrity": "sha512-ytMCvXbBOgfDu9Qw67279wq/jNEe7EZLjLyekX7ROnvHRADqFr3lwZI6ih41UmtRZAmXAx8Ghyuqy154EjB5mQ==",
       "funding": [
         {
           "type": "gitcoin",
@@ -11661,6 +9907,7 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@wagmi/connectors": "3.1.11",
         "abitype": "0.8.7",
@@ -11679,8 +9926,7 @@
     },
     "node_modules/@wallet-standard/app": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
-      "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -11690,16 +9936,14 @@
     },
     "node_modules/@wallet-standard/base": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
-      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/core": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/core/-/core-1.0.3.tgz",
-      "integrity": "sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/app": "^1.0.1",
         "@wallet-standard/base": "^1.0.1",
@@ -11712,8 +9956,7 @@
     },
     "node_modules/@wallet-standard/features": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
-      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -11723,8 +9966,7 @@
     },
     "node_modules/@wallet-standard/wallet": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
-      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -11734,8 +9976,7 @@
     },
     "node_modules/@walletconnect/browser-utils": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
-      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
         "@walletconnect/types": "^1.8.0",
@@ -11746,8 +9987,7 @@
     },
     "node_modules/@walletconnect/core": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.3.tgz",
-      "integrity": "sha512-57uv0FW4L6H/tmkb1kS2nG41MDguyDgZbGR58nkDUd1TO/HydyiTByVOhFzIxgN331cnY/1G1rMaKqncgdnOFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -11773,16 +10013,14 @@
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
-      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -11794,21 +10032,18 @@
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/core/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/crypto": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.3.tgz",
-      "integrity": "sha512-+2jdORD7XQs76I2Odgr3wwrtyuLUXD/kprNVsjWRhhhdO9Mt6WqVzOPu0/t7OHSmgal8k7SoBQzUc5hu/8zL/g==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/environment": "^1.0.1",
@@ -11820,13 +10055,11 @@
     },
     "node_modules/@walletconnect/crypto/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/encoding": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.2.tgz",
-      "integrity": "sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==",
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "1.0.0",
         "tslib": "1.14.1",
@@ -11835,26 +10068,22 @@
     },
     "node_modules/@walletconnect/encoding/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/environment": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
-      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/environment/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/ethereum-provider": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.11.0.tgz",
-      "integrity": "sha512-YrTeHVjuSuhlUw7SQ6xBJXDuJ6iAC+RwINm9nVhoKYJSHAy3EVSJZOofMKrnecL0iRMtD29nj57mxAInIBRuZA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -11870,8 +10099,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -11894,8 +10122,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
-      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -11904,8 +10131,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
-      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -11914,8 +10140,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
-      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+      "license": "MIT",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -11923,8 +10148,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
-      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -11934,17 +10158,14 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/sign-client": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.0.tgz",
-      "integrity": "sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==",
-      "deprecated": "Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/core": "2.11.0",
         "@walletconnect/events": "^1.0.1",
@@ -11959,8 +10180,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -11972,8 +10192,7 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -11993,16 +10212,14 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -12010,18 +10227,15 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -12040,8 +10254,7 @@
     },
     "node_modules/@walletconnect/events": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
-      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -12049,13 +10262,11 @@
     },
     "node_modules/@walletconnect/events/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/heartbeat": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
-      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -12064,8 +10275,7 @@
     },
     "node_modules/@walletconnect/jsonrpc-http-connection": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
-      "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -12075,21 +10285,18 @@
     },
     "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
-      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -12098,21 +10305,18 @@
     },
     "node_modules/@walletconnect/jsonrpc-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
-      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
       "dependencies": {
         "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0"
@@ -12120,8 +10324,7 @@
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
-      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.3",
@@ -12130,13 +10333,11 @@
     },
     "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
-      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -12146,21 +10347,18 @@
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -12179,8 +10377,7 @@
     },
     "node_modules/@walletconnect/keyvaluestorage": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
-      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.1",
         "idb-keyval": "^6.2.1",
@@ -12197,21 +10394,18 @@
     },
     "node_modules/@walletconnect/keyvaluestorage/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/legacy-client": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-client/-/legacy-client-2.0.0.tgz",
-      "integrity": "sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/crypto": "^1.0.3",
         "@walletconnect/encoding": "^1.0.2",
@@ -12227,24 +10421,21 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -12252,13 +10443,11 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/legacy-client/node_modules/query-string": {
       "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "license": "MIT",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -12274,13 +10463,11 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/legacy-modal": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-modal/-/legacy-modal-2.0.0.tgz",
-      "integrity": "sha512-jckNd8lMhm4X7dX9TDdxM3bXKJnaqkRs6K2Mo5j6GmbIF9Eyx40jZ5+q457RVxvM6ciZEDT5s1wBHWdWoOo+9Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/legacy-types": "^2.0.0",
         "@walletconnect/legacy-utils": "^2.0.0",
@@ -12291,16 +10478,14 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/cliui": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -12309,13 +10494,11 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -12326,16 +10509,14 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -12345,8 +10526,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12359,8 +10539,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -12370,16 +10549,14 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/pngjs": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/preact": {
       "version": "10.25.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
-      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12387,8 +10564,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/qrcode": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
-      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "pngjs": "^5.0.0",
@@ -12403,8 +10579,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12416,8 +10591,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12429,8 +10603,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/yargs": {
       "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -12450,8 +10623,7 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -12462,8 +10634,7 @@
     },
     "node_modules/@walletconnect/legacy-provider": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-provider/-/legacy-provider-2.0.0.tgz",
-      "integrity": "sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.4",
         "@walletconnect/jsonrpc-provider": "^1.0.6",
@@ -12475,16 +10646,14 @@
     },
     "node_modules/@walletconnect/legacy-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-types/-/legacy-types-2.0.0.tgz",
-      "integrity": "sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
     },
     "node_modules/@walletconnect/legacy-utils": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-utils/-/legacy-utils-2.0.0.tgz",
-      "integrity": "sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
@@ -12498,24 +10667,21 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -12523,13 +10689,11 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/query-string": {
       "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
-      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
+      "license": "MIT",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -12545,13 +10709,11 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/logger": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
         "pino": "7.11.0"
@@ -12559,27 +10721,22 @@
     },
     "node_modules/@walletconnect/logger/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/logger/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/mobile-registry": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
-      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==",
-      "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry"
+      "license": "MIT"
     },
     "node_modules/@walletconnect/modal": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.2.tgz",
-      "integrity": "sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/modal-core": "2.6.2",
         "@walletconnect/modal-ui": "2.6.2"
@@ -12587,16 +10744,14 @@
     },
     "node_modules/@walletconnect/modal-core": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.2.tgz",
-      "integrity": "sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "valtio": "1.11.2"
       }
     },
     "node_modules/@walletconnect/modal-ui": {
       "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.2.tgz",
-      "integrity": "sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/modal-core": "2.6.2",
         "lit": "2.8.0",
@@ -12606,16 +10761,14 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/cliui": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -12624,13 +10777,11 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/modal-ui/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -12641,16 +10792,14 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -12660,8 +10809,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -12674,8 +10822,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -12685,16 +10832,14 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/pngjs": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/qrcode": {
       "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -12710,8 +10855,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -12723,8 +10867,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -12736,8 +10879,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/yargs": {
       "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -12757,8 +10899,7 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -12769,9 +10910,7 @@
     },
     "node_modules/@walletconnect/qrcode-modal": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.8.0.tgz",
-      "integrity": "sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==",
-      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/mobile-registry": "^1.4.0",
@@ -12783,8 +10922,7 @@
     },
     "node_modules/@walletconnect/randombytes": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.3.tgz",
-      "integrity": "sha512-35lpzxcHFbTN3ABefC9W+uBpNZl1GC4Wpx0ed30gibfO/y9oLdy1NznbV96HARQKSBV9J9M/rrtIvf6a23jfYw==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/environment": "^1.0.1",
@@ -12794,21 +10932,18 @@
     },
     "node_modules/@walletconnect/randombytes/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/relay-api": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
-      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
     },
     "node_modules/@walletconnect/relay-auth": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
-      "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
+      "license": "MIT",
       "dependencies": {
         "@stablelib/ed25519": "^1.0.2",
         "@stablelib/random": "^1.0.1",
@@ -12820,26 +10955,22 @@
     },
     "node_modules/@walletconnect/relay-auth/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/relay-auth/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/safe-json": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
-      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/sign-client": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.3.tgz",
-      "integrity": "sha512-OzOWxRTfVGCHU3OOF6ibPkgPfDpivFJjuknfcOUt9PYWpTAv6YKOmT4cyfBPhc7llruyHpV44fYbykMcLIvEcg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/core": "2.17.3",
         "@walletconnect/events": "1.0.1",
@@ -12854,8 +10985,7 @@
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
-      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -12867,27 +10997,22 @@
     },
     "node_modules/@walletconnect/time": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
-      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/time/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/types": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
-      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==",
-      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/"
+      "license": "Apache-2.0"
     },
     "node_modules/@walletconnect/universal-provider": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.11.0.tgz",
-      "integrity": "sha512-zgJv8jDvIMP4Qse/D9oIRXGdfoNqonsrjPZanQ/CHNe7oXGOBiQND2IIeX+tS0H7uNA0TPvctljCLiIN9nw4eA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -12902,8 +11027,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.0.tgz",
-      "integrity": "sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -12926,8 +11050,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
-      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -12936,8 +11059,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
-      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -12946,8 +11068,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
-      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
+      "license": "MIT",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -12955,8 +11076,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
-      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -12966,17 +11086,14 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.0.tgz",
-      "integrity": "sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==",
-      "deprecated": "Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/core": "2.11.0",
         "@walletconnect/events": "^1.0.1",
@@ -12991,8 +11108,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
-      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -13004,8 +11120,7 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
-      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -13025,16 +11140,14 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -13042,18 +11155,15 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/universal-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/universal-provider/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -13072,8 +11182,7 @@
     },
     "node_modules/@walletconnect/utils": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.3.tgz",
-      "integrity": "sha512-tG77UpZNeLYgeOwViwWnifpyBatkPlpKSSayhN0gcjY1lZAUNqtYslpm4AdTxlrA3pL61MnyybXgWYT5eZjarw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/hash": "5.7.0",
         "@ethersproject/transactions": "5.7.0",
@@ -13099,16 +11208,14 @@
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
-      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
-      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -13120,16 +11227,14 @@
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
-      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
-      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -13137,32 +11242,26 @@
     },
     "node_modules/@walletconnect/utils/node_modules/detect-browser": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
-      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/utils/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/@walletconnect/window-getters": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
-      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
+      "license": "MIT"
     },
     "node_modules/@walletconnect/window-metadata": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
-      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
+      "license": "MIT",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.0"
       }
     },
     "node_modules/@web3modal/core": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.4.3.tgz",
-      "integrity": "sha512-7Z/sDe9RIYQ2k9ITcxgEa/u7FvlI76vcVVZn9UY4ISivefqrH4JAS3GX4JmVNUUlovwuiZdyqBv4llAQOMK6Rg==",
-      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
+      "license": "Apache-2.0",
       "dependencies": {
         "buffer": "6.0.3",
         "valtio": "1.10.5"
@@ -13170,16 +11269,14 @@
     },
     "node_modules/@web3modal/core/node_modules/use-sync-external-store": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@web3modal/core/node_modules/valtio": {
       "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.5.tgz",
-      "integrity": "sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==",
+      "license": "MIT",
       "dependencies": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -13198,9 +11295,7 @@
     },
     "node_modules/@web3modal/standalone": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.4.3.tgz",
-      "integrity": "sha512-5ATXBoa4GGm+TIUSsKWsfWCJunv1XevOizpgTFhqyeGgRDmWhqsz9UIPzH/1mk+g0iJ/xqMKs5F6v9D2QeKxag==",
-      "deprecated": "This package has been deprecated in favor of @walletconnect/modal. Please read more at https://docs.walletconnect.com",
+      "license": "Apache-2.0",
       "dependencies": {
         "@web3modal/core": "2.4.3",
         "@web3modal/ui": "2.4.3"
@@ -13208,9 +11303,7 @@
     },
     "node_modules/@web3modal/ui": {
       "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.4.3.tgz",
-      "integrity": "sha512-J989p8CdtEhI9gZHf/rZ/WFqYlrAHWw9GmAhFoiNODwjAp0BoG/uoaPiijJMchXdngihZOjLGCQwDXU16DHiKg==",
-      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
+      "license": "Apache-2.0",
       "dependencies": {
         "@web3modal/core": "2.4.3",
         "lit": "2.7.5",
@@ -13220,16 +11313,14 @@
     },
     "node_modules/@web3modal/ui/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@web3modal/ui/node_modules/cliui": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -13238,13 +11329,11 @@
     },
     "node_modules/@web3modal/ui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/@web3modal/ui/node_modules/find-up": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -13255,16 +11344,14 @@
     },
     "node_modules/@web3modal/ui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@web3modal/ui/node_modules/lit": {
       "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.5.tgz",
-      "integrity": "sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -13273,8 +11360,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/locate-path": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -13284,8 +11370,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -13298,8 +11383,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/p-locate": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -13309,16 +11393,14 @@
     },
     "node_modules/@web3modal/ui/node_modules/pngjs": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
-      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@web3modal/ui/node_modules/qrcode": {
       "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "license": "MIT",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -13334,8 +11416,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13347,8 +11428,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -13360,8 +11440,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/yargs": {
       "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -13381,8 +11460,7 @@
     },
     "node_modules/@web3modal/ui/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -13393,8 +11471,7 @@
     },
     "node_modules/@wormhole-foundation/sdk": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.3.0-beta.3.tgz",
-      "integrity": "sha512-/xHaMGHNQFKNcqREyx7O0VLEkoSaqAEj76Siu9S5OgphapYfvXbbVxVCjb+3vLUi4LG01nfdMAPoK6vwXvEcSA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-algorand-core": "1.3.0-beta.3",
@@ -13429,8 +11506,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.3.0-beta.3.tgz",
-      "integrity": "sha512-CJrdj++y/n8q+WqdOxpM1/n22yrEIRxbWFmTTvySv2I9sb3OwMiZmN4+9k3sBQJS91xZ703eHtGunsQoyPTHTg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "algosdk": "2.7.0"
@@ -13441,8 +11517,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-ziqbbVjDKRDCnX2sEBbBpEVWx/cAMOpp2jCrsI7JQCSlByFqTl/FaQk+ITKnxmQuZQ2lzJDZbMq8Ql1ZtfkrmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -13453,8 +11528,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-BcZ9Y98yQPFtZSu8s10VEptf4/WNSJJy/bM0nQNiLQgao2TqL+nw+0BCKrnIux7vYzGWMAWyZdsXL4nbyetPrA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-algorand-core": "1.3.0-beta.3",
@@ -13466,8 +11540,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.3.0-beta.3.tgz",
-      "integrity": "sha512-/O1Hk2KOWHXqZ9IN99uPgKCxBtUjFyJkuoVMsjtDcAqABLA0oZhVOuOT33Nf2zui+/B8a99cXYKZV/HFnVzddg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "aptos": "1.21.0"
@@ -13478,8 +11551,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-joagrPoKX7QrCXUP7gnKHZgvleyrsRzEyYo0z/2V4CA3wSJZPXINen7ssbVwYYWt5yRLkHHhBVYfkpdWHd+W1g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -13490,8 +11562,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-/9I5lqd4P212dQIBuST8osbbD+P4o2ae7M307H+6rPWqjT0HJpILQW5BvQTGWeL2sm3DIZBwePBYPfgW13TS0A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -13502,8 +11573,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@noble/hashes": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -13513,16 +11583,14 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/base": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/bip39": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
@@ -13533,9 +11601,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/aptos": {
       "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
-      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
-      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/aptos-client": "^0.1.0",
         "@noble/hashes": "1.3.3",
@@ -13550,13 +11616,11 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/form-data": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -13568,8 +11632,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-base": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0-beta.3.tgz",
-      "integrity": "sha512-5j1DL9enxAEMPBu1UEjjWbT9fmXV+iMAvwv6l8/QEhEFzdUpaWAyBApdixnGsoxvF7wEFYK3+voA6Zc5Eu+j8Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
@@ -13577,8 +11640,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.3.0-beta.3.tgz",
-      "integrity": "sha512-8Metv+O+HzUVAFzY4JfwL/4R5dTmNTmy6q6ZTqo6YkPmm5tCc7XHSXLqhwVwENMqvFVraXvwzTpuqAqOEsA7wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-definitions": "1.3.0-beta.3",
@@ -13590,8 +11652,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.3.0-beta.3.tgz",
-      "integrity": "sha512-LL3vwHjXWzdqXdrBt8+CBfapdpXKejt3OlXUzT+svCxBSYgmz+2U6Q027RcGeMEaaDBDFdX/Du57kZ/NEcYCeA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
@@ -13606,8 +11667,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-dj3x/iXQJBafPd0NnelAkrNS44AJrXe0MqVmWYWVKRJPnEiOOVp2bpAM3T61oYCL1MSChHUlPLq+a+5jNCoQFg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
@@ -13621,8 +11681,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.3.0-beta.3.tgz",
-      "integrity": "sha512-0x6fvSmrKPE2XyHpyux6k5oLc46TzBaAWTsIJom8bAWICwf+ErWRPUjaMFjFnzkzoGpLe6C6CzkdzURqFhb9PA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
@@ -13638,8 +11697,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-Xjcb8q4vlUtrpgcvnK+wBIPEOgJkihUQjUI7rKh1cGw1h2PXRdrZFStJelCNiGD3Hti3PzEXe0+wyc/s+Oi/jg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
@@ -13652,8 +11710,6 @@
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.3.0-beta.3.tgz",
-      "integrity": "sha512-fRdi49L0BBrWgNM1QlA4IS9kSvvMsmiLZFx6AXv6f95CTGVtplxmplTcTRUf9fTiiRBq9AfEWVKiS5vywE686w==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -13662,8 +11718,6 @@
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-0.6.1.tgz",
-      "integrity": "sha512-OVaskp2xFv/y9qloVuTA5xXwDErKBREQkN8mrFYNG9vsI5r/wzItkPt0/RzGBtClT7beWt3ZfLOULzSpi6ktyw==",
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0"
@@ -13671,8 +11725,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.3.0-beta.3.tgz",
-      "integrity": "sha512-I4DS1JXrLvUstjVUn0iZQpqbTrEU3gKmZ5G1W/cXtgNBxcHEBvJW6xl2Y0y1XriXQIQHLyovXArRtq/xVbWxrA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "ethers": "^6.5.1"
@@ -13683,8 +11736,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.3.0-beta.3.tgz",
-      "integrity": "sha512-ChTV5rNkrNE/HTrhJ2KjVXtEWrsxudxf7W4f+LSl09hD67ytOPUnM0rCpsOe8f7dRiMzFnVjsL3JybvhwrfeNA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -13696,8 +11748,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-TXPbpmTEK6wurFCxeq9wQRkWaywl7Kt7fcR6bRuOiktp5rh+8PKlVAFVxG/x/lrtJuCNDiZmzbdgljJjdELhCw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -13709,8 +11760,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-ntt": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-ntt/-/sdk-evm-ntt-0.6.1.tgz",
-      "integrity": "sha512-PT/05wur6iRGfmfy52QQb7NSoNtvhQ31DVtSl19ugYBGHM6rccAs+QstihwyQ1AfX2CNzOoxGschIQ2Q06CD+w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "ethers": "^6.5.1"
@@ -13727,8 +11777,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.3.0-beta.3.tgz",
-      "integrity": "sha512-odATK5hABkkWtvDRMkG3zqwx5EExhyq16cyCHwz8we5yDrDHTyNqxrIoXGwygBmXSz/lzRgwrTwLVp7vanhlXA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -13742,8 +11791,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-PdDeQZXV8Qa8+5UysecTMCCq7SMr0HqjSvf/ZirrcF4v/bbWmgPwbqo+2a5yidCyQFPxEiaawcFLTSWGr4qkgA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -13756,16 +11804,14 @@
     },
     "node_modules/@wormhole-foundation/sdk-icons": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.3.0.tgz",
-      "integrity": "sha512-yz2e8eVhG8+FN3GItiJDmFKjviz3O8hjNZZEsOJXQgy4DoQbvRz3gGSZTrHllQDkEIo7A4liSG2Qf7u1hzyV2Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.3.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons/node_modules/@wormhole-foundation/sdk-base": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0.tgz",
-      "integrity": "sha512-/QpnDN6WBOOZC0mkeEmUWbUv/gLRY5aEl1U1mYXIInglSvIlARzFJtcFhxiuKMOZfufXM81j4G1XsZAWzff6lQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
@@ -13773,8 +11819,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-route-ntt": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-route-ntt/-/sdk-route-ntt-0.6.1.tgz",
-      "integrity": "sha512-nR/m7l9PePz9Dk7kXAosS+ei9SCXK0aqsSvyxm4wNwnxoCNU2OotwkPVmaIbAyr1BkZ1J2ii921sOTTWcInILg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "@wormhole-foundation/sdk-evm-ntt": "0.6.1",
@@ -13789,8 +11834,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.3.0-beta.3.tgz",
-      "integrity": "sha512-/C2k3gl3dRpE6nTjrLgJygCJLWm8j2TIZCskGBa45Txp5NPVk0sLK7S3oDK2wWzIiYBURTSfpFaxrrcFqR+2yQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13805,8 +11849,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.3.0-beta.3.tgz",
-      "integrity": "sha512-ukJ8tyYgSAyYNreim5XfE0Sq6XCJ1l076ycxwoM5/xI2ikD1wuT+fNeoJq3OLvgthvWfATieh/Rzma1HAhIsYQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
@@ -13820,8 +11863,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
-      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -13836,8 +11878,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-B+0L22FUcAxxwO7iBt1aCqD60/Zb2e7GSxVU3Fh1EDrqNkQfqJHkJ96Wy+lH3jwSJR/wgntGacD3FDn2fKl56w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13851,8 +11892,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-ntt": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-0.6.1.tgz",
-      "integrity": "sha512-YSumolkZ9wKGvRLOzB12u+RgAzC4Yg1gzN2dUvdngWLsGeikfnDCGOz5fBqAdM5M5nK3ECHDShw8fnfTqNQaGQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -13873,8 +11913,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-ntt/node_modules/@solana/spl-token": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.0.tgz",
-      "integrity": "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -13890,8 +11929,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-PLekAYlc1DBSO7/f1fGmOTEeHl725chibx+C6Ihy1d5iR1RBwZG9PGbBw9g8fHJISVVvPs6fRPCcHvi5vWwH2w==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
@@ -13906,8 +11944,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
-      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -13922,8 +11959,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
-      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -13938,8 +11974,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.3.0-beta.3.tgz",
-      "integrity": "sha512-ERSu+/f6362GMx9w96D4WDvpf33ObE7SfotEYAHSJom03UXz4zHfCvfFw74G/gnaL9S9X85SJVmXQVquDH/0qA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -13950,8 +11985,7 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.3.0-beta.3.tgz",
-      "integrity": "sha512-8JWsIbScXkI8mYMH4zokHpjs5dtMwRf1MuevZ4cv+8Tr7gQJistPLcWIAsT3S+Edw6VuurflMSLF08G2NM4/nA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -13963,17 +11997,14 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -13994,29 +12025,25 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.3.0-beta.3.tgz",
-      "integrity": "sha512-iAwLWo/gGQtgHmDiobHvyT3XuO6wb+n9xe2c/OKWnmGdVrv90bYbCNgolzY4iFw2Ls6xbTQMkyaqmn7wZ3d97A==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -14028,17 +12055,14 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -14059,29 +12083,25 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.3.0-beta.3.tgz",
-      "integrity": "sha512-CGAc/NPy1Rk6ynpYIBZcP3uAaHpASuVPI21h3+mqbMMAsIzDQ9f3p8VV8bOTRoTQ+YEKgglOqcThZMzGVUGmqA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -14094,17 +12114,14 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -14125,38 +12142,32 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
-      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
-      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
-      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -14177,29 +12188,25 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/base-x": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/bs58": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wry/caches": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
-      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -14209,8 +12216,7 @@
     },
     "node_modules/@wry/context": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
-      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -14220,8 +12226,7 @@
     },
     "node_modules/@wry/equality": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
-      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -14231,8 +12236,7 @@
     },
     "node_modules/@wry/trie": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
-      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -14242,8 +12246,7 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-aptos": {
       "version": "0.0.1-alpha.14",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-aptos/-/wallet-aggregator-aptos-0.0.1-alpha.14.tgz",
-      "integrity": "sha512-GC6ELtC9TQrF48Of1O5O/Hlx9vhxUJu/0LEQynnYpm/McZG9JSOQkJHkXeQZ2I/PCi+Ojw1evKMldUnb7FWY3w==",
+      "license": "MIT",
       "dependencies": {
         "@manahippo/aptos-wallet-adapter": "^1.0.8",
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18"
@@ -14251,21 +12254,18 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-core": {
       "version": "0.0.1-alpha.22",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.22.tgz",
-      "integrity": "sha512-NzFm0nTSH5KR4pxEY8r8b9BdlT8Q95r0YfiEScERqpowWeYYGP/pZA/x+/iEEF2vpAbINLXz+pwcwGT/5r1xhA==",
+      "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
     },
     "node_modules/@xlabs-libs/wallet-aggregator-core/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/@xlabs-libs/wallet-aggregator-evm": {
       "version": "0.0.2-alpha.5",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-evm/-/wallet-aggregator-evm-0.0.2-alpha.5.tgz",
-      "integrity": "sha512-ZWVN9OT5SxHDhtCodMgznJ4jxcPQD4qD4pFySzlNghPBMMLXGCZsXh20WuUnI2MUS/yMvdSBM5PEMnR3MNyH0g==",
+      "license": "MIT",
       "dependencies": {
         "@binance/w3w-ethereum-provider": "1.1.8-alpha.0",
         "@binance/w3w-utils": "^1.1.6",
@@ -14280,8 +12280,7 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-solana": {
       "version": "0.0.1-alpha.16",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-solana/-/wallet-aggregator-solana-0.0.1-alpha.16.tgz",
-      "integrity": "sha512-arZIpogXIk8r5JiDz2ajOGzAfWDO6hspUDSMqGuFs5ld+l078NRjGoZMqX3EzHLAY1sRF6LNb+xuRTtHb/yfzw==",
+      "license": "MIT",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-wallet-adapter-base": "^1.1.1",
@@ -14291,8 +12290,7 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-sui": {
       "version": "0.0.1-alpha.10",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-sui/-/wallet-aggregator-sui-0.0.1-alpha.10.tgz",
-      "integrity": "sha512-AvtN28dZCgjcqQsPbaK5QC+T76AA6npUc10aVLFa3W7Cj4JC2XDJdIju/FDhYcDMVIyNtCAiCnJqQDi/QykB+Q==",
+      "license": "MIT",
       "dependencies": {
         "@kunalabs-io/sui-snap-wallet": "^0.4.2",
         "@mysten/sui.js": "^0.32.2",
@@ -14302,8 +12300,7 @@
     },
     "node_modules/abitype": {
       "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.8.7.tgz",
-      "integrity": "sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.4",
         "zod": "^3 >=3.19.1"
@@ -14316,8 +12313,7 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -14327,8 +12323,7 @@
     },
     "node_modules/acorn": {
       "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14338,18 +12333,16 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -14359,13 +12352,11 @@
     },
     "node_modules/aes-js": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
-      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+      "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
       "dependencies": {
         "debug": "4"
       },
@@ -14375,8 +12366,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
-      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
+      "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -14386,9 +12376,8 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -14402,9 +12391,8 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -14419,9 +12407,8 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14435,22 +12422,19 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/algo-msgpack-with-bigint": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
-      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/algosdk": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
-      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
+      "license": "MIT",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
@@ -14468,15 +12452,13 @@
     },
     "node_modules/alien-signals": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
-      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -14489,16 +12471,14 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -14511,13 +12491,11 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
+      "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -14528,8 +12506,7 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -14539,9 +12516,7 @@
     },
     "node_modules/aptos": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.5.0.tgz",
-      "integrity": "sha512-N7OuRtU7IYHkDkNx+4QS3g/QQGCp+36KzYn3oXPmT7Kttfuv+UKliQVdjy3cLmwd/DCQSh9ObTovwdxnHjUn0g==",
-      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
+      "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "1.1.3",
         "@scure/bip39": "1.1.0",
@@ -14555,33 +12530,30 @@
     },
     "node_modules/aptos/node_modules/@noble/hashes": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/aptos/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/aptos/node_modules/@scure/bip39": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
-      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/aptos/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/aptos/node_modules/@scure/bip39": {
+      "version": "1.1.0",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.1.1",
         "@scure/base": "~1.1.0"
@@ -14589,8 +12561,7 @@
     },
     "node_modules/aptos/node_modules/axios": {
       "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -14598,8 +12569,7 @@
     },
     "node_modules/aptos/node_modules/form-data": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -14611,28 +12581,24 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/array-union": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/asn1.js": {
       "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -14641,13 +12607,11 @@
     },
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/assert": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
-      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.2",
         "is-nan": "^1.3.2",
@@ -14658,38 +12622,33 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
-      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "license": "MIT"
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -14712,8 +12671,7 @@
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -14726,9 +12684,8 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
-      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.6.3",
@@ -14740,9 +12697,8 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
         "core-js-compat": "^3.38.0"
@@ -14753,9 +12709,8 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
-      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -14765,21 +12720,17 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "license": "MIT"
     },
     "node_modules/base-x": {
       "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -14793,20 +12744,19 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/base64url": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/bchaddrjs": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/bchaddrjs/-/bchaddrjs-0.5.2.tgz",
-      "integrity": "sha512-OO7gIn3m7ea4FVx4cT8gdlWQR2+++EquhdpWQJH9BQjK63tJJ6ngB3QMZDO6DiBoXiIGUsTPHjlrHVxPGcGxLQ==",
+      "license": "MIT",
       "dependencies": {
         "bs58check": "2.1.2",
         "buffer": "^6.0.3",
@@ -14819,22 +12769,19 @@
     },
     "node_modules/bech32": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
-      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
+      "license": "MIT"
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
-      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
+      "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.3.0"
       },
@@ -14844,16 +12791,14 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
-      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -14863,48 +12808,41 @@
     },
     "node_modules/binary-layout": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.0.3.tgz",
-      "integrity": "sha512-kpXCSOko4wbQaQswZk4IPcjVZwN77TKZgjMacdoX54EvUHAn/CzJclCt25SUmpXfzFrGovoq3LkPJkMy10bZxQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/binary-parser": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
-      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bip39": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/bip66": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
-      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ=="
+      "license": "MIT"
     },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
-      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
+      "license": "MIT"
     },
     "node_modules/blake-hash": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
-      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2",
@@ -14916,18 +12854,15 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+      "license": "MIT"
     },
     "node_modules/borsh": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -14936,13 +12871,11 @@
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -14950,8 +12883,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -14961,27 +12893,23 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "license": "MIT"
     },
     "node_modules/browser-headers": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
-      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
+      "license": "Apache-2.0"
     },
     "node_modules/browser-resolve": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
-      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "resolve": "^1.17.0"
       }
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+      "license": "MIT",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -14993,8 +12921,7 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+      "license": "MIT",
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -15003,8 +12930,7 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -15014,8 +12940,7 @@
     },
     "node_modules/browserify-rsa": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^5.2.1",
         "randombytes": "^2.1.0",
@@ -15027,8 +12952,7 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
-      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
+      "license": "ISC",
       "dependencies": {
         "bn.js": "^5.2.1",
         "browserify-rsa": "^4.1.0",
@@ -15047,13 +12971,11 @@
     },
     "node_modules/browserify-sign/node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "license": "MIT"
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -15066,41 +12988,34 @@
     },
     "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "license": "MIT"
     },
     "node_modules/browserify-sign/node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "license": "MIT"
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
       }
     },
     "node_modules/browserify-zlib/node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/browserslist": {
       "version": "4.24.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "funding": [
         {
           "type": "opencollective",
@@ -15115,6 +13030,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -15130,16 +13046,14 @@
     },
     "node_modules/bs58": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
       }
     },
     "node_modules/bs58check": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -15148,8 +13062,6 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -15164,6 +13076,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -15171,8 +13084,7 @@
     },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "license": "MIT",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -15180,23 +13092,19 @@
     },
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+      "license": "MIT"
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+      "license": "MIT"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+      "license": "MIT"
     },
     "node_modules/buffer-layout": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
-      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.5"
       }
@@ -15204,8 +13112,6 @@
     "node_modules/buffer-polyfill": {
       "name": "buffer",
       "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "funding": [
         {
@@ -15221,6 +13127,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -15228,14 +13135,12 @@
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
+      "license": "MIT"
     },
     "node_modules/bufferutil": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -15246,31 +13151,27 @@
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cac": {
       "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -15286,8 +13187,7 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -15300,8 +13200,7 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -15317,8 +13216,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -15329,8 +13227,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "get-intrinsic": "^1.2.6"
@@ -15344,16 +13241,14 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -15363,16 +13258,13 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001690",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
-      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -15386,26 +13278,24 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/cashaddrjs": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
-      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
+      "license": "MIT",
       "dependencies": {
         "big-integer": "1.6.36"
       }
     },
     "node_modules/cbor-sync": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cbor-sync/-/cbor-sync-1.0.4.tgz",
-      "integrity": "sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA=="
+      "license": "MIT"
     },
     "node_modules/chai": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -15421,9 +13311,8 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15437,9 +13326,8 @@
     },
     "node_modules/check-error": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -15449,8 +13337,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -15472,8 +13359,7 @@
     },
     "node_modules/cipher-base": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
-      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -15484,22 +13370,19 @@
     },
     "node_modules/citty": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+      "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
       }
     },
     "node_modules/classnames": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -15512,9 +13395,8 @@
     },
     "node_modules/cli-truncate": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
-      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
@@ -15528,8 +13410,7 @@
     },
     "node_modules/clipboardy": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
-      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
+      "license": "MIT",
       "dependencies": {
         "execa": "^8.0.1",
         "is-wsl": "^3.1.0",
@@ -15544,8 +13425,7 @@
     },
     "node_modules/clipboardy/node_modules/execa": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -15566,8 +13446,7 @@
     },
     "node_modules/clipboardy/node_modules/get-stream": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -15577,16 +13456,14 @@
     },
     "node_modules/clipboardy/node_modules/human-signals": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
       }
     },
     "node_modules/clipboardy/node_modules/is-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -15596,8 +13473,7 @@
     },
     "node_modules/clipboardy/node_modules/npm-run-path": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -15610,8 +13486,7 @@
     },
     "node_modules/clipboardy/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -15621,8 +13496,7 @@
     },
     "node_modules/clipboardy/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -15632,8 +13506,7 @@
     },
     "node_modules/cliui": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "license": "ISC",
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -15642,16 +13515,14 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -15661,34 +13532,29 @@
     },
     "node_modules/cliui/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/cliui/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -15700,8 +13566,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -15711,8 +13576,7 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -15724,8 +13588,7 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -15735,16 +13598,14 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -15754,19 +13615,16 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -15776,73 +13634,61 @@
     },
     "node_modules/commander": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
-      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "license": "MIT"
     },
     "node_modules/confbox": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
-      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
-      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
+      "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
-      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/cookie-es": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
-      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
+      "license": "MIT"
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-js-compat": {
       "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
-      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.24.2"
       },
@@ -15853,13 +13699,11 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -15873,21 +13717,18 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
-      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/crc": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.1.0"
       }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -15897,8 +13738,6 @@
     },
     "node_modules/crc/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -15913,6 +13752,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -15920,8 +13760,7 @@
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -15929,13 +13768,11 @@
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -15946,8 +13783,7 @@
     },
     "node_modules/create-hmac": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -15959,22 +13795,19 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -15986,16 +13819,14 @@
     },
     "node_modules/crossws": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.1.tgz",
-      "integrity": "sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==",
+      "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
+      "license": "MIT",
       "dependencies": {
         "browserify-cipher": "^1.0.1",
         "browserify-sign": "^4.2.3",
@@ -16019,8 +13850,7 @@
     },
     "node_modules/crypto-hash": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
-      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -16030,13 +13860,11 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -16046,25 +13874,21 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "license": "MIT"
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
-      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debounce": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
-      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -16079,29 +13903,25 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
+      "license": "MIT"
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -16114,8 +13934,7 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16125,9 +13944,8 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -16137,22 +13955,19 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -16167,17 +13982,15 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -16192,13 +14005,11 @@
     },
     "node_modules/defu": {
       "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+      "license": "MIT"
     },
     "node_modules/delay": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
-      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16208,16 +14019,14 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/des.js": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -16225,18 +14034,15 @@
     },
     "node_modules/destr": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
-      "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
+      "license": "MIT"
     },
     "node_modules/detect-browser": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
-      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -16246,22 +14052,19 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
+      "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
-      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -16270,19 +14073,16 @@
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
-      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
+      "license": "MIT"
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -16292,14 +14092,12 @@
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -16309,8 +14107,7 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -16318,9 +14115,8 @@
     },
     "node_modules/domain-browser": {
       "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
-      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16330,8 +14126,7 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "license": "MIT",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -16339,8 +14134,7 @@
     },
     "node_modules/draggabilly": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/draggabilly/-/draggabilly-3.0.0.tgz",
-      "integrity": "sha512-aEs+B6prbMZQMxc9lgTpCBfyCUhRur/VFucHhIOvlvvdARTj7TcDmX/cdOUtqbjJJUh7+agyJXR5Z6IFe1MxwQ==",
+      "license": "MIT",
       "dependencies": {
         "get-size": "^3.0.0",
         "unidragger": "^3.0.0"
@@ -16348,8 +14142,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -16361,14 +14154,12 @@
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
-      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -16378,27 +14169,22 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+      "license": "MIT"
     },
     "node_modules/eip1193-provider": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
-      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "@json-rpc-tools/provider": "^1.5.5"
       }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.74",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
-      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw=="
+      "license": "ISC"
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -16411,31 +14197,26 @@
     },
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "license": "MIT"
     },
     "node_modules/encode-utf8": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
-      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
+      "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/engine.io-client": {
       "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.2.tgz",
-      "integrity": "sha512-TAr+NKeoVTjEVW8P3iHguO1LO6RlUz9O5Y8o7EY0fU+gY1NYqas7NN3slpFtbXEsLMHk0h90fJMfKjRkQ0qUIw==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
@@ -16446,8 +14227,7 @@
     },
     "node_modules/engine.io-client/node_modules/debug": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -16462,8 +14242,7 @@
     },
     "node_modules/engine.io-client/node_modules/ws": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -16482,17 +14261,15 @@
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
-      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -16502,9 +14279,8 @@
     },
     "node_modules/env-cmd": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
-      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^4.0.0",
         "cross-spawn": "^7.0.0"
@@ -16518,41 +14294,36 @@
     },
     "node_modules/env-cmd/node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -16562,23 +14333,20 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+      "license": "MIT"
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -16613,16 +14381,14 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16632,10 +14398,8 @@
     },
     "node_modules/eslint": {
       "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -16688,9 +14452,8 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
-      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -16700,9 +14463,8 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
-      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16712,9 +14474,8 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -16725,9 +14486,8 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -16737,9 +14497,8 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -16753,18 +14512,16 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -16774,9 +14531,8 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -16789,9 +14545,8 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -16801,9 +14556,8 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -16818,9 +14572,8 @@
     },
     "node_modules/esquery": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -16830,18 +14583,16 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -16851,41 +14602,36 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/eth-block-tracker": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-7.1.0.tgz",
-      "integrity": "sha512-8YdplnuE1IK4xfqpf4iU7oBxnOYAc35934o083G8ao+8WM8QQtt/mVlAY6yIAdY1eMeLqg4Z//PZjJGmWGPMRg==",
+      "license": "MIT",
       "dependencies": {
         "@metamask/eth-json-rpc-provider": "^1.0.0",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -16899,8 +14645,7 @@
     },
     "node_modules/eth-block-tracker/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
-      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -16908,8 +14653,7 @@
     },
     "node_modules/eth-block-tracker/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
-      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -16922,8 +14666,7 @@
     },
     "node_modules/eth-block-tracker/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
-      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
+      "license": "ISC",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -16937,8 +14680,7 @@
     },
     "node_modules/eth-block-tracker/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -16948,16 +14690,14 @@
     },
     "node_modules/eth-block-tracker/node_modules/superstruct": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/eth-json-rpc-filters": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-6.0.1.tgz",
-      "integrity": "sha512-ITJTvqoCw6OVMLs7pI8f4gG92n/St6x80ACtHodeS+IXmO0w+t1T5OOzfSt7KLSMLRkVUoexV7tztLgDxg+iig==",
+      "license": "ISC",
       "dependencies": {
         "@metamask/safe-event-emitter": "^3.0.0",
         "async-mutex": "^0.2.6",
@@ -16971,16 +14711,14 @@
     },
     "node_modules/eth-json-rpc-filters/node_modules/async-mutex": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.6.tgz",
-      "integrity": "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       }
     },
     "node_modules/eth-json-rpc-filters/node_modules/pify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16990,8 +14728,7 @@
     },
     "node_modules/eth-query": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
-      "integrity": "sha512-srES0ZcvwkR/wd5OQBRA1bIJMww1skfGS0s8wlwK3/oNP4+wnds60krvu5R1QbpRQjMmpG5OMIWro5s7gvDPsA==",
+      "license": "ISC",
       "dependencies": {
         "json-rpc-random-id": "^1.0.0",
         "xtend": "^4.0.1"
@@ -16999,16 +14736,14 @@
     },
     "node_modules/eth-rpc-errors": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
-      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
+      "license": "MIT",
       "dependencies": {
         "fast-safe-stringify": "^2.0.6"
       }
     },
     "node_modules/ethereum-cryptography": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
@@ -17018,8 +14753,7 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -17029,8 +14763,7 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -17040,16 +14773,14 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/base": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip32": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.4.0",
         "@noble/hashes": "~1.4.0",
@@ -17061,8 +14792,7 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip39": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
@@ -17073,9 +14803,7 @@
     },
     "node_modules/ethereumjs-abi": {
       "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "deprecated": "This library has been deprecated and usage is discouraged.",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -17083,21 +14811,18 @@
     },
     "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
       "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/ethereumjs-abi/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -17118,8 +14843,7 @@
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -17132,8 +14856,7 @@
     },
     "node_modules/ethereumjs-util": {
       "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -17147,8 +14870,7 @@
     },
     "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -17169,8 +14891,6 @@
     },
     "node_modules/ethers": {
       "version": "6.13.4",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
-      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
       "funding": [
         {
           "type": "individual",
@@ -17181,6 +14901,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -17196,8 +14917,7 @@
     },
     "node_modules/ethers/node_modules/@noble/curves": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -17207,8 +14927,7 @@
     },
     "node_modules/ethers/node_modules/@noble/hashes": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -17218,26 +14937,22 @@
     },
     "node_modules/ethers/node_modules/@types/node": {
       "version": "22.7.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
-      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/ethers/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
-      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
+      "license": "MIT"
     },
     "node_modules/ethers/node_modules/tslib": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "license": "0BSD"
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -17256,8 +14971,7 @@
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -17269,34 +14983,29 @@
     },
     "node_modules/ev-emitter": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-2.1.2.tgz",
-      "integrity": "sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q=="
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+      "license": "MIT",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -17304,9 +15013,8 @@
     },
     "node_modules/execa": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
-      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -17327,9 +15035,8 @@
     },
     "node_modules/execa/node_modules/is-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -17339,9 +15046,8 @@
     },
     "node_modules/execa/node_modules/npm-run-path": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -17354,9 +15060,8 @@
     },
     "node_modules/execa/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -17366,13 +15071,11 @@
     },
     "node_modules/exenv": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/extension-port-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-3.0.0.tgz",
-      "integrity": "sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw==",
+      "license": "ISC",
       "dependencies": {
         "readable-stream": "^3.6.2 || ^4.4.2",
         "webextension-polyfill": ">=0.10.0 <1.0"
@@ -17383,21 +15086,17 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "engines": {
         "node": "> 0.1.90"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -17411,59 +15110,50 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
+      "license": "MIT"
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
+      "license": "MIT"
     },
     "node_modules/fast-uri": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
-      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
       "peer": true
     },
     "node_modules/fastq": {
       "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -17473,13 +15163,11 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -17489,22 +15177,19 @@
     },
     "node_modules/filter-obj": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -17518,9 +15203,8 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -17532,20 +15216,18 @@
     },
     "node_modules/flatted": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -17557,16 +15239,14 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
       }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
-      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
+      "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -17580,8 +15260,7 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -17591,8 +15270,7 @@
     },
     "node_modules/form-data": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -17604,9 +15282,8 @@
     },
     "node_modules/fs-extra": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -17618,34 +15295,18 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -17653,25 +15314,22 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
-      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "dunder-proto": "^1.0.0",
@@ -17693,19 +15351,16 @@
     },
     "node_modules/get-port-please": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
-      "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
+      "license": "MIT"
     },
     "node_modules/get-size": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-size/-/get-size-3.0.0.tgz",
-      "integrity": "sha512-Y8aiXLq4leR7807UY0yuKEwif5s3kbVp1nTv+i4jBeoUzByTLKkLWu/HorS6/pB+7gsB0o7OTogC8AoOOeT0Hw=="
+      "license": "MIT"
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -17715,9 +15370,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17735,8 +15388,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -17746,16 +15398,14 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -17769,9 +15419,8 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -17789,13 +15438,11 @@
     },
     "node_modules/google-protobuf": {
       "version": "3.21.4",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
-      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
+      "license": "(BSD-3-Clause AND Apache-2.0)"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -17805,8 +15452,7 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -17829,8 +15475,7 @@
     },
     "node_modules/gql.tada": {
       "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
-      "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
+      "license": "MIT",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
@@ -17847,28 +15492,24 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
-      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
-      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -17881,9 +15522,8 @@
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
-      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "duplexer": "^0.1.2"
       },
@@ -17896,8 +15536,7 @@
     },
     "node_modules/h3": {
       "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.0.tgz",
-      "integrity": "sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==",
+      "license": "MIT",
       "dependencies": {
         "cookie-es": "^1.2.2",
         "crossws": ">=0.2.0 <0.4.0",
@@ -17913,17 +15552,15 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -17933,8 +15570,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -17944,8 +15580,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -17958,8 +15593,7 @@
     },
     "node_modules/hash-base": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -17970,8 +15604,7 @@
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -17979,8 +15612,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -17990,27 +15622,23 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
+      "license": "MIT"
     },
     "node_modules/hi-base32": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
-      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
+      "license": "MIT"
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "license": "MIT",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -18019,32 +15647,27 @@
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
       }
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
-      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/http-shutdown": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
-      "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -18052,13 +15675,11 @@
     },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -18069,14 +15690,12 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -18087,26 +15706,23 @@
     },
     "node_modules/human-signals": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
-      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
       }
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
       "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -18119,13 +15735,10 @@
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
-      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -18139,21 +15752,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/immer": {
       "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -18161,8 +15773,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -18176,9 +15787,8 @@
     },
     "node_modules/import-from-esm": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
-      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
@@ -18189,18 +15799,16 @@
     },
     "node_modules/import-lazy": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
-      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -18208,18 +15816,15 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -18227,31 +15832,26 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "license": "ISC"
     },
     "node_modules/injectpromise": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/injectpromise/-/injectpromise-1.0.0.tgz",
-      "integrity": "sha512-qNq5wy4qX4uWHcVFOEU+RqZkoVG65FhvGkyDWbuBxILMjK6A1LFf5A1mgXZkD4nRx5FCorD81X/XvPKp/zVfPA=="
+      "license": "MIT"
     },
     "node_modules/int64-buffer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
-      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="
+      "license": "MIT"
     },
     "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -18262,16 +15862,14 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
-      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -18285,13 +15883,11 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -18301,8 +15897,7 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -18312,8 +15907,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
-      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
+      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -18326,8 +15920,7 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -18340,17 +15933,15 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -18360,8 +15951,7 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "license": "MIT",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -18374,8 +15964,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -18385,8 +15974,7 @@
     },
     "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -18394,8 +15982,7 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -18411,8 +15998,7 @@
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
-      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -18426,25 +16012,22 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -18454,8 +16037,7 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -18468,13 +16050,11 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "license": "MIT"
     },
     "node_modules/is-wsl": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
-      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -18487,8 +16067,7 @@
     },
     "node_modules/is64bit": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
-      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
+      "license": "MIT",
       "dependencies": {
         "system-architecture": "^0.1.0"
       },
@@ -18501,18 +16080,15 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+      "license": "ISC"
     },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -18520,17 +16096,15 @@
     },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
-      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/isomorphic-unfetch": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -18538,30 +16112,27 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/isows": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -18574,8 +16145,7 @@
     },
     "node_modules/jayson": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
-      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -18599,18 +16169,15 @@
     },
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+      "license": "MIT"
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "license": "MIT"
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -18629,48 +16196,40 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
       }
     },
     "node_modules/jju": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-base64": {
       "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
-      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "license": "MIT"
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+      "license": "MIT"
     },
     "node_modules/js-sha512": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
-      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -18680,26 +16239,22 @@
     },
     "node_modules/jsbi": {
       "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
-      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+      "license": "MIT"
     },
     "node_modules/jscrypto": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.3.tgz",
-      "integrity": "sha512-lryZl0flhodv4SZHOqyb1bx5sKcJxj0VBo0Kzb4QMAg3L021IC9uGpl0RCZa+9KJwlRGSK2C80ITcwbe19OKLQ==",
+      "license": "MIT",
       "bin": {
         "jscrypto": "bin/cli.js"
       }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -18709,26 +16264,22 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "license": "MIT"
     },
     "node_modules/json-rpc-engine": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
-      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
+      "license": "ISC",
       "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "eth-rpc-errors": "^4.0.2"
@@ -18739,13 +16290,11 @@
     },
     "node_modules/json-rpc-engine/node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
-      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
+      "license": "ISC"
     },
     "node_modules/json-rpc-protocol": {
       "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/json-rpc-protocol/-/json-rpc-protocol-0.13.2.tgz",
-      "integrity": "sha512-2InSi+c7wGESmvYcEVS0clctpJCodV7gLqLN1BIIPNK07wokXIwhOL8RQWU4O7oX5adChn6HJGtIU6JaUQ1P/A==",
+      "license": "ISC",
       "dependencies": {
         "make-error": "^1.3.0"
       },
@@ -18755,19 +16304,16 @@
     },
     "node_modules/json-rpc-random-id": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
-      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="
+      "license": "ISC"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.0.tgz",
-      "integrity": "sha512-ex8jk9BZHBolvbd5cRnAgwyaYcYB0qZldy1e+LCOdcF6+AUmVZ6LcGUMzsRTW83QMeu+GxZGrcLqxqrgfXGvIw==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -18784,19 +16330,16 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -18807,9 +16350,8 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -18819,32 +16361,28 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "engines": [
         "node >= 0.2.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/jsonschema": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
-      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -18858,14 +16396,12 @@
     },
     "node_modules/jsqr": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
-      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="
+      "license": "Apache-2.0"
     },
     "node_modules/keccak": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
-      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -18877,13 +16413,11 @@
     },
     "node_modules/keccak/node_modules/node-addon-api": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
-      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+      "license": "MIT"
     },
     "node_modules/keccak256": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.6.tgz",
-      "integrity": "sha512-8GLiM01PkdJVGUhR1e6M/AvWnSqYS0HaERI+K/QtStGDGlSTx2B1zTqZk4Zlqu5TxHJNTxWAdP9Y+WI50OApUw==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -18892,28 +16426,24 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
     },
     "node_modules/keyvaluestorage-interface": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
-      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
+      "license": "MIT"
     },
     "node_modules/kolorist": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
-      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -18924,36 +16454,31 @@
     },
     "node_modules/libsodium-sumo": {
       "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.15.tgz",
-      "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw=="
+      "license": "ISC"
     },
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.15",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.15.tgz",
-      "integrity": "sha512-aSWY8wKDZh5TC7rMvEdTHoyppVq/1dTSAeAR7H6pzd6QRT3vQWcT5pGwCotLcpPEOLXX6VvqihSPkpEhYAjANA==",
+      "license": "ISC",
       "dependencies": {
         "libsodium-sumo": "^0.7.15"
       }
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+      "license": "MIT"
     },
     "node_modules/lint-staged": {
       "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.3.0.tgz",
-      "integrity": "sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "5.3.0",
         "commander": "11.0.0",
@@ -18978,9 +16503,8 @@
     },
     "node_modules/lint-staged/node_modules/chalk": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -18990,18 +16514,16 @@
     },
     "node_modules/lint-staged/node_modules/commander": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
-      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/lint-staged/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -19016,9 +16538,8 @@
     },
     "node_modules/lint-staged/node_modules/micromatch": {
       "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -19029,15 +16550,13 @@
     },
     "node_modules/lint-staged/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lint-staged/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -19047,17 +16566,15 @@
     },
     "node_modules/lint-staged/node_modules/yaml": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/listhen": {
       "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
-      "integrity": "sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==",
+      "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "@parcel/watcher-wasm": "^2.4.1",
@@ -19085,17 +16602,15 @@
     },
     "node_modules/listhen/node_modules/jiti": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/listr2": {
       "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
-      "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cli-truncate": "^3.1.0",
         "colorette": "^2.0.20",
@@ -19118,14 +16633,12 @@
     },
     "node_modules/listr2/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lit": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -19134,8 +16647,7 @@
     },
     "node_modules/lit-element": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
@@ -19144,17 +16656,15 @@
     },
     "node_modules/lit-html": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
-      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.3",
         "pkg-types": "^1.2.1"
@@ -19168,9 +16678,8 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -19183,35 +16692,29 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+      "license": "MIT"
     },
     "node_modules/log-update": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
-      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -19228,9 +16731,8 @@
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^1.0.2"
       },
@@ -19243,9 +16745,8 @@
     },
     "node_modules/log-update/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -19255,9 +16756,8 @@
     },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -19270,9 +16770,8 @@
     },
     "node_modules/log-update/node_modules/type-fest": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -19282,8 +16781,7 @@
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
-      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -19294,13 +16792,11 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -19310,63 +16806,55 @@
     },
     "node_modules/loupe": {
       "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
       }
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+      "license": "ISC"
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -19376,8 +16864,7 @@
     },
     "node_modules/material-ui-popup-state": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.3.3.tgz",
-      "integrity": "sha512-eaoA4y965neZw1/iPYZ7haCGO369m5QXJT35e0RStzHd4lgrd6PC+UYkYTIRGTrNt+8Vbx8qtYUFDzRjjAGwnw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@types/prop-types": "^15.7.3",
@@ -19400,16 +16887,14 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -19418,26 +16903,22 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micro-ftch": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
-      "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg=="
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -19448,8 +16929,7 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -19459,8 +16939,7 @@
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -19471,13 +16950,11 @@
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -19487,16 +16964,14 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -19506,8 +16981,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
-      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -19517,26 +16991,22 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "license": "ISC"
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -19546,29 +17016,25 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
-      "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.14.0",
         "pathe": "^1.1.2",
@@ -19578,8 +17044,7 @@
     },
     "node_modules/motion": {
       "version": "10.16.2",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
-      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
+      "license": "MIT",
       "dependencies": {
         "@motionone/animation": "^10.15.1",
         "@motionone/dom": "^10.16.2",
@@ -19591,22 +17056,19 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
-      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "license": "MIT"
     },
     "node_modules/msafe-wallet": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/msafe-wallet/-/msafe-wallet-2.1.5.tgz",
-      "integrity": "sha512-azUF0o96WTYh6jJCwVG9FQ4erRlScvEn0z5+l7WNCbqP9oPKUCR2ySttDjaMa0cO06wz5huk3bW59ND7swiH6Q==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3",
         "json-rpc-protocol": "^0.13.2"
@@ -19614,19 +17076,16 @@
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
-      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/multiformats": {
       "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -19635,19 +17094,17 @@
     },
     "node_modules/nan": {
       "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -19657,20 +17114,17 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
-      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "license": "MIT",
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -19678,13 +17132,11 @@
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
+      "license": "MIT"
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -19702,21 +17154,18 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
-      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
+      "license": "MIT"
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -19725,14 +17174,12 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
+      "license": "MIT"
     },
     "node_modules/node-stdlib-browser": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.0.tgz",
-      "integrity": "sha512-g/koYzOr9Fb1Jc+tHUHlFd5gODjGn48tHexUK8q6iqOVriEgSnd3/1T7myBYc+0KBVze/7F7n65ec9rW6OD7xw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert": "^2.0.0",
         "browser-resolve": "^2.0.0",
@@ -19768,8 +17215,6 @@
     },
     "node_modules/node-stdlib-browser/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -19785,6 +17230,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -19792,16 +17238,14 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -19811,9 +17255,8 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -19823,25 +17266,22 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -19851,8 +17291,7 @@
     },
     "node_modules/object-is": {
       "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -19866,16 +17305,14 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -19893,13 +17330,11 @@
     },
     "node_modules/oblivious-set": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
-      "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
+      "license": "MIT"
     },
     "node_modules/ofetch": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
-      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+      "license": "MIT",
       "dependencies": {
         "destr": "^2.0.3",
         "node-fetch-native": "^1.6.4",
@@ -19908,26 +17343,22 @@
     },
     "node_modules/ohash": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
-      "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
+      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/onetime": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
-      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -19940,9 +17371,8 @@
     },
     "node_modules/open": {
       "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -19957,9 +17387,8 @@
     },
     "node_modules/open/node_modules/is-docker": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -19972,9 +17401,8 @@
     },
     "node_modules/open/node_modules/is-wsl": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -19984,17 +17412,15 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
+      "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optimism": {
       "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
-      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
+      "license": "MIT",
       "dependencies": {
         "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.0",
@@ -20004,9 +17430,8 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -20021,20 +17446,18 @@
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ox": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
-      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
         "@noble/curves": "^1.6.0",
@@ -20055,8 +17478,7 @@
     },
     "node_modules/ox/node_modules/abitype": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
-      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -20075,22 +17497,19 @@
     },
     "node_modules/ox/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+      "license": "MIT"
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -20103,9 +17522,8 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -20118,26 +17536,22 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -20147,8 +17561,7 @@
     },
     "node_modules/parse-asn1": {
       "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
-      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
+      "license": "ISC",
       "dependencies": {
         "asn1.js": "^4.10.1",
         "browserify-aes": "^1.2.0",
@@ -20163,8 +17576,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -20180,43 +17592,37 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -20230,35 +17636,30 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "license": "ISC"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pathe": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
+      "license": "MIT"
     },
     "node_modules/pathval": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "license": "MIT",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -20272,14 +17673,12 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -20289,9 +17688,8 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
       },
@@ -20301,16 +17699,14 @@
     },
     "node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/pino": {
       "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.0.0",
@@ -20330,8 +17726,7 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "license": "MIT",
       "dependencies": {
         "duplexify": "^4.1.2",
         "split2": "^4.0.0"
@@ -20339,22 +17734,19 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
+      "license": "MIT"
     },
     "node_modules/pirates": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "find-up": "^5.0.0"
       },
@@ -20364,8 +17756,7 @@
     },
     "node_modules/pkg-types": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
-      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
+      "license": "MIT",
       "dependencies": {
         "confbox": "^0.1.8",
         "mlly": "^1.7.2",
@@ -20374,32 +17765,27 @@
     },
     "node_modules/pngjs": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
-      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/pony-cause": {
       "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-2.1.11.tgz",
-      "integrity": "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==",
+      "license": "0BSD",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
       "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -20414,6 +17800,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -20425,8 +17812,7 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -20441,8 +17827,7 @@
     },
     "node_modules/postcss-js": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
+      "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -20459,8 +17844,6 @@
     },
     "node_modules/postcss-load-config": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -20471,6 +17854,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "lilconfig": "^3.0.0",
         "yaml": "^2.3.4"
@@ -20493,8 +17877,7 @@
     },
     "node_modules/postcss-load-config/node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -20504,8 +17887,7 @@
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -20515,8 +17897,6 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -20527,6 +17907,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.1.1"
       },
@@ -20539,8 +17920,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -20551,13 +17931,11 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+      "license": "MIT"
     },
     "node_modules/preact": {
       "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
-      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -20565,18 +17943,16 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
       "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -20589,9 +17965,8 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -20603,9 +17978,8 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -20615,32 +17989,27 @@
     },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "license": "MIT"
     },
     "node_modules/process-warning": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -20649,14 +18018,12 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "license": "MIT"
     },
     "node_modules/protobufjs": {
       "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -20677,23 +18044,19 @@
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+      "license": "Apache-2.0"
     },
     "node_modules/proxy-compare": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
-      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "license": "MIT"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+      "license": "MIT",
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -20705,13 +18068,11 @@
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -20719,27 +18080,23 @@
     },
     "node_modules/punycode": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pushdata-bitcoin": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
-      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
+      "license": "MIT",
       "dependencies": {
         "bitcoin-ops": "^1.3.0"
       }
     },
     "node_modules/qr.js": {
       "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
+      "license": "MIT"
     },
     "node_modules/qrcode": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
-      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.4.3",
         "buffer-alloc": "^1.2.0",
@@ -20758,16 +18115,13 @@
     },
     "node_modules/qrcode.react": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
-      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/qrcode/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -20782,6 +18136,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -20789,9 +18144,8 @@
     },
     "node_modules/qs": {
       "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -20804,8 +18158,7 @@
     },
     "node_modules/query-string": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
+      "license": "MIT",
       "dependencies": {
         "decode-uri-component": "^0.2.2",
         "filter-obj": "^1.1.0",
@@ -20821,16 +18174,12 @@
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
       "engines": {
         "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -20844,17 +18193,16 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+      "license": "MIT"
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -20864,21 +18212,18 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
-      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+      "license": "MIT",
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -20886,8 +18231,7 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -20897,8 +18241,7 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -20909,8 +18252,7 @@
     },
     "node_modules/react-infinite-scroller": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
-      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
+      "license": "MIT",
       "dependencies": {
         "prop-types": "^15.5.8"
       },
@@ -20920,18 +18262,15 @@
     },
     "node_modules/react-is": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
-      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
+      "license": "MIT"
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+      "license": "MIT"
     },
     "node_modules/react-modal": {
       "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
-      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -20945,8 +18284,7 @@
     },
     "node_modules/react-redux": {
       "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
-      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -20983,21 +18321,18 @@
     },
     "node_modules/react-redux/node_modules/react-is": {
       "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
+      "license": "MIT"
     },
     "node_modules/react-timer-hook": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.8.tgz",
-      "integrity": "sha512-bi2e7DhPBU1MRPU4ZHaVqBmgM9e2HK0ae8O2AIqwqjcPo4/qR7lVGQonOQLAKOZPQCJSYfV8F5aBWzOLXElzqQ==",
+      "license": "ISC",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -21011,24 +18346,21 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
       }
     },
     "node_modules/read-cache/node_modules/pify": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -21040,8 +18372,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -21051,8 +18382,7 @@
     },
     "node_modules/readdirp/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -21062,21 +18392,17 @@
     },
     "node_modules/readonly-date": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
-      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
+      "license": "Apache-2.0"
     },
     "node_modules/real-require": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -21086,31 +18412,27 @@
     },
     "node_modules/redux": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
-      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
+      "license": "MIT",
       "peerDependencies": {
         "redux": "^4"
       }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
-      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -21120,23 +18442,20 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
-      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
     },
     "node_modules/regexpu-core": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
-      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -21151,15 +18470,13 @@
     },
     "node_modules/regjsgen": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
-      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -21169,9 +18486,8 @@
     },
     "node_modules/regjsparser/node_modules/jsesc": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -21181,8 +18497,7 @@
     },
     "node_modules/rehackt": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "*"
@@ -21198,35 +18513,30 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+      "license": "ISC"
     },
     "node_modules/reselect": {
       "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
-      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.9",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.9.tgz",
-      "integrity": "sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==",
+      "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -21241,29 +18551,25 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/response-iterator": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
-      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -21273,9 +18579,8 @@
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -21289,18 +18594,16 @@
     },
     "node_modules/restore-cursor/node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -21313,8 +18616,7 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -21322,16 +18624,13 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -21344,8 +18643,7 @@
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "license": "MIT",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -21353,8 +18651,7 @@
     },
     "node_modules/ripple-address-codec": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.3.1.tgz",
-      "integrity": "sha512-Qa3+9wKVvpL/xYtT6+wANsn0A1QcC5CT6IMZbRJZ/1lGt7gmwIfsrCuz1X0+LCEO7zgb+3UT1I1dc0k/5dwKQQ==",
+      "license": "ISC",
       "dependencies": {
         "base-x": "^3.0.9",
         "create-hash": "^1.1.2"
@@ -21365,8 +18662,7 @@
     },
     "node_modules/ripple-binary-codec": {
       "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.11.0.tgz",
-      "integrity": "sha512-g7+gs3T+NfoeW6vIq5dcN0CkIT4t/zwRzFxz8X2RzfbrWRnewPUKqQbmBgs05tXLX5NuWPaneiaAVpFpYBcdfw==",
+      "license": "ISC",
       "dependencies": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
@@ -21381,16 +18677,14 @@
     },
     "node_modules/ripple-binary-codec/node_modules/big-integer": {
       "version": "1.6.52",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
-      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/ripple-keypairs": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.3.1.tgz",
-      "integrity": "sha512-dmPlraWKJciFJxHcoubDahGnoIalG5e/BtV6HNDUs7wLXmtnLMHt6w4ed9R8MTL2zNrVPiIdI/HCtMMo0Tm7JQ==",
+      "license": "ISC",
       "dependencies": {
         "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
@@ -21404,9 +18698,7 @@
     },
     "node_modules/ripple-lib": {
       "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.1.tgz",
-      "integrity": "sha512-OQk+Syl2JfxKxV2KuF/kBMtnh012I5tNnziP3G4WDGCGSIAgeqkOgkR59IQ0YDNrs1YW8GbApxrdMSRi/QClcA==",
-      "deprecated": "ripple-lib is deprecated. Please migrate to xrpl.js using this migration guide: https://xrpl.org/xrpljs2-migration-guide.html",
+      "license": "ISC",
       "dependencies": {
         "@types/lodash": "^4.14.136",
         "@types/ws": "^7.2.0",
@@ -21427,8 +18719,7 @@
     },
     "node_modules/ripple-lib-transactionparser": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.8.2.tgz",
-      "integrity": "sha512-1teosQLjYHLyOQrKUQfYyMjDR3MAq/Ga+MJuLUfpBMypl4LZB4bEoMcmG99/+WVTEiZOezJmH9iCSvm/MyxD+g==",
+      "license": "ISC",
       "dependencies": {
         "bignumber.js": "^9.0.0",
         "lodash": "^4.17.15"
@@ -21436,8 +18727,7 @@
     },
     "node_modules/ripple-lib/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21456,8 +18746,7 @@
     },
     "node_modules/rlp": {
       "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
+      "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -21467,9 +18756,8 @@
     },
     "node_modules/rollup": {
       "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
-      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -21505,9 +18793,8 @@
     },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
-      "integrity": "sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "open": "^8.4.0",
         "picomatch": "^2.3.1",
@@ -21531,9 +18818,8 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -21545,24 +18831,21 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup-plugin-visualizer/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -21572,18 +18855,16 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
       "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -21595,9 +18876,8 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -21612,18 +18892,16 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -21639,17 +18917,15 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/rpc-websockets": {
       "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
-      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
+      "license": "LGPL-3.0-only",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "uuid": "^8.3.2",
@@ -21666,8 +18942,7 @@
     },
     "node_modules/rtcpeerconnection-shim": {
       "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
-      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "sdp": "^2.6.0"
       },
@@ -21678,8 +18953,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -21694,14 +18967,14 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -21711,13 +18984,10 @@
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "license": "0BSD"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -21731,25 +19001,23 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-json-utils": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
-      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
+      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
-      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/salmon-adapter-sdk": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/salmon-adapter-sdk/-/salmon-adapter-sdk-1.1.1.tgz",
-      "integrity": "sha512-28ysSzmDjx2AbotxSggqdclh9MCwlPJUldKkCph48oS5Xtwu0QOg8T9ZRHS2Mben4Y8sTq6VvxXznKssCYFBJA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@project-serum/sol-wallet-adapter": "^0.2.6",
         "eventemitter3": "^4.0.7"
@@ -21760,27 +19028,23 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
-      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+      "license": "MIT"
     },
     "node_modules/sdp": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
-      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
+      "license": "MIT"
     },
     "node_modules/secp256k1": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
-      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "elliptic": "^6.5.7",
         "node-addon-api": "^5.0.0",
@@ -21792,26 +19056,22 @@
     },
     "node_modules/secp256k1/node_modules/node-addon-api": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -21826,13 +19086,11 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+      "license": "MIT"
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -21843,16 +19101,14 @@
     },
     "node_modules/sha3": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
-      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
+      "license": "MIT",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -21862,16 +19118,14 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -21886,8 +19140,7 @@
     },
     "node_modules/shx": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
-      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -21901,9 +19154,8 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -21920,9 +19172,8 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -21936,9 +19187,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -21954,9 +19204,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -21973,21 +19222,18 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
-      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sirv": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
-      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
         "mrmime": "^2.0.0",
@@ -21999,18 +19245,16 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.0.0",
         "is-fullwidth-code-point": "^4.0.0"
@@ -22024,9 +19268,8 @@
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -22036,8 +19279,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -22045,8 +19287,7 @@
     },
     "node_modules/snake-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
-      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+      "license": "MIT",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -22054,8 +19295,7 @@
     },
     "node_modules/snakecase-keys": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.5.0.tgz",
-      "integrity": "sha512-r3kRtnoPu3FxGJ3fny6PKNnU3pteb29o6qAa0ugzhSseKNWRkw1dw8nIjXMyyKaU9vQxxVIE62Mb3bKbdrgpiw==",
+      "license": "MIT",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
@@ -22067,8 +19307,7 @@
     },
     "node_modules/snakecase-keys/node_modules/type-fest": {
       "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
-      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=14.16"
       },
@@ -22078,8 +19317,7 @@
     },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
-      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -22092,8 +19330,7 @@
     },
     "node_modules/socket.io-client/node_modules/debug": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -22108,8 +19345,7 @@
     },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
-      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -22120,8 +19356,7 @@
     },
     "node_modules/socket.io-parser/node_modules/debug": {
       "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -22136,8 +19371,7 @@
     },
     "node_modules/socks": {
       "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -22149,8 +19383,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.1",
         "debug": "^4.3.4",
@@ -22162,77 +19395,66 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
-      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
+      "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/split2": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
       "engines": {
         "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
-      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/std-env": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
-      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
+      "license": "MIT"
     },
     "node_modules/store2": {
       "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.3.tgz",
-      "integrity": "sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg=="
+      "license": "MIT"
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
-      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -22240,9 +19462,8 @@
     },
     "node_modules/stream-http": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
-      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.4",
@@ -22252,43 +19473,37 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter-types": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
+      "license": "ISC"
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -22304,8 +19519,7 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -22317,21 +19531,18 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -22341,8 +19552,7 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -22355,8 +19565,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -22367,8 +19576,7 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -22378,17 +19586,15 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
-      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -22398,8 +19604,7 @@
     },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
+      "license": "MIT",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -22410,9 +19615,8 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -22422,9 +19626,8 @@
     },
     "node_modules/strip-literal": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
-      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -22434,19 +19637,16 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
-      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -22466,24 +19666,21 @@
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/sucrase/node_modules/glob": {
       "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -22501,8 +19698,7 @@
     },
     "node_modules/sucrase/node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -22515,14 +19711,12 @@
     },
     "node_modules/superstruct": {
       "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
-      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -22532,8 +19726,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -22543,16 +19736,14 @@
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/system-architecture": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
-      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -22562,8 +19753,7 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
-      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
+      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -22598,8 +19788,7 @@
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -22609,8 +19798,7 @@
     },
     "node_modules/tailwindcss/node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       },
@@ -22619,28 +19807,23 @@
       }
     },
     "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+      "version": "1.0.2"
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -22650,22 +19833,19 @@
     },
     "node_modules/thread-stream": {
       "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
+      "license": "MIT",
       "dependencies": {
         "real-require": "^0.1.0"
       }
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+      "license": "MIT"
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
-      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "setimmediate": "^1.0.4"
       },
@@ -22675,15 +19855,13 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
-      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -22697,46 +19875,40 @@
     },
     "node_modules/tiny-secp256k1/node_modules/bn.js": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
-      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinypool": {
       "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
-      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
-      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -22746,32 +19918,27 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
+      "license": "MIT"
     },
     "node_modules/toml": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
-      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
+      "license": "MIT"
     },
     "node_modules/totalist": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
-      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "license": "MIT"
     },
     "node_modules/tronweb": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-5.3.2.tgz",
-      "integrity": "sha512-iPcIjMCxb6H7FXMntAj47F3L+7jSideyQ7ZOvRj9MeZBh46SHevMrDDR57HzakUa/tT8VvlPFHtqFK4hzTLkXw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@ethersproject/abi": "^5.7.0",
@@ -22790,26 +19957,22 @@
     },
     "node_modules/tronweb/node_modules/eventemitter3": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+      "license": "MIT"
     },
     "node_modules/tronweb/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+      "license": "Apache-2.0"
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -22819,14 +19982,12 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
-      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+      "license": "MIT"
     },
     "node_modules/ts-unused-exports": {
       "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ts-unused-exports/-/ts-unused-exports-10.1.0.tgz",
-      "integrity": "sha512-QA11Dpwkm5Apfe9s/UkFzHEpbiBxKy0VQ72YRAoqq9VgNbxvvIOcS5Kgm1MCitOec9YU6nf51DEWnmL6jkP2Yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "tsconfig-paths": "^3.9.0"
@@ -22848,9 +20009,8 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -22860,9 +20020,8 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -22872,13 +20031,11 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "license": "0BSD"
     },
     "node_modules/tss-react": {
       "version": "4.9.14",
-      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.14.tgz",
-      "integrity": "sha512-nAj4RCQk3ADzrmtxmTcmN1B9EKxPMIxuCfJ3ll964CksndJ2/ZImF6rAMo2Kud5yE3ENXHpPIBHCyuMtgptMvw==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/cache": "*",
         "@emotion/serialize": "*",
@@ -22902,9 +20059,8 @@
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -22917,31 +20073,26 @@
     },
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
-      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
-      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+      "license": "Unlicense"
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -22951,18 +20102,16 @@
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -22972,21 +20121,18 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typeforce": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
-      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22997,8 +20143,6 @@
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
-      "integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
       "funding": [
         {
           "type": "opencollective",
@@ -23013,6 +20157,7 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
+      "license": "MIT",
       "bin": {
         "ua-parser-js": "script/cli.js"
       },
@@ -23022,39 +20167,33 @@
     },
     "node_modules/ufo": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
+      "license": "MIT"
     },
     "node_modules/uint8array-tools": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
-      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/uint8arrays": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
+      "license": "MIT",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
-      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "license": "MIT"
     },
     "node_modules/unenv": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
-      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+      "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
         "defu": "^6.1.4",
@@ -23065,23 +20204,20 @@
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
-      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -23092,51 +20228,45 @@
     },
     "node_modules/unicode-match-property-value-ecmascript": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
-      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
-      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unidragger": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/unidragger/-/unidragger-3.0.1.tgz",
-      "integrity": "sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==",
+      "license": "MIT",
       "dependencies": {
         "ev-emitter": "^2.0.0"
       }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/unload": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
-      "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==",
+      "license": "Apache-2.0",
       "funding": {
         "url": "https://github.com/sponsors/pubkey"
       }
     },
     "node_modules/unstorage": {
       "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.0.tgz",
-      "integrity": "sha512-FjkD8JSdZyktjzPUR9KbR1Pc2tD9b+rEMMNMyvrlpBwQCftL9WgU7iAvb95QDBi5wDL75SQyTovQASBPzt3a9g==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.6.0",
@@ -23228,13 +20358,11 @@
     },
     "node_modules/unstorage/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+      "license": "ISC"
     },
     "node_modules/untun": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
-      "integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
+      "license": "MIT",
       "dependencies": {
         "citty": "^0.1.5",
         "consola": "^3.2.3",
@@ -23246,8 +20374,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
-      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -23262,6 +20388,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.0"
@@ -23275,32 +20402,28 @@
     },
     "node_modules/uqr": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
-      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/uri-js/node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/url": {
       "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
-      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -23311,9 +20434,8 @@
     },
     "node_modules/usb": {
       "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.14.0.tgz",
-      "integrity": "sha512-I3lzVOH21BsO6qPYvx1C7Ji08lbuM0qmsEtNGAphqlhNME5cz/vExY+jIXZl+HQIRybI/sTxdyLab5tALsL69w==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
         "node-addon-api": "^8.0.0",
@@ -23325,16 +20447,14 @@
     },
     "node_modules/usb/node_modules/node-addon-api": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
-      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
+      "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/use-debounce": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
-      "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -23344,17 +20464,15 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
-      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -23365,8 +20483,7 @@
     },
     "node_modules/util": {
       "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -23377,22 +20494,18 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+      "license": "MIT"
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uuidv4": {
       "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "dependencies": {
         "@types/uuid": "8.3.4",
         "uuid": "8.3.2"
@@ -23400,16 +20513,14 @@
     },
     "node_modules/validator": {
       "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
-      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/valtio": {
       "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.2.tgz",
-      "integrity": "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==",
+      "license": "MIT",
       "dependencies": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -23432,24 +20543,21 @@
     },
     "node_modules/valtio/node_modules/use-sync-external-store": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/varuint-bitcoin": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
-      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
+      "license": "MIT",
       "dependencies": {
         "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/versions": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/versions/-/versions-10.4.3.tgz",
-      "integrity": "sha512-pD7dDotmV6dTffxQUHjsjbG7K/MFTnNcF0KpFYRD9BwHV+vQEf8VRmd3/CTn9Xu8BxNhrLac+x25Ny1SA2Lp/w==",
+      "license": "BSD-2-Clause",
       "bin": {
         "versions": "bin/versions.js"
       },
@@ -23459,14 +20567,13 @@
     },
     "node_modules/viem": {
       "version": "1.21.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
-      "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.0",
         "@noble/curves": "1.2.0",
@@ -23488,13 +20595,11 @@
     },
     "node_modules/viem/node_modules/@adraffy/ens-normalize": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+      "license": "MIT"
     },
     "node_modules/viem/node_modules/@noble/curves": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -23504,8 +20609,7 @@
     },
     "node_modules/viem/node_modules/@noble/hashes": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -23515,16 +20619,14 @@
     },
     "node_modules/viem/node_modules/@scure/base": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/viem/node_modules/@scure/bip32": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.2.0",
         "@noble/hashes": "~1.3.2",
@@ -23536,8 +20638,7 @@
     },
     "node_modules/viem/node_modules/@scure/bip39": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
@@ -23548,14 +20649,13 @@
     },
     "node_modules/viem/node_modules/abitype": {
       "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.4",
         "zod": "^3 >=3.19.1"
@@ -23571,8 +20671,7 @@
     },
     "node_modules/viem/node_modules/ws": {
       "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23591,9 +20690,8 @@
     },
     "node_modules/vite": {
       "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -23650,9 +20748,8 @@
     },
     "node_modules/vite-bundle-visualizer": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz",
-      "integrity": "sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "import-from-esm": "^1.3.3",
@@ -23668,9 +20765,8 @@
     },
     "node_modules/vite-node": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
-      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -23690,9 +20786,8 @@
     },
     "node_modules/vite-plugin-dts": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.4.0.tgz",
-      "integrity": "sha512-CJ6phvnnPLF+aFk8Jz2ZcMBLleJ4gKJOXb9We5Kzmsp5bPuD+uMDeVefjFNYSXZ+wdcqnf+Yp2P7oA5hBKQTlQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor": "^7.48.1",
         "@rollup/pluginutils": "^5.1.4",
@@ -23719,9 +20814,8 @@
     },
     "node_modules/vitest": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
-      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "1.6.0",
         "@vitest/runner": "1.6.0",
@@ -23784,9 +20878,8 @@
     },
     "node_modules/vitest/node_modules/execa": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -23807,9 +20900,8 @@
     },
     "node_modules/vitest/node_modules/get-stream": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -23819,18 +20911,16 @@
     },
     "node_modules/vitest/node_modules/human-signals": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
       }
     },
     "node_modules/vitest/node_modules/is-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -23840,9 +20930,8 @@
     },
     "node_modules/vitest/node_modules/npm-run-path": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
-      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -23855,9 +20944,8 @@
     },
     "node_modules/vitest/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -23867,9 +20955,8 @@
     },
     "node_modules/vitest/node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -23879,29 +20966,25 @@
     },
     "node_modules/vlq": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
-      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
+      "license": "MIT"
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
-      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-jsonrpc": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
-      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
-      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.4",
         "semver": "^7.3.4",
@@ -23913,9 +20996,8 @@
     },
     "node_modules/vscode-languageclient/node_modules/semver": {
       "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -23925,9 +21007,8 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
-      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.16.0"
       },
@@ -23937,9 +21018,8 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
-      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "6.0.0",
         "vscode-languageserver-types": "3.16.0"
@@ -23947,26 +21027,21 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
-      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
-      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
-      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wagmi": {
       "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-1.4.13.tgz",
-      "integrity": "sha512-AScVYFjqNt1wMgL99Bob7MLdhoTZ3XKiOZL5HVBdy4W1sh7QodA3gQ8IsmTuUrQ7oQaTxjiXEhwg7sWNrPBvJA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -23977,6 +21052,7 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-sync-storage-persister": "^4.27.1",
@@ -23999,27 +21075,24 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-vitals": {
       "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
-      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+      "license": "Apache-2.0"
     },
     "node_modules/webauthn-p256": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
-      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.4.0"
@@ -24027,19 +21100,16 @@
     },
     "node_modules/webextension-polyfill": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
-      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
+      "license": "MPL-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "license": "BSD-2-Clause"
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
-      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "0.5.7",
         "acorn": "^8.0.4",
@@ -24063,18 +21133,16 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
       "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -24093,8 +21161,7 @@
     },
     "node_modules/webrtc-adapter": {
       "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
-      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "rtcpeerconnection-shim": "^1.2.15",
         "sdp": "^2.12.0"
@@ -24106,13 +21173,11 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -24120,8 +21185,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -24134,13 +21198,11 @@
     },
     "node_modules/which-module": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
+      "license": "ISC"
     },
     "node_modules/which-typed-array": {
       "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -24158,9 +21220,8 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
-      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -24174,29 +21235,25 @@
     },
     "node_modules/wif": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
-      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
+      "license": "MIT",
       "dependencies": {
         "bs58check": "^4.0.0"
       }
     },
     "node_modules/wif/node_modules/base-x": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
-      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
+      "license": "MIT"
     },
     "node_modules/wif/node_modules/bs58": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
-      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/wif/node_modules/bs58check": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
-      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -24204,17 +21261,15 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -24230,8 +21285,7 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -24246,21 +21300,18 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -24272,8 +21323,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -24283,8 +21333,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -24294,8 +21343,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -24308,13 +21356,11 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -24333,16 +21379,13 @@
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
-      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/xstream": {
       "version": "11.14.0",
-      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
-      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
+      "license": "MIT",
       "dependencies": {
         "globalthis": "^1.0.1",
         "symbol-observable": "^2.0.3"
@@ -24350,42 +21393,36 @@
     },
     "node_modules/xstream/node_modules/symbol-observable": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
-      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
+      "license": "ISC"
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "license": "ISC",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs": {
       "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "license": "MIT",
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -24401,8 +21438,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "license": "ISC",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -24410,29 +21446,25 @@
     },
     "node_modules/yargs-parser/node_modules/camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "license": "MIT",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -24442,16 +21474,14 @@
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "license": "MIT",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -24462,8 +21492,7 @@
     },
     "node_modules/yargs/node_modules/p-limit": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -24476,8 +21505,7 @@
     },
     "node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "license": "MIT",
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -24487,16 +21515,14 @@
     },
     "node_modules/yargs/node_modules/path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -24508,8 +21534,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -24519,9 +21544,8 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -24531,21 +21555,18 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
+      "license": "MIT"
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
+      "license": "MIT",
       "dependencies": {
         "zen-observable": "0.8.15"
       }
     },
     "node_modules/zustand": {
       "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
-      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+      "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "1.2.2"
       },
@@ -24571,8 +21592,7 @@
     },
     "node_modules/zustand/node_modules/use-sync-external-store": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -91,7 +91,8 @@
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.0.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.12.tgz",
+      "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA==",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -103,7 +104,8 @@
     },
     "node_modules/@0no-co/graphqlsp": {
       "version": "1.12.16",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
+      "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
       "dependencies": {
         "@gql.tada/internal": "^1.0.0",
         "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
@@ -115,11 +117,13 @@
     },
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "engines": {
         "node": ">=10"
       },
@@ -129,7 +133,8 @@
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -141,7 +146,8 @@
     },
     "node_modules/@apollo/client": {
       "version": "3.12.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.12.3.tgz",
+      "integrity": "sha512-KZ5zymRdb8bMbGUb1wP2U04ff7qIGgaC1BCdCVC+IPFiXkxEhHBc5fDEQOwAUT+vUo9KbBh3g7QK/JCOswn59w==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -182,7 +188,8 @@
     },
     "node_modules/@aptos-labs/aptos-client": {
       "version": "0.1.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@aptos-labs/aptos-client/-/aptos-client-0.1.1.tgz",
+      "integrity": "sha512-kJsoy4fAPTOhzVr7Vwq8s/AUg6BQiJDa7WOqRzev4zsuIS3+JCuIZ6vUd7UBsjnxtmguJJulMRs9qWCzVBt2XA==",
       "dependencies": {
         "axios": "1.7.4",
         "got": "^11.8.6"
@@ -193,8 +200,9 @@
     },
     "node_modules/@artursapek/vite-plugin-checker": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@artursapek/vite-plugin-checker/-/vite-plugin-checker-0.7.4.tgz",
+      "integrity": "sha512-W00hk2C9BoPwVcANYRiNwhEqRwkdY6EekL7ipOj2ap6RW1ymYBcLsKyiw6H08ziozeBYjcUwX2bTo7YTGwaR2g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "ansi-escapes": "^4.3.0",
@@ -258,7 +266,8 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -270,14 +279,16 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
       "version": "7.26.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
@@ -306,7 +317,8 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
+      "integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
       "dependencies": {
         "@babel/parser": "^7.26.3",
         "@babel/types": "^7.26.3",
@@ -320,7 +332,8 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+      "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -330,7 +343,8 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
       "dependencies": {
         "@babel/compat-data": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -344,7 +358,8 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
+      "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -363,8 +378,9 @@
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.26.3.tgz",
+      "integrity": "sha512-G7ZRb40uUgdKOQqPLjfD12ZmGA54PzqDFUv2BKImnC9QIfGhIHKvVML0oN8IUiDq4iRqpq74ABpvOaerfWdong==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "regexpu-core": "^6.2.0",
@@ -379,8 +395,9 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
+      "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -394,7 +411,8 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+      "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -405,7 +423,8 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
+      "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -416,7 +435,8 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.26.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9",
@@ -431,7 +451,8 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+      "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -441,15 +462,17 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz",
+      "integrity": "sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-wrap-function": "^7.25.9",
@@ -464,7 +487,8 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
+      "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -479,7 +503,8 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+      "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -490,29 +515,33 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
+      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+      "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/traverse": "^7.25.9",
@@ -524,7 +553,8 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.26.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
       "peer": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
@@ -536,7 +566,8 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
+      "integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
       "dependencies": {
         "@babel/types": "^7.26.3"
       },
@@ -549,8 +580,9 @@
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+      "integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -564,8 +596,9 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+      "integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -578,8 +611,9 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+      "integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -592,8 +626,9 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
@@ -608,8 +643,9 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+      "integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/traverse": "^7.25.9"
@@ -623,8 +659,10 @@
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-create-class-features-plugin": "^7.21.0",
@@ -640,8 +678,9 @@
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+      "integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -654,8 +693,9 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+      "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -668,7 +708,8 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+      "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -681,8 +722,9 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
       },
@@ -695,7 +737,8 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+      "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -708,8 +751,9 @@
     },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+      "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
         "@babel/helper-plugin-utils": "^7.18.6"
@@ -723,8 +767,9 @@
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+      "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -737,8 +782,9 @@
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
+      "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
@@ -753,8 +799,9 @@
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+      "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -769,8 +816,9 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz",
+      "integrity": "sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -783,8 +831,9 @@
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
+      "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -797,8 +846,9 @@
     },
     "node_modules/@babel/plugin-transform-class-properties": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+      "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -812,8 +862,9 @@
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+      "integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -827,8 +878,9 @@
     },
     "node_modules/@babel/plugin-transform-classes": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+      "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -846,8 +898,9 @@
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+      "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/template": "^7.25.9"
@@ -861,8 +914,9 @@
     },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+      "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -875,8 +929,9 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+      "integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -890,8 +945,9 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+      "integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -904,8 +960,9 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -919,8 +976,9 @@
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+      "integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -933,8 +991,9 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+      "integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -947,8 +1006,9 @@
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+      "integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -961,8 +1021,9 @@
     },
     "node_modules/@babel/plugin-transform-for-of": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
+      "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -976,8 +1037,9 @@
     },
     "node_modules/@babel/plugin-transform-function-name": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+      "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -992,8 +1054,9 @@
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+      "integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1006,8 +1069,9 @@
     },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+      "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1020,8 +1084,9 @@
     },
     "node_modules/@babel/plugin-transform-logical-assignment-operators": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+      "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1034,8 +1099,9 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+      "integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1048,8 +1114,9 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+      "integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1063,7 +1130,8 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+      "integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.26.0",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1077,8 +1145,9 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+      "integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1094,8 +1163,9 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+      "integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1109,8 +1179,9 @@
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+      "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1124,8 +1195,9 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+      "integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1138,8 +1210,9 @@
     },
     "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
+      "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1152,8 +1225,9 @@
     },
     "node_modules/@babel/plugin-transform-numeric-separator": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+      "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1166,8 +1240,9 @@
     },
     "node_modules/@babel/plugin-transform-object-rest-spread": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+      "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1182,8 +1257,9 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+      "integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-replace-supers": "^7.25.9"
@@ -1197,8 +1273,9 @@
     },
     "node_modules/@babel/plugin-transform-optional-catch-binding": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+      "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1211,8 +1288,9 @@
     },
     "node_modules/@babel/plugin-transform-optional-chaining": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+      "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1226,8 +1304,9 @@
     },
     "node_modules/@babel/plugin-transform-parameters": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+      "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1240,8 +1319,9 @@
     },
     "node_modules/@babel/plugin-transform-private-methods": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+      "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1255,8 +1335,9 @@
     },
     "node_modules/@babel/plugin-transform-private-property-in-object": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+      "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1271,8 +1352,9 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+      "integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1285,8 +1367,9 @@
     },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
+      "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
@@ -1300,8 +1383,9 @@
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
       "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+      "integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1315,8 +1399,9 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+      "integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1329,8 +1414,9 @@
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+      "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1343,8 +1429,9 @@
     },
     "node_modules/@babel/plugin-transform-spread": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+      "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1358,8 +1445,9 @@
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+      "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1372,8 +1460,9 @@
     },
     "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz",
+      "integrity": "sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1386,8 +1475,9 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz",
+      "integrity": "sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1400,7 +1490,8 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.26.3.tgz",
+      "integrity": "sha512-6+5hpdr6mETwSKjmJUdYw0EIkATiQhnELWlE3kJFBwSg/BGIVwVaVbX+gOXBCdc7Ln1RXZxyWGecIXhUfnl7oA==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1417,8 +1508,9 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+      "integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1431,8 +1523,9 @@
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+      "integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1446,8 +1539,9 @@
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+      "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1461,8 +1555,9 @@
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+      "integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1476,8 +1571,9 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.0.tgz",
+      "integrity": "sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.26.0",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -1558,8 +1654,9 @@
     },
     "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1569,8 +1666,9 @@
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+      "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/types": "^7.4.4",
@@ -1582,7 +1680,8 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.26.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.26.0.tgz",
+      "integrity": "sha512-NMk1IGZ5I/oHhoXEElcm+xUnL/szL6xflkFZmoEU9xj1qSJXpiS7rsspYo92B4DRCDvZn2erT5LdsCeXAKNCkg==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-validator-option": "^7.25.9",
@@ -1599,7 +1698,8 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.26.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
+      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1609,7 +1709,8 @@
     },
     "node_modules/@babel/template": {
       "version": "7.25.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
+      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
       "dependencies": {
         "@babel/code-frame": "^7.25.9",
         "@babel/parser": "^7.25.9",
@@ -1621,7 +1722,8 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.26.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
+      "integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
         "@babel/generator": "^7.26.3",
@@ -1637,7 +1739,8 @@
     },
     "node_modules/@babel/types": {
       "version": "7.26.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
+      "integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -1648,7 +1751,8 @@
     },
     "node_modules/@binance/w3w-core": {
       "version": "1.1.8-alpha.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-core/-/w3w-core-1.1.8-alpha.0.tgz",
+      "integrity": "sha512-fLTBqF4Yb7s4zFMhzHnmurQqszbiE9c8ZdmbELSkWgSwEHtEO7DAOAV61X9mCLLeCLpQkwz3sLULg/Agjr5iXA==",
       "dependencies": {
         "@binance/w3w-qrcode-modal": "1.1.5",
         "@binance/w3w-socket-transport": "1.1.4",
@@ -1661,7 +1765,8 @@
     },
     "node_modules/@binance/w3w-core/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1671,11 +1776,13 @@
     },
     "node_modules/@binance/w3w-core/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-ethereum-provider": {
       "version": "1.1.8-alpha.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-ethereum-provider/-/w3w-ethereum-provider-1.1.8-alpha.0.tgz",
+      "integrity": "sha512-pmJWrv1npmqYYz1M3wtaXVY4rSJh2GYjNgRXoFb9SUJOklO8zHqKUjRoPWcHtWQTnEHmwzE4e/dIzE3tecRAjg==",
       "dependencies": {
         "@binance/w3w-http-client": "1.1.4",
         "@binance/w3w-sign-client": "1.1.8-alpha.0",
@@ -1687,7 +1794,8 @@
     },
     "node_modules/@binance/w3w-ethereum-provider/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1697,11 +1805,13 @@
     },
     "node_modules/@binance/w3w-ethereum-provider/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-http-client": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-http-client/-/w3w-http-client-1.1.4.tgz",
+      "integrity": "sha512-dovohLZThYNY2DNbM0XILjLsgo+ZMdMRRTkbdewrLcj1KkXwUn36K2tFsi/aDZXTBjWcNlziaGQYHmbuLEXTpw==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -1711,7 +1821,8 @@
     },
     "node_modules/@binance/w3w-http-client/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1721,11 +1832,13 @@
     },
     "node_modules/@binance/w3w-http-client/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-qrcode-modal": {
       "version": "1.1.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-qrcode-modal/-/w3w-qrcode-modal-1.1.5.tgz",
+      "integrity": "sha512-SFwA9PeCAlPBjfgLf9chLoia3D5pWpDjDZOZ6wD3G3Xspd4XKrtQl4UvFpAm6hkrgw6fShtI2zis9PQYAxQjiA==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -1738,7 +1851,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1748,14 +1862,16 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/camelcase": {
       "version": "5.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/cliui": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -1764,15 +1880,18 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/find-up": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -1783,14 +1902,16 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/locate-path": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -1800,7 +1921,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -1813,7 +1935,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/p-locate": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -1823,14 +1946,16 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/pngjs": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/qrcode": {
       "version": "1.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "pngjs": "^5.0.0",
@@ -1845,7 +1970,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/react": {
       "version": "18.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1855,7 +1981,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/react-dom": {
       "version": "18.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -1866,7 +1993,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -1878,7 +2006,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -1890,7 +2019,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/yargs": {
       "version": "15.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -1910,7 +2040,8 @@
     },
     "node_modules/@binance/w3w-qrcode-modal/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -1921,7 +2052,8 @@
     },
     "node_modules/@binance/w3w-sign-client": {
       "version": "1.1.8-alpha.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-sign-client/-/w3w-sign-client-1.1.8-alpha.0.tgz",
+      "integrity": "sha512-p/p/aN6bwCko6X6SGvHGIEW/8ePx/2FWecnAwZaqWmglOdc3u632MWYgTj814Vn6tM36kntY5GoYbGVPMPtQ2w==",
       "dependencies": {
         "@binance/w3w-core": "1.1.8-alpha.0",
         "@binance/w3w-types": "1.1.4",
@@ -1930,7 +2062,8 @@
     },
     "node_modules/@binance/w3w-sign-client/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1940,11 +2073,13 @@
     },
     "node_modules/@binance/w3w-sign-client/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-socket-transport": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-socket-transport/-/w3w-socket-transport-1.1.4.tgz",
+      "integrity": "sha512-SFHknzRM74CMam95bcpcyGeYVHfET3vrANU6XROAVYTa+kCP2O6/tIZVO+WC5HyEJf2uNcJJAV1PVn3gq/3kKQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "@binance/w3w-utils": "1.1.4",
@@ -1953,7 +2088,8 @@
     },
     "node_modules/@binance/w3w-socket-transport/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1963,22 +2099,26 @@
     },
     "node_modules/@binance/w3w-socket-transport/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-types": {
       "version": "1.1.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-types/-/w3w-types-1.1.4.tgz",
+      "integrity": "sha512-CCnneapNTVY1+RseZNIhExVp3ux8LihcXRkGwmvJtZTTJJIC7xQlTWy9olkAsz+opqWK+heAcyYGmt4RUt1M5g==",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
     },
     "node_modules/@binance/w3w-types/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-utils": {
       "version": "1.1.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.6.tgz",
+      "integrity": "sha512-NGT629vS9tRlbigtNn9wHtTYNB00oyDcsajO/kpAcDiQn4ktYs7+oTIr/qLvjP8Z3opTXpbooqMPITDY7DI0IA==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -1988,11 +2128,13 @@
     },
     "node_modules/@binance/w3w-utils/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@binance/w3w-wagmi-connector": {
       "version": "1.2.2-alpha.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-wagmi-connector/-/w3w-wagmi-connector-1.2.2-alpha.0.tgz",
+      "integrity": "sha512-Eq2DYib3FBDht5Zn+mQsq4seQyDdZOXBo6hS0TznYiS4SYG08G7paydNhgEAX7aoue5rwR1ZOYzCTvstB/6lFQ==",
       "dependencies": {
         "@binance/w3w-ethereum-provider": "1.1.8-alpha.0",
         "@binance/w3w-utils": "1.1.4"
@@ -2004,7 +2146,8 @@
     },
     "node_modules/@binance/w3w-wagmi-connector/node_modules/@binance/w3w-utils": {
       "version": "1.1.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@binance/w3w-utils/-/w3w-utils-1.1.4.tgz",
+      "integrity": "sha512-lWpxCj5IB8XNKmFotZ2MLsK4rP5ECyC5jHxbDuvjseMlZchEaWKRXViUcwIz3XdJPVM3DDArqqweLEyxCcsDtQ==",
       "dependencies": {
         "@binance/w3w-types": "1.1.4",
         "eventemitter3": "^5.0.0",
@@ -2014,11 +2157,13 @@
     },
     "node_modules/@binance/w3w-wagmi-connector/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@blocto/sdk": {
       "version": "0.3.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@blocto/sdk/-/sdk-0.3.6.tgz",
+      "integrity": "sha512-hbsc9eC1EL9wJ+8nXUp3POkC84qt46FPRqX3tYzxeQn72Zvhew6T81wKvzXZsuLmmoo8FBzPiXkb0QMWJkpOLw==",
       "dependencies": {
         "bs58": "^4.0.1",
         "buffer": "^6.0.3",
@@ -2040,7 +2185,8 @@
     },
     "node_modules/@coinbase/wallet-sdk": {
       "version": "3.9.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.9.3.tgz",
+      "integrity": "sha512-N/A2DRIf0Y3PHc1XAMvbBUu4zisna6qAdqABMZwBMNEfWrXpAwx16pZGkYCLGE+Rvv1edbcB2LYDRnACNcmCiw==",
       "dependencies": {
         "bn.js": "^5.2.1",
         "buffer": "^6.0.3",
@@ -2055,18 +2201,21 @@
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/clsx": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/preact": {
       "version": "10.25.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
+      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2074,7 +2223,8 @@
     },
     "node_modules/@confio/ics23": {
       "version": "0.6.8",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@confio/ics23/-/ics23-0.6.8.tgz",
+      "integrity": "sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==",
       "dependencies": {
         "@noble/hashes": "^1.0.0",
         "protobufjs": "^6.8.8"
@@ -2082,8 +2232,9 @@
     },
     "node_modules/@confio/ics23/node_modules/protobufjs": {
       "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.4.tgz",
+      "integrity": "sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -2106,7 +2257,8 @@
     },
     "node_modules/@coral-xyz/anchor": {
       "version": "0.29.0",
-      "license": "(MIT OR Apache-2.0)",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.29.0.tgz",
+      "integrity": "sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==",
       "dependencies": {
         "@coral-xyz/borsh": "^0.29.0",
         "@noble/hashes": "^1.3.1",
@@ -2129,7 +2281,8 @@
     },
     "node_modules/@coral-xyz/borsh": {
       "version": "0.29.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.29.0.tgz",
+      "integrity": "sha512-s7VFVa3a0oqpkuRloWVPdCK7hMbAMY270geZOGfCnaqexrP5dTIpbEHL33req6IYPPJ0hYa71cdvJ1h6V55/oQ==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -2143,7 +2296,8 @@
     },
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
+      "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -2153,7 +2307,8 @@
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/cosmwasm-stargate/-/cosmwasm-stargate-0.32.4.tgz",
+      "integrity": "sha512-Fuo9BGEiB+POJ5WeRyBGuhyKR1ordvxZGLPuPosFJOH9U0gKMgcjwKMCgAlWFkMlHaTB+tNdA8AifWiHrI7VgA==",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -2169,7 +2324,8 @@
     },
     "node_modules/@cosmjs/crypto": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
+      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
       "dependencies": {
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
@@ -2182,7 +2338,8 @@
     },
     "node_modules/@cosmjs/encoding": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
+      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "bech32": "^1.1.4",
@@ -2191,11 +2348,13 @@
     },
     "node_modules/@cosmjs/encoding/node_modules/bech32": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
+      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/@cosmjs/json-rpc": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.32.4.tgz",
+      "integrity": "sha512-/jt4mBl7nYzfJ2J/VJ+r19c92mUKF0Lt0JxM3MXEJl7wlwW5haHAWtzRujHkyYMXOwIR+gBqT2S0vntXVBRyhQ==",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "xstream": "^11.14.0"
@@ -2203,14 +2362,16 @@
     },
     "node_modules/@cosmjs/math": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
+      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -2222,7 +2383,8 @@
     },
     "node_modules/@cosmjs/socket": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.32.4.tgz",
+      "integrity": "sha512-davcyYziBhkzfXQTu1l5NrpDYv0K9GekZCC9apBRvL1dvMc9F/ygM7iemHjUA+z8tJkxKxrt/YPjJ6XNHzLrkw==",
       "dependencies": {
         "@cosmjs/stream": "^0.32.4",
         "isomorphic-ws": "^4.0.1",
@@ -2232,7 +2394,8 @@
     },
     "node_modules/@cosmjs/socket/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -2251,7 +2414,8 @@
     },
     "node_modules/@cosmjs/stargate": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.32.4.tgz",
+      "integrity": "sha512-usj08LxBSsPRq9sbpCeVdyLx2guEcOHfJS9mHGCLCXpdAPEIEQEtWLDpEUc0LEhWOx6+k/ChXTc5NpFkdrtGUQ==",
       "dependencies": {
         "@confio/ics23": "^0.6.8",
         "@cosmjs/amino": "^0.32.4",
@@ -2267,14 +2431,16 @@
     },
     "node_modules/@cosmjs/stream": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.32.4.tgz",
+      "integrity": "sha512-Gih++NYHEiP+oyD4jNEUxU9antoC0pFSg+33Hpp0JlHwH0wXhtD3OOKnzSfDB7OIoEbrzLJUpEjOgpCp5Z+W3A==",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc": {
       "version": "0.32.4",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.32.4.tgz",
+      "integrity": "sha512-MWvUUno+4bCb/LmlMIErLypXxy7ckUuzEmpufYYYd9wgbdCXaTaO08SZzyFM5PI8UJ/0S2AmUrgWhldlbxO8mw==",
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -2288,31 +2454,24 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.32.4.tgz",
+      "integrity": "sha512-D1Yc+Zy8oL/hkUkFUL/bwxvuDBzRGpc4cF7/SkdhxX4iHpSLgdOuTt1mhCh9+kl6NQREy9t7SYZ6xeW5gFe60w=="
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
+      "integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -2329,11 +2488,13 @@
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
       "version": "1.9.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/@emotion/cache": {
       "version": "11.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
+      "integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
@@ -2344,22 +2505,26 @@
     },
     "node_modules/@emotion/hash": {
       "version": "0.9.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
+      "integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g=="
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz",
+      "integrity": "sha512-/ACwoqx7XQi9knQs/G0qKvv5teDMhD7bXYns9N/wM8ah8iNb8jZ2uNO0YOgiq2o2poIvVtJS2YALasQuMSQ7Kw==",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
       }
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ=="
     },
     "node_modules/@emotion/react": {
       "version": "11.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
+      "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2381,7 +2546,8 @@
     },
     "node_modules/@emotion/serialize": {
       "version": "1.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
+      "integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
@@ -2392,11 +2558,13 @@
     },
     "node_modules/@emotion/sheet": {
       "version": "1.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
+      "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg=="
     },
     "node_modules/@emotion/styled": {
       "version": "11.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
+      "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2417,38 +2585,109 @@
     },
     "node_modules/@emotion/unitless": {
       "version": "0.10.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
+      "integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg=="
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
+      "integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/@emotion/utils": {
       "version": "1.4.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
+      "integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA=="
     },
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
+      "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
     },
     "node_modules/@emurgo/cardano-serialization-lib-browser": {
       "version": "11.5.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-browser/-/cardano-serialization-lib-browser-11.5.0.tgz",
+      "integrity": "sha512-qchOJ9NYDUz10tzs5r5QhP9hK0p+ZOlRiBwPdTAxqAYLw/8emYBkQQLaS8T1DF6EkeudyrgS00ym5Trw1fo4iA=="
     },
     "node_modules/@emurgo/cardano-serialization-lib-nodejs": {
       "version": "11.5.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-11.5.0.tgz",
+      "integrity": "sha512-IlVABlRgo9XaTR1NunwZpWcxnfEv04ba2l1vkUz4S1W7Jt36F4CtffP+jPeqBZGnAe+fnUwo0XjIJC3ZTNToNQ=="
     },
-    "node_modules/@esbuild/darwin-arm64": {
+    "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2457,10 +2696,299 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -2476,16 +3004,18 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2506,8 +3036,9 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2520,8 +3051,9 @@
     },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -2531,22 +3063,25 @@
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@ethereumjs/common": {
       "version": "4.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-4.4.0.tgz",
+      "integrity": "sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==",
       "dependencies": {
         "@ethereumjs/util": "^9.1.0"
       }
     },
     "node_modules/@ethereumjs/common/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -2556,7 +3091,8 @@
     },
     "node_modules/@ethereumjs/common/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
+      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -2567,7 +3103,8 @@
     },
     "node_modules/@ethereumjs/rlp": {
       "version": "4.0.1",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
+      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
       "bin": {
         "rlp": "bin/rlp"
       },
@@ -2577,7 +3114,8 @@
     },
     "node_modules/@ethereumjs/tx": {
       "version": "5.4.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-5.4.0.tgz",
+      "integrity": "sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==",
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
@@ -2590,7 +3128,8 @@
     },
     "node_modules/@ethereumjs/tx/node_modules/@ethereumjs/rlp": {
       "version": "5.0.2",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
+      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -2600,7 +3139,8 @@
     },
     "node_modules/@ethereumjs/tx/node_modules/@ethereumjs/util": {
       "version": "9.1.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
+      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -2611,7 +3151,8 @@
     },
     "node_modules/@ethereumjs/util": {
       "version": "8.1.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
+      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^2.0.0",
@@ -2623,6 +3164,8 @@
     },
     "node_modules/@ethersproject/abi": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz",
+      "integrity": "sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==",
       "funding": [
         {
           "type": "individual",
@@ -2633,7 +3176,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -2648,6 +3190,8 @@
     },
     "node_modules/@ethersproject/abstract-provider": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz",
+      "integrity": "sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==",
       "funding": [
         {
           "type": "individual",
@@ -2658,7 +3202,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -2671,6 +3214,8 @@
     },
     "node_modules/@ethersproject/abstract-signer": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz",
+      "integrity": "sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==",
       "funding": [
         {
           "type": "individual",
@@ -2681,7 +3226,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -2692,6 +3236,8 @@
     },
     "node_modules/@ethersproject/address": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
       "funding": [
         {
           "type": "individual",
@@ -2702,7 +3248,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -2713,6 +3258,8 @@
     },
     "node_modules/@ethersproject/base64": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz",
+      "integrity": "sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==",
       "funding": [
         {
           "type": "individual",
@@ -2723,13 +3270,14 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/bignumber": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -2740,7 +3288,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -2749,6 +3296,8 @@
     },
     "node_modules/@ethersproject/bytes": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -2759,13 +3308,14 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz",
+      "integrity": "sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==",
       "funding": [
         {
           "type": "individual",
@@ -2776,13 +3326,14 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/hash": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz",
+      "integrity": "sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==",
       "funding": [
         {
           "type": "individual",
@@ -2793,7 +3344,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/address": "^5.7.0",
@@ -2808,6 +3358,8 @@
     },
     "node_modules/@ethersproject/keccak256": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
       "funding": [
         {
           "type": "individual",
@@ -2818,7 +3370,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "js-sha3": "0.8.0"
@@ -2826,6 +3377,8 @@
     },
     "node_modules/@ethersproject/logger": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "funding": [
         {
           "type": "individual",
@@ -2835,11 +3388,12 @@
           "type": "individual",
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/@ethersproject/networks": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz",
+      "integrity": "sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==",
       "funding": [
         {
           "type": "individual",
@@ -2850,13 +3404,14 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/properties": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz",
+      "integrity": "sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==",
       "funding": [
         {
           "type": "individual",
@@ -2867,13 +3422,14 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/rlp": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
       "funding": [
         {
           "type": "individual",
@@ -2884,7 +3440,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0"
@@ -2892,6 +3447,8 @@
     },
     "node_modules/@ethersproject/signing-key": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz",
+      "integrity": "sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==",
       "funding": [
         {
           "type": "individual",
@@ -2902,7 +3459,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/logger": "^5.7.0",
@@ -2914,7 +3470,8 @@
     },
     "node_modules/@ethersproject/signing-key/node_modules/elliptic": {
       "version": "6.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -2927,10 +3484,13 @@
     },
     "node_modules/@ethersproject/signing-key/node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/@ethersproject/strings": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
+      "integrity": "sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==",
       "funding": [
         {
           "type": "individual",
@@ -2941,7 +3501,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/constants": "^5.7.0",
@@ -2950,6 +3509,8 @@
     },
     "node_modules/@ethersproject/transactions": {
       "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
+      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
       "funding": [
         {
           "type": "individual",
@@ -2960,7 +3521,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -2975,6 +3535,8 @@
     },
     "node_modules/@ethersproject/web": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz",
+      "integrity": "sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==",
       "funding": [
         {
           "type": "individual",
@@ -2985,7 +3547,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@ethersproject/base64": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -2996,7 +3557,8 @@
     },
     "node_modules/@fewcha/web3": {
       "version": "0.1.32",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@fewcha/web3/-/web3-0.1.32.tgz",
+      "integrity": "sha512-5QrBit4XlDpg4b8UMmDHNxDL/or+1/mk688IbZZ6JSEnvFs15/FW60TTPBTzt9sQKLC+0fq7uMCi3JH/EoMZYg==",
       "dependencies": {
         "aptos": "^1.3.14",
         "buffer": "^6.0.3"
@@ -3004,7 +3566,8 @@
     },
     "node_modules/@fivebinaries/coin-selection": {
       "version": "2.2.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@fivebinaries/coin-selection/-/coin-selection-2.2.1.tgz",
+      "integrity": "sha512-iYFsYr7RY7TEvTqP9NKR4p/yf3Iybf9abUDR7lRjzanGsrLwVsREvIuyE05iRYFrvqarlk+gWRPsdR1N2hUBrg==",
       "dependencies": {
         "@emurgo/cardano-serialization-lib-browser": "^11.5.0",
         "@emurgo/cardano-serialization-lib-nodejs": "11.5.0"
@@ -3012,7 +3575,8 @@
     },
     "node_modules/@fractalwagmi/popup-connection": {
       "version": "1.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.1.1.tgz",
+      "integrity": "sha512-hYL+45iYwNbwjvP2DxP3YzVsrAGtj/RV9LOgMpJyCxsfNoyyOoi2+YrnywKkiANingiG2kJ1nKsizbu1Bd4zZw==",
       "peerDependencies": {
         "react": "^17.0.2 || ^18",
         "react-dom": "^17.0.2 || ^18"
@@ -3020,7 +3584,8 @@
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter": {
       "version": "0.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/solana-wallet-adapter/-/solana-wallet-adapter-0.1.1.tgz",
+      "integrity": "sha512-oTZLEuD+zLKXyhZC5tDRMPKPj8iaxKLxXiCjqRfOo4xmSbS2izGRWLJbKMYYsJysn/OI3UJ3P6CWP8WUWi0dZg==",
       "dependencies": {
         "@fractalwagmi/popup-connection": "^1.0.18",
         "@solana/wallet-adapter-base": "^0.9.17",
@@ -3029,18 +3594,21 @@
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@fractalwagmi/solana-wallet-adapter/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@gql.tada/cli-utils": {
       "version": "1.6.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
+      "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
       "dependencies": {
         "@0no-co/graphqlsp": "^1.12.13",
         "@gql.tada/internal": "1.0.8",
@@ -3064,7 +3632,8 @@
     },
     "node_modules/@gql.tada/internal": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
+      "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5"
       },
@@ -3075,15 +3644,18 @@
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
@@ -3095,8 +3667,9 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -3107,12 +3680,15 @@
     },
     "node_modules/@humanwhocodes/object-schema": {
       "version": "2.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true
     },
     "node_modules/@injectivelabs/core-proto-ts": {
       "version": "1.13.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-1.13.4.tgz",
+      "integrity": "sha512-81+bwey0qzNgOzUASsxYghSahcWzH5l6bSceW8FdR7w42+Knp+bAgbg12sSyS1hiOO2kMXx6tBvmYkCmnghM1Q==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3122,14 +3698,16 @@
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/exceptions": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.33.tgz",
+      "integrity": "sha512-2c8YzLgwTOOsyc1WheqdM8jEfgGBhVrXN4cZ0jsikFVsLF619IDRn3hjIYqTeNERaEpeRPiuJGfZDu0DomwFrQ==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3139,7 +3717,8 @@
     },
     "node_modules/@injectivelabs/grpc-web": {
       "version": "0.0.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web/-/grpc-web-0.0.1.tgz",
+      "integrity": "sha512-Pu5YgaZp+OvR5UWfqbrPdHer3+gDf+b5fQoY+t2VZx1IAVHX8bzbN9EreYTvTYtFeDpYRWM8P7app2u4EX5wTw==",
       "dependencies": {
         "browser-headers": "^0.4.1"
       },
@@ -3149,21 +3728,24 @@
     },
     "node_modules/@injectivelabs/grpc-web-node-http-transport": {
       "version": "0.0.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-node-http-transport/-/grpc-web-node-http-transport-0.0.2.tgz",
+      "integrity": "sha512-rpyhXLiGY/UMs6v6YmgWHJHiO9l0AgDyVNv+jcutNVt4tQrmNvnpvz2wCAGOFtq5LuX/E9ChtTVpk3gWGqXcGA==",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
     },
     "node_modules/@injectivelabs/grpc-web-react-native-transport": {
       "version": "0.0.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/grpc-web-react-native-transport/-/grpc-web-react-native-transport-0.0.2.tgz",
+      "integrity": "sha512-mk+aukQXnYNgPsPnu3KBi+FD0ZHQpazIlaBZ2jNZG7QAVmxTWtv3R66Zoq99Wx2dnE946NsZBYAoa0K5oSjnow==",
       "peerDependencies": {
         "@injectivelabs/grpc-web": ">=0.0.1"
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts": {
       "version": "1.13.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.13.3.tgz",
+      "integrity": "sha512-rLesVPCARl+OC82vj063/pUawYu0ISty/2+xg6ya4Lwk6PDbXmtRvw8wpNP6K+pAsBOKaSkRnO4ThP5qbX+E6A==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3173,14 +3755,16 @@
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/mito-proto-ts": {
       "version": "1.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.13.0.tgz",
+      "integrity": "sha512-DE9iK7PkEnkWAMTDJDH01R8jxkxVCNuurfVp/09Te9wY3dm3mRx9M6R756JywP2Sd/ggJl2UbavGAQe2pZ7v1w==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3190,14 +3774,16 @@
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/networks": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.33.tgz",
+      "integrity": "sha512-XDhAYwWYKdKBRfwO/MIfMyKjKRWz/AliMJG9yaM1C/cDlGHmA3EY7Au2Nf+PdkRhuxl2FzLV2Hp4uWeC0g8BYw==",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3207,7 +3793,8 @@
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
       "version": "1.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/olp-proto-ts/-/olp-proto-ts-1.13.1.tgz",
+      "integrity": "sha512-dKxse7mZpmvRhm00Wn8Yy93EVEvFD7FPWeWFfxga0Patow3HK0D7k43VV7fE5kX9CDM1bxTatEVQ7WYGq4w0Eg==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -3217,14 +3804,16 @@
     },
     "node_modules/@injectivelabs/olp-proto-ts/node_modules/rxjs": {
       "version": "7.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.33.tgz",
+      "integrity": "sha512-qEuu6yzhy8t8rtviCBqV1VMR+JAaDSy59Eebd23i+1P5zqQ9X2lZLLLxz+gWjiglWb8uQYsoLN3TFh2509WNzQ==",
       "dependencies": {
         "@apollo/client": "^3.11.10",
         "@cosmjs/amino": "^0.32.3",
@@ -3264,7 +3853,8 @@
     },
     "node_modules/@injectivelabs/test-utils": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.33.tgz",
+      "integrity": "sha512-1SfIRsMnWcJAYNrrpY+ZUWmbD62lWWdIvD6c+FYmFKS14zU3yDIK9NXe9g1lTM/GdUVkVKQgGg2QAYZ5f2G/xA==",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/networks": "^1.14.33",
@@ -3277,26 +3867,18 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/test-utils/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@injectivelabs/ts-types": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.33.tgz",
+      "integrity": "sha512-sJZzMNJtZFFZoPKZ91G09bxrZqQ5aS9omoTjQWy+7OxfiRAakzhsarTueX47hm6oTaN0XeBgD3wkMukkWUaobw==",
       "dependencies": {
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/utils": {
       "version": "1.14.33",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.33.tgz",
+      "integrity": "sha512-zsezML4dTujF0xGLhcGmWBCghfJiy9MW+r6VqR8zJUlxnmnEdNpmsvBhBI6cmmov6Se4FL+yALAIFRvTm3txbg==",
       "dependencies": {
         "@injectivelabs/exceptions": "^1.14.33",
         "@injectivelabs/ts-types": "^1.14.33",
@@ -3308,19 +3890,10 @@
         "store2": "^2.12.0"
       }
     },
-    "node_modules/@injectivelabs/utils/node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -3335,7 +3908,8 @@
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "engines": {
         "node": ">=12"
       },
@@ -3345,7 +3919,8 @@
     },
     "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -3358,8 +3933,9 @@
     },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -3369,12 +3945,14 @@
     },
     "node_modules/@jest/schemas/node_modules/@sinclair/typebox": {
       "version": "0.27.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@jnwng/walletconnect-solana": {
       "version": "0.2.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@jnwng/walletconnect-solana/-/walletconnect-solana-0.2.0.tgz",
+      "integrity": "sha512-nyRq0xLEj9i2J4UXQ0Mr4KzsooTMbLu0ewHOqdQV7iZE0PfbtKa8poTSF4ZBAQD8hoMHEx+I7zGFCNMI9BTrTA==",
       "dependencies": {
         "@walletconnect/qrcode-modal": "^1.8.0",
         "@walletconnect/sign-client": "^2.7.2",
@@ -3387,18 +3965,21 @@
     },
     "node_modules/@jnwng/walletconnect-solana/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@jnwng/walletconnect-solana/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3410,25 +3991,29 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -3436,7 +4021,9 @@
     },
     "node_modules/@json-rpc-tools/provider": {
       "version": "1.7.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/provider/-/provider-1.7.6.tgz",
+      "integrity": "sha512-z7D3xvJ33UfCGv77n40lbzOYjZKVM3k2+5cV7xS8G6SCvKTzMkhkUYuD/qzQUNT4cG/lv0e9mRToweEEVLVVmA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@json-rpc-tools/utils": "^1.7.6",
         "axios": "^0.21.0",
@@ -3446,7 +4033,8 @@
     },
     "node_modules/@json-rpc-tools/provider/node_modules/axios": {
       "version": "0.27.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -3454,7 +4042,8 @@
     },
     "node_modules/@json-rpc-tools/provider/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -3473,14 +4062,18 @@
     },
     "node_modules/@json-rpc-tools/types": {
       "version": "1.7.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/types/-/types-1.7.6.tgz",
+      "integrity": "sha512-nDSqmyRNEqEK9TZHtM15uNnDljczhCUdBmRhpNZ95bIPKEDQ+nTDmGMFd2lLin3upc5h2VVVd9tkTDdbXUhDIQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0"
       }
     },
     "node_modules/@json-rpc-tools/utils": {
       "version": "1.7.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@json-rpc-tools/utils/-/utils-1.7.6.tgz",
+      "integrity": "sha512-HjA8x/U/Q78HRRe19yh8HVKoZ+Iaoo3YZjakJYxR+rw52NHo6jM+VE9b8+7ygkCFXl/EHID5wh/MkXaE/jGyYw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@json-rpc-tools/types": "^1.7.6",
         "@pedrouid/environment": "^1.0.1"
@@ -3488,8 +4081,9 @@
     },
     "node_modules/@kev1n-peters/vite-plugin-node-polyfills": {
       "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@kev1n-peters/vite-plugin-node-polyfills/-/vite-plugin-node-polyfills-0.17.4.tgz",
+      "integrity": "sha512-B87rIZFB6IMseeXCK73gfDBVDVxcOUVL7GB43eJuH8UWOUL3OACr7DLsrd/ncU6sSAlf6H5kuphVtrga5WSKTg==",
       "dev": true,
-      "license": "MIT",
       "workspaces": [
         "."
       ],
@@ -3508,18 +4102,21 @@
     },
     "node_modules/@keystonehq/alias-sampling": {
       "version": "0.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@keystonehq/alias-sampling/-/alias-sampling-0.1.2.tgz",
+      "integrity": "sha512-5ukLB3bcgltgaFfQfYKYwHDUbwHicekYo53fSEa7xhVkAEqsA74kxdIwoBIURmGUtXe3EVIRm4SYlgcrt2Ri0w=="
     },
     "node_modules/@keystonehq/aptossnap-adapter": {
       "version": "0.2.8",
-      "license": "(Apache-2.0 AND MIT)",
+      "resolved": "https://registry.npmjs.org/@keystonehq/aptossnap-adapter/-/aptossnap-adapter-0.2.8.tgz",
+      "integrity": "sha512-1+YuptOjNysM6pTRqn9PiF8cjGwLEiG/tXxo0HqglDHsq+tBnJaOxe+Zk15JO8pEC8yLr0o17qoFrW1qo3kySQ==",
       "dependencies": {
         "aptos": "^1.3.14"
       }
     },
     "node_modules/@keystonehq/bc-ur-registry": {
       "version": "0.5.5",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry/-/bc-ur-registry-0.5.5.tgz",
+      "integrity": "sha512-PoclPHf0OhpIKLfLwzymsu+CjkWf5ZKvaVjpkq3HUalcI4KW8wLk0m8qI2kBVv6F0BQ0ERPqW8OfjLTVqIgWLA==",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.1.5",
         "bs58check": "^2.1.2",
@@ -3528,7 +4125,8 @@
     },
     "node_modules/@keystonehq/bc-ur-registry-sol": {
       "version": "0.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@keystonehq/bc-ur-registry-sol/-/bc-ur-registry-sol-0.3.1.tgz",
+      "integrity": "sha512-Okr5hwPxBZxB4EKLK1GSC9vsrh/tFMQ5dvs3EQ9NCOmCn7CXdXIMSeafrpGCHk484Jf5c6X0Wq0yf0VqY2A/8Q==",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.5.0",
         "bs58check": "^2.1.2",
@@ -3537,7 +4135,8 @@
     },
     "node_modules/@keystonehq/sdk": {
       "version": "0.13.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@keystonehq/sdk/-/sdk-0.13.1.tgz",
+      "integrity": "sha512-545l83TE5t1cyUZUaNqZOAh15ibWOg9QbK/YeLwnrxt+GOod+ATk3j9SpN6yTSLO8DNl2/x6dKRIFVtTEkZDAg==",
       "dependencies": {
         "@ngraveio/bc-ur": "^1.0.0",
         "qrcode.react": "^1.0.1",
@@ -3551,7 +4150,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/qrcode.react": {
       "version": "1.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-1.0.1.tgz",
+      "integrity": "sha512-8d3Tackk8IRLXTo67Y+c1rpaiXjoz/Dd2HpcMdW//62/x8J1Nbho14Kh8x974t9prsLHN6XqVgcnRiBGFptQmg==",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.0",
@@ -3563,7 +4163,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react": {
       "version": "16.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -3575,7 +4176,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react-dom": {
       "version": "16.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -3588,7 +4190,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/react-qr-reader": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-2.2.1.tgz",
+      "integrity": "sha512-EL5JEj53u2yAOgtpAKAVBzD/SiKWn0Bl7AZy6ZrSf1lub7xHwtaXe6XSx36Wbhl1VMGmvmrwYMRwO1aSCT2fwA==",
       "dependencies": {
         "jsqr": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -3601,7 +4204,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/scheduler": {
       "version": "0.19.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -3609,7 +4213,8 @@
     },
     "node_modules/@keystonehq/sdk/node_modules/typescript": {
       "version": "4.9.5",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3620,7 +4225,8 @@
     },
     "node_modules/@keystonehq/sol-keyring": {
       "version": "0.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@keystonehq/sol-keyring/-/sol-keyring-0.3.1.tgz",
+      "integrity": "sha512-RU6I3HQrQ9NpRDP9TwlBIy5DftVcNcyk0NWfhkPy/YanhMcCB0cRPw68iQl1rMnR6n1G2+YrBHMxm6swCW+B4Q==",
       "dependencies": {
         "@keystonehq/bc-ur-registry": "^0.5.0",
         "@keystonehq/bc-ur-registry-sol": "^0.3.1",
@@ -3632,18 +4238,21 @@
     },
     "node_modules/@keystonehq/sol-keyring/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@keystonehq/sol-keyring/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet": {
       "version": "0.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@kunalabs-io/sui-snap-wallet/-/sui-snap-wallet-0.4.3.tgz",
+      "integrity": "sha512-cmSbuxTwwif0jmh5M/famqiG/A7hF6TokUXcy6/VA46Wun8pix9839JVr+vp1iLh5T3PvG+KgchSEgJ9vn5Usg==",
       "dependencies": {
         "@metamask/detect-provider": "^2.0.0",
         "@metamask/providers": "^15.0.0",
@@ -3655,14 +4264,17 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -3683,7 +4295,8 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/@mysten/wallet-standard": {
       "version": "0.10.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.10.3.tgz",
+      "integrity": "sha512-StEMbJ7YkdjxoScmOJJjt9JaNgoRLD3FgU4LGFrKFtMXOhPu1Z4WF3qgfYBr+C3UgDh+JNiDIfN9TiGeM/Ahpw==",
       "dependencies": {
         "@mysten/sui.js": "0.50.1",
         "@wallet-standard/core": "1.0.3"
@@ -3691,25 +4304,29 @@
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@kunalabs-io/sui-snap-wallet/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@ledgerhq/devices": {
       "version": "6.27.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/devices/-/devices-6.27.1.tgz",
+      "integrity": "sha512-jX++oy89jtv7Dp2X6gwt3MMkoajel80JFWcdc0HCouwDsV1mVJ3SQdwl/bQU0zd8HI6KebvUP95QTwbQLLK/RQ==",
       "dependencies": {
         "@ledgerhq/errors": "^6.10.0",
         "@ledgerhq/logs": "^6.10.0",
@@ -3719,7 +4336,8 @@
     },
     "node_modules/@ledgerhq/devices/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3729,11 +4347,13 @@
     },
     "node_modules/@ledgerhq/errors": {
       "version": "6.10.2",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.2.tgz",
+      "integrity": "sha512-iMfEJPWaan8QaZw87WMUnFFRJqveE3FpU2ObTE0ydTJLPJNOUJjjurGBklqdWM/j5BIQvpi3byGKFChfNg8CaQ=="
     },
     "node_modules/@ledgerhq/hw-transport": {
       "version": "6.27.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.1.tgz",
+      "integrity": "sha512-hnE4/Fq1YzQI4PA1W0H8tCkI99R3UWDb3pJeZd6/Xs4Qw/q1uiQO+vNLC6KIPPhK0IajUfuI/P2jk0qWcMsuAQ==",
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -3742,7 +4362,8 @@
     },
     "node_modules/@ledgerhq/hw-transport-webhid": {
       "version": "6.27.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/hw-transport-webhid/-/hw-transport-webhid-6.27.1.tgz",
+      "integrity": "sha512-u74rBYlibpbyGblSn74fRs2pMM19gEAkYhfVibq0RE1GNFjxDMFC1n7Sb+93Jqmz8flyfB4UFJsxs8/l1tm2Kw==",
       "dependencies": {
         "@ledgerhq/devices": "^6.27.1",
         "@ledgerhq/errors": "^6.10.0",
@@ -3752,21 +4373,27 @@
     },
     "node_modules/@ledgerhq/logs": {
       "version": "6.12.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.12.0.tgz",
+      "integrity": "sha512-ExDoj1QV5eC6TEbMdLUMMk9cfvNKhhv5gXol4SmULRVCx/3iyCPhJ74nsb3S0Vb+/f+XujBEj3vQn5+cwS0fNA=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
     "node_modules/@lit/reactive-element": {
       "version": "1.6.3",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@manahippo/aptos-wallet-adapter": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@manahippo/aptos-wallet-adapter/-/aptos-wallet-adapter-1.0.10.tgz",
+      "integrity": "sha512-3i3OinlnoFlYEOw0ixjsRQQWFVSdecIBhxJqxHdN4kV+Vda/St+NAB7zzVZ9Mp0gY80UbWTRp9/IcRrfdpcKFg==",
+      "deprecated": "No longer maintained. Consider using https://github.com/aptos-labs/aptos-wallet-adapter instead",
       "dependencies": {
         "@blocto/sdk": "^0.3.1",
         "@fewcha/web3": "0.1.32",
@@ -3784,7 +4411,8 @@
     },
     "node_modules/@mayanfinance/swap-sdk": {
       "version": "9.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-9.3.0.tgz",
+      "integrity": "sha512-Pm+lYqaEZl3JTTFYF74KqD0ncEaKu416u+AehgqKWKfBbSw5clASfrgFceT6+tB/Vrft2pincok/iSJ98g1s4Q==",
       "dependencies": {
         "@solana/buffer-layout": "^4 || ^3",
         "@solana/web3.js": "^1.87.6",
@@ -3796,7 +4424,8 @@
     },
     "node_modules/@mayanfinance/wormhole-sdk-route": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mayanfinance/wormhole-sdk-route/-/wormhole-sdk-route-1.1.0.tgz",
+      "integrity": "sha512-gYOVK2Ky0dFliU7ltBFvLLZqrx72djFiYMaTQjzQeXwsXsVa+bbBdYgHPF8Rm99qF2Oh2Swm/RwnhdspfIVzNw==",
       "dependencies": {
         "@mayanfinance/swap-sdk": "9.3.0",
         "axios": "^1.4.0"
@@ -3814,13 +4443,16 @@
     },
     "node_modules/@metamask/detect-provider": {
       "version": "2.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
+      "integrity": "sha512-sFpN+TX13E9fdBDh9lvQeZdJn4qYoRb/6QF2oZZK/Pn559IhCFacPMU1rMuqyXoFQF3JSJfii2l98B87QDPeCQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/eth-json-rpc-provider": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-json-rpc-provider/-/eth-json-rpc-provider-1.0.1.tgz",
+      "integrity": "sha512-whiUMPlAOrVGmX8aKYVPvlKyG4CpQXiNNyt74vE1xb5sPvmx5oA7B/kOi/JdBvhGQq97U1/AVdXEdk2zkP8qyA==",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.0.0",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -3832,7 +4464,8 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -3840,7 +4473,8 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -3853,7 +4487,8 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
+      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -3867,7 +4502,8 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3877,14 +4513,16 @@
     },
     "node_modules/@metamask/eth-json-rpc-provider/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@metamask/eth-sig-util": {
       "version": "4.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
       "dependencies": {
         "ethereumjs-abi": "^0.6.8",
         "ethereumjs-util": "^6.2.1",
@@ -3898,18 +4536,21 @@
     },
     "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
       "version": "4.11.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -3930,7 +4571,8 @@
     },
     "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -3943,7 +4585,8 @@
     },
     "node_modules/@metamask/json-rpc-engine": {
       "version": "7.3.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-engine/-/json-rpc-engine-7.3.3.tgz",
+      "integrity": "sha512-dwZPq8wx9yV3IX2caLi9q9xZBw2XeIoYqdyihDDDpuHVCEiqadJLwqM3zy+uwf6F1QYQ65A8aOMQg1Uw7LMLNg==",
       "dependencies": {
         "@metamask/rpc-errors": "^6.2.1",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -3955,7 +4598,8 @@
     },
     "node_modules/@metamask/json-rpc-middleware-stream": {
       "version": "6.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/json-rpc-middleware-stream/-/json-rpc-middleware-stream-6.0.2.tgz",
+      "integrity": "sha512-jtyx3PRfc1kqoLpYveIVQNwsxYKefc64/LCl9h9Da1m3nUKEvypbYuXSIwi237qvOjKmNHQKsDOZg6f4uBf62Q==",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.3.2",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -3968,7 +4612,8 @@
     },
     "node_modules/@metamask/object-multiplex": {
       "version": "2.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/object-multiplex/-/object-multiplex-2.1.0.tgz",
+      "integrity": "sha512-4vKIiv0DQxljcXwfpnbsXcfa5glMj5Zg9mqn4xpIWqkv6uJ2ma5/GtUfLFSxhlxnR8asRMv8dDmWya1Tc1sDFA==",
       "dependencies": {
         "once": "^1.4.0",
         "readable-stream": "^3.6.2"
@@ -3979,7 +4624,8 @@
     },
     "node_modules/@metamask/providers": {
       "version": "15.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@metamask/providers/-/providers-15.0.0.tgz",
+      "integrity": "sha512-FXvL1NQNl6I7fMOJTfQYcBlBZ33vSlm6w80cMpmn8sJh0Lb7wcBpe02UwBsNlARnI+Qsr26XeDs6WHUHQh8CuA==",
       "dependencies": {
         "@metamask/json-rpc-engine": "^7.3.2",
         "@metamask/json-rpc-middleware-stream": "^6.0.2",
@@ -4000,7 +4646,8 @@
     },
     "node_modules/@metamask/rpc-errors": {
       "version": "6.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-6.4.0.tgz",
+      "integrity": "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg==",
       "dependencies": {
         "@metamask/utils": "^9.0.0",
         "fast-safe-stringify": "^2.0.6"
@@ -4011,7 +4658,8 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -4019,7 +4667,8 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -4032,7 +4681,8 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/@metamask/utils": {
       "version": "9.3.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-9.3.0.tgz",
+      "integrity": "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g==",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.1.0",
@@ -4050,7 +4700,8 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4060,32 +4711,36 @@
     },
     "node_modules/@metamask/rpc-errors/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@metamask/safe-event-emitter": {
       "version": "3.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-3.1.2.tgz",
+      "integrity": "sha512-5yb2gMI1BDm0JybZezeoX/3XhPDOtTbcFvpTXM9kxsoZjPZFh4XciqRbpD6N86HYZqWDhEaKUDuOyR0sQHEjMA==",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/@metamask/superstruct": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@metamask/superstruct/-/superstruct-3.1.0.tgz",
+      "integrity": "sha512-N08M56HdOgBfRKkrgCMZvQppkZGcArEop3kixNEtVbJKm6P9Cfg0YkI6X0s1g78sNrj2fWUwvJADdZuzJgFttA==",
       "engines": {
         "node": ">=16.0.0"
       }
     },
     "node_modules/@metamask/utils": {
       "version": "8.5.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-8.5.0.tgz",
+      "integrity": "sha512-I6bkduevXb72TIM9q2LRO63JSsF9EXduh3sBr9oybNX2hNNpr/j1tEjXrsG0Uabm4MJ1xkGAQEMwifvKZIkyxQ==",
       "dependencies": {
         "@ethereumjs/tx": "^4.2.0",
         "@metamask/superstruct": "^3.0.0",
@@ -4103,7 +4758,8 @@
     },
     "node_modules/@metamask/utils/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -4111,7 +4767,8 @@
     },
     "node_modules/@metamask/utils/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -4124,7 +4781,8 @@
     },
     "node_modules/@metamask/utils/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4134,19 +4792,21 @@
     },
     "node_modules/@metamask/utils/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@microsoft/api-extractor": {
       "version": "7.48.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.48.1.tgz",
+      "integrity": "sha512-HN9Osa1WxqLM66RaqB5nPAadx+nTIQmY/XtkFdaJvusjG8Tus++QqZtD7KPZDSkhEMGHsYeSyeU8qUzCDUXPjg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.30.1",
         "@microsoft/tsdoc": "~0.15.1",
@@ -4168,8 +4828,9 @@
     },
     "node_modules/@microsoft/api-extractor-model": {
       "version": "7.30.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.1.tgz",
+      "integrity": "sha512-CTS2PlASJHxVY8hqHORVb1HdECWOEMcMnM6/kDkPr0RZapAFSIHhg9D4jxuE8g+OWYHtPc10LCpmde5pylTRlA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
@@ -4178,8 +4839,9 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4189,8 +4851,9 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/minimatch": {
       "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4200,8 +4863,9 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4214,16 +4878,18 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
       "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4234,18 +4900,21 @@
     },
     "node_modules/@microsoft/api-extractor/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.15.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "dev": true
     },
     "node_modules/@microsoft/tsdoc-config": {
       "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.17.1.tgz",
+      "integrity": "sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.15.1",
         "ajv": "~8.12.0",
@@ -4255,8 +4924,9 @@
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
       "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4270,19 +4940,22 @@
     },
     "node_modules/@microsoft/tsdoc-config/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/@mobily/ts-belt": {
       "version": "3.13.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mobily/ts-belt/-/ts-belt-3.13.1.tgz",
+      "integrity": "sha512-K5KqIhPI/EoCTbA6CGbrenM9s41OouyK8A03fGJJcla/zKucsgLbz8HNbeseoLarRPgyWJsUyCYqFhI7t3Ra9Q==",
       "engines": {
         "node": ">= 10.*"
       }
     },
     "node_modules/@motionone/animation": {
       "version": "10.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
+      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
       "dependencies": {
         "@motionone/easing": "^10.18.0",
         "@motionone/types": "^10.17.1",
@@ -4292,7 +4965,8 @@
     },
     "node_modules/@motionone/dom": {
       "version": "10.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.18.0.tgz",
+      "integrity": "sha512-bKLP7E0eyO4B2UaHBBN55tnppwRnaE3KFfh3Ps9HhnAkar3Cb69kUCJY9as8LrccVYKgHA+JY5dOQqJLOPhF5A==",
       "dependencies": {
         "@motionone/animation": "^10.18.0",
         "@motionone/generators": "^10.18.0",
@@ -4304,7 +4978,8 @@
     },
     "node_modules/@motionone/easing": {
       "version": "10.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
+      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
       "dependencies": {
         "@motionone/utils": "^10.18.0",
         "tslib": "^2.3.1"
@@ -4312,7 +4987,8 @@
     },
     "node_modules/@motionone/generators": {
       "version": "10.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
+      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
       "dependencies": {
         "@motionone/types": "^10.17.1",
         "@motionone/utils": "^10.18.0",
@@ -4321,7 +4997,8 @@
     },
     "node_modules/@motionone/svelte": {
       "version": "10.16.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.4.tgz",
+      "integrity": "sha512-zRVqk20lD1xqe+yEDZhMYgftsuHc25+9JSo+r0a0OWUJFocjSV9D/+UGhX4xgJsuwB9acPzXLr20w40VnY2PQA==",
       "dependencies": {
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
@@ -4329,11 +5006,13 @@
     },
     "node_modules/@motionone/types": {
       "version": "10.17.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
+      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A=="
     },
     "node_modules/@motionone/utils": {
       "version": "10.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
+      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
       "dependencies": {
         "@motionone/types": "^10.17.1",
         "hey-listen": "^1.0.8",
@@ -4342,7 +5021,9 @@
     },
     "node_modules/@motionone/vue": {
       "version": "10.16.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.4.tgz",
+      "integrity": "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg==",
+      "deprecated": "Motion One for Vue is deprecated. Use Oku Motion instead https://oku-ui.com/motion",
       "dependencies": {
         "@motionone/dom": "^10.16.4",
         "tslib": "^2.3.1"
@@ -4350,7 +5031,8 @@
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.12.tgz",
+      "integrity": "sha512-rkN+bPpe2Xn8h4ZLqKy5JsZt3nzMyTJ2ySdyLHHf0IL+PrxS46dxOIC1i66R8qi14kJBHfy7Byqv1yUvpwf0iw==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
@@ -4358,7 +5040,8 @@
     },
     "node_modules/@mui/icons-material": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.12.tgz",
+      "integrity": "sha512-4Ocmbl1uzkWxAdYYARCLySJNqALgrJ+Fdr95FLpKZV7zMZxyoJRdPTO/CgUxjFjlj9Sy2Gi7j3HX4f5HS2GLeQ==",
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -4382,7 +5065,8 @@
     },
     "node_modules/@mui/material": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.12.tgz",
+      "integrity": "sha512-+M0UPy0xa9xGo8TV1vp9Mmf85TNUqpk7OoSiw+BaZf3D584S3aqfl+CL+EBTt9t52A97GnCjVNvXTO7hmLqhHw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.16.12",
@@ -4425,7 +5109,8 @@
     },
     "node_modules/@mui/private-theming": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.16.12.tgz",
+      "integrity": "sha512-hhLTSZxsazwZZ4bUAKgFcbsnfCrwizSnJI7/bXf/R9/tZkZBy+bKY05/Au/bIgGKzuZ4KTlKlPn+U/uufEXrNw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/utils": "^5.16.12",
@@ -4450,7 +5135,8 @@
     },
     "node_modules/@mui/styled-engine": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.16.12.tgz",
+      "integrity": "sha512-TMf3SN19rkJPh1hQZTjoY8UsJa5qExfr78owwCuEZLjIhsajAYiWmbJzJ8mM3grEWLiP3MziDA4zy4LFNri12Q==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@emotion/cache": "^11.13.5",
@@ -4480,7 +5166,8 @@
     },
     "node_modules/@mui/system": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.16.12.tgz",
+      "integrity": "sha512-rDsndVl0ug0Ex2rZt8x0WIF3Zc0EMFT2TmRVWP4jzk38aLS6WsxryXAZUQa0BKEnB3vfx1pSP/xa44TdKQ94dg==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/private-theming": "^5.16.12",
@@ -4518,7 +5205,8 @@
     },
     "node_modules/@mui/types": {
       "version": "7.2.20",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.20.tgz",
+      "integrity": "sha512-straFHD7L8v05l/N5vcWk+y7eL9JF0C2mtph/y4BPm3gn2Eh61dDwDB65pa8DLss3WJfDXYC7Kx5yjP0EmXpgw==",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -4530,7 +5218,8 @@
     },
     "node_modules/@mui/utils": {
       "version": "5.16.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.16.12.tgz",
+      "integrity": "sha512-p3JAq7nA0ur8M/zLnBvR6ZeAjM8mD4LnPdKfsJAYPS26w4eDQjQzl55XvoOmch2MeXhmWaO4Pkvs/xurrISNBw==",
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/types": "^7.2.15",
@@ -4558,25 +5247,30 @@
     },
     "node_modules/@mysten/bcs": {
       "version": "0.7.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.1.tgz",
+      "integrity": "sha512-wFPb8bkhwrbiStfZMV5rFM7J+umpke59/dNjDp+UYJKykNlW23LCk2ePyEUvGdb62HGJM1jyOJ8g4egE3OmdKA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/bcs/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@mysten/bcs/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/sui.js": {
       "version": "0.32.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.32.2.tgz",
+      "integrity": "sha512-/Hm4xkGolJhqj8FvQr7QSHDTlxIvL52mtbOao9f75YjrBh7y1Uh9kbJSY7xiTF1NY9sv6p5hUVlYRJuM0Hvn9A==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@mysten/bcs": "0.7.1",
         "@noble/curves": "^1.0.0",
@@ -4595,14 +5289,17 @@
     },
     "node_modules/@mysten/sui.js/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base": {
       "version": "0.9.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/wallet-adapter-base/-/wallet-adapter-base-0.9.0.tgz",
+      "integrity": "sha512-Obcfd30AC0Tcyvqc9+h0vvjrRB6Td2PNWhxRlTq/hSxDY66M3XqTLgoO8wDBtz+91oga4obAYvM02m7xV7X0Zw==",
+      "deprecated": "Wallet adapters have been deprecated in favor of the Wallet Standard. Please upgrade to the latest Wallet Kit versions.",
       "dependencies": {
         "@mysten/sui.js": "0.40.0",
         "@mysten/wallet-standard": "0.6.0"
@@ -4610,14 +5307,17 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/bcs": {
       "version": "0.7.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.3.tgz",
+      "integrity": "sha512-fbusBfsyc2MpTACi72H5edWJ670T84va+qn9jSPpb5BzZ+pzUM1Q0ApPrF5OT+mB1o5Ng+mxPQpBCZQkfiV2TA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/sui.js": {
       "version": "0.40.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.40.0.tgz",
+      "integrity": "sha512-PEGdMe+QgpIdDIpyO4/yb+CK4x3Hki+kYPbQ5n3DVsWyb2ztFwB+5oYdc7qG3QkniO1lnCrlSHqZ5mN+x3RzrQ==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@mysten/bcs": "0.7.3",
         "@noble/curves": "^1.1.0",
@@ -4636,7 +5336,8 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/@mysten/wallet-standard": {
       "version": "0.6.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.6.0.tgz",
+      "integrity": "sha512-xE/OijN9zIPoTjTWuxlYMHtp7kXPcAR8dDAbxOIH5h7EZCTk+G6p+SzDp8jV5magf50VcYP0cVjS4CQLx1wQuQ==",
       "dependencies": {
         "@mysten/sui.js": "0.40.0",
         "@wallet-standard/core": "1.0.3"
@@ -4644,25 +5345,29 @@
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/wallet-adapter-base/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard": {
       "version": "0.5.14",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/wallet-standard/-/wallet-standard-0.5.14.tgz",
+      "integrity": "sha512-O4pBU5nO5zBMuhIpOiMkJinxUo68M1m4ca4AQNM5gYLMpuHipcHDNPpCINIyIsCsff61ilGDzPhZU4R8+zZ/2A==",
       "dependencies": {
         "@mysten/sui.js": "0.39.0",
         "@wallet-standard/core": "1.0.3"
@@ -4670,14 +5375,17 @@
     },
     "node_modules/@mysten/wallet-standard/node_modules/@mysten/bcs": {
       "version": "0.7.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.7.3.tgz",
+      "integrity": "sha512-fbusBfsyc2MpTACi72H5edWJ670T84va+qn9jSPpb5BzZ+pzUM1Q0ApPrF5OT+mB1o5Ng+mxPQpBCZQkfiV2TA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard/node_modules/@mysten/sui.js": {
       "version": "0.39.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.39.0.tgz",
+      "integrity": "sha512-fJu6k7+Qb1z2h9i5Jai0sTWmaGP1UT6d/JIXhEwMZ6cz+13GT/8zRp8kUhP7Oq9Z2hxmwfy1ROptbsrv/x9V8A==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@mysten/bcs": "0.7.3",
         "@noble/curves": "^1.1.0",
@@ -4696,25 +5404,29 @@
     },
     "node_modules/@mysten/wallet-standard/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@mysten/wallet-standard/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@mysten/wallet-standard/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@ngraveio/bc-ur": {
       "version": "1.1.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ngraveio/bc-ur/-/bc-ur-1.1.13.tgz",
+      "integrity": "sha512-j73akJMV4+vLR2yQ4AphPIT5HZmxVjn/LxpL7YHoINnXoH6ccc90Zzck6/n6a3bCXOVZwBxq+YHwbAKRV+P8Zg==",
       "dependencies": {
         "@keystonehq/alias-sampling": "^0.1.1",
         "assert": "^2.0.0",
@@ -4727,7 +5439,8 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -4740,7 +5453,8 @@
     },
     "node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4750,7 +5464,8 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.6.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4760,7 +5475,8 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -4771,14 +5487,16 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -4789,7 +5507,8 @@
     },
     "node_modules/@open-rpc/client-js": {
       "version": "1.8.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@open-rpc/client-js/-/client-js-1.8.1.tgz",
+      "integrity": "sha512-vV+Hetl688nY/oWI9IFY0iKDrWuLdYhf7OIKI6U1DcnJV7r4gAgwRJjEr1QVYszUc0gjkHoQJzqevmXMGLyA0g==",
       "dependencies": {
         "isomorphic-fetch": "^3.0.0",
         "isomorphic-ws": "^5.0.0",
@@ -4799,14 +5518,16 @@
     },
     "node_modules/@open-rpc/client-js/node_modules/isomorphic-ws": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/@open-rpc/client-js/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -4825,7 +5546,8 @@
     },
     "node_modules/@openblockhq/dappsdk": {
       "version": "5.0.15",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@openblockhq/dappsdk/-/dappsdk-5.0.15.tgz",
+      "integrity": "sha512-AtoswQtRRDOoryR0pXFYVphS+3ad4H7T8M0ItRTlIQ4SdEyPunKeb8mxN6EOkm0veicUM+mWOeh9ReCc+MI2KA==",
       "dependencies": {
         "@mysten/sui.js": "^0.32.1",
         "@mysten/wallet-standard": "^0.5.3",
@@ -4843,19 +5565,22 @@
     },
     "node_modules/@openblockhq/dappsdk/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@openblockhq/dappsdk/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+      "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "detect-libc": "^1.0.3",
         "is-glob": "^4.0.3",
@@ -4885,12 +5610,32 @@
         "@parcel/watcher-win32-x64": "2.5.0"
       }
     },
-    "node_modules/@parcel/watcher-darwin-arm64": {
+    "node_modules/@parcel/watcher-android-arm64": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+      "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
       "cpu": [
         "arm64"
       ],
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+      "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+      "cpu": [
+        "arm64"
+      ],
       "optional": true,
       "os": [
         "darwin"
@@ -4903,12 +5648,165 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+      "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+      "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+      "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+      "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+      "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+      "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+      "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+      "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher-wasm": {
       "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.0.tgz",
+      "integrity": "sha512-Z4ouuR8Pfggk1EYYbTaIoxc+Yv4o7cGQnH0Xy8+pQ+HbiW+ZnwhcD2LPf/prfq1nIWpAxjOkQ8uSMFWMtBLiVQ==",
       "bundleDependencies": [
         "napi-wasm"
       ],
-      "license": "MIT",
       "dependencies": {
         "is-glob": "^4.0.3",
         "micromatch": "^4.0.5",
@@ -4927,13 +5825,72 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+      "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+      "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
+      "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/@parcel/watcher/node_modules/node-addon-api": {
       "version": "7.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="
     },
     "node_modules/@particle-network/analytics": {
       "version": "1.0.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@particle-network/analytics/-/analytics-1.0.2.tgz",
+      "integrity": "sha512-E4EpTRYcfNOkxj+bgNdQydBrvdLGo4HfVStZCuOr3967dYek30r6L7Nkaa9zJXRE2eGT4lPvcAXDV2WxDZl/Xg==",
       "dependencies": {
         "hash.js": "^1.1.7",
         "uuidv4": "^6.2.13"
@@ -4941,7 +5898,8 @@
     },
     "node_modules/@particle-network/auth": {
       "version": "1.3.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@particle-network/auth/-/auth-1.3.1.tgz",
+      "integrity": "sha512-hu6ie5RjjN4X+6y/vfjyCsSX3pQuS8k8ZoMb61QWwhWsnZXKzpBUVeAEk55aGfxxXY+KfBkSmZosyaZHGoHnfw==",
       "dependencies": {
         "@particle-network/analytics": "^1.0.1",
         "@particle-network/chains": "*",
@@ -4952,11 +5910,13 @@
     },
     "node_modules/@particle-network/chains": {
       "version": "1.8.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@particle-network/chains/-/chains-1.8.0.tgz",
+      "integrity": "sha512-Mh96ihIdfI9KoZ5/HBayMdV46caO4dVH40R6KcBHUiFU8eq91iIxItAdZETlCt4HuHX57DUYVAj+B7u3sXXgnQ=="
     },
     "node_modules/@particle-network/crypto": {
       "version": "1.0.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@particle-network/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-GgvHmHcFiNkCLZdcJOgctSbgvs251yp+EAdUydOE3gSoIxN6KEr/Snu9DebENhd/nFb7FDk5ap0Hg49P7pj1fg==",
       "dependencies": {
         "crypto-js": "^4.1.1",
         "uuidv4": "^6.2.13"
@@ -4964,7 +5924,8 @@
     },
     "node_modules/@particle-network/solana-wallet": {
       "version": "1.3.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@particle-network/solana-wallet/-/solana-wallet-1.3.2.tgz",
+      "integrity": "sha512-KviKVP87OtWq813y8IumM3rIQMNkTjHBaQmCUbTWGebz3csFOv54JIoy1r+3J3NnA+mBxBdZeRedZ5g+07v75w==",
       "dependencies": {
         "@particle-network/auth": "^1.3.1"
       },
@@ -4975,11 +5936,13 @@
     },
     "node_modules/@pedrouid/environment": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -4987,12 +5950,14 @@
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.28",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
+      "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
+      "dev": true
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5000,7 +5965,8 @@
     },
     "node_modules/@project-serum/anchor": {
       "version": "0.26.0",
-      "license": "(MIT OR Apache-2.0)",
+      "resolved": "https://registry.npmjs.org/@project-serum/anchor/-/anchor-0.26.0.tgz",
+      "integrity": "sha512-Nq+COIjE1135T7qfnOHEn7E0q39bQTgXLFk837/rgFe6Hkew9WML7eHsS+lSYD2p3OJaTiUOHTAq1lHy36oIqQ==",
       "dependencies": {
         "@coral-xyz/borsh": "^0.26.0",
         "@solana/web3.js": "^1.68.0",
@@ -5024,7 +5990,8 @@
     },
     "node_modules/@project-serum/anchor/node_modules/@coral-xyz/borsh": {
       "version": "0.26.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@coral-xyz/borsh/-/borsh-0.26.0.tgz",
+      "integrity": "sha512-uCZ0xus0CszQPHYfWAqKS5swS1UxvePu83oOF+TWpUkedsNlg6p2p4azxZNSSqwXb9uXMFgxhuMBX9r3Xoi0vQ==",
       "dependencies": {
         "bn.js": "^5.1.2",
         "buffer-layout": "^1.2.0"
@@ -5038,7 +6005,8 @@
     },
     "node_modules/@project-serum/sol-wallet-adapter": {
       "version": "0.2.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@project-serum/sol-wallet-adapter/-/sol-wallet-adapter-0.2.6.tgz",
+      "integrity": "sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g==",
       "dependencies": {
         "bs58": "^4.0.1",
         "eventemitter3": "^4.0.7"
@@ -5052,23 +6020,28 @@
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -5076,27 +6049,33 @@
     },
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.7.tgz",
+      "integrity": "sha512-t7v8ZPxhhKgOKtU+uyJT13lu4vL7az5aFi4IdoDs/eS548edn2M8Ik9h8fxgvMjGoAUVFSt6ZC1P5cWmQ014QQ==",
       "dependencies": {
         "immer": "^9.0.21",
         "redux": "^4.2.1",
@@ -5118,8 +6097,9 @@
     },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
+      "integrity": "sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
         "estree-walker": "^2.0.2",
@@ -5139,8 +6119,9 @@
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
+      "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -5158,22 +6139,258 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
+    "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
+      "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
+      "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
+      "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ]
     },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
+      "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
+      "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
+      "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
+      "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
+      "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
+      "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
+      "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
+      "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
+      "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
+      "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
+      "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
+      "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
+      "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
+      "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@rushstack/node-core-library": {
       "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.10.1.tgz",
+      "integrity": "sha512-BSb/KcyBHmUQwINrgtzo6jiH0HlGFmrUy33vO6unmceuVKTEyL2q+P0fQq2oB5hvXVWOEUhxB2QvlkZluvUEmg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "~8.13.0",
         "ajv-draft-04": "~1.0.0",
@@ -5195,8 +6412,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/ajv": {
       "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "json-schema-traverse": "^1.0.0",
@@ -5210,8 +6428,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/ajv-draft-04": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "ajv": "^8.5.0"
       },
@@ -5223,8 +6442,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5236,21 +6456,24 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/@rushstack/node-core-library/node_modules/jsonfile": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
-      "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5260,8 +6483,9 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5274,21 +6498,24 @@
     },
     "node_modules/@rushstack/node-core-library/node_modules/universalify": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
       }
     },
     "node_modules/@rushstack/node-core-library/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/@rushstack/rig-package": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.5.3.tgz",
+      "integrity": "sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "resolve": "~1.22.1",
         "strip-json-comments": "~3.1.1"
@@ -5296,8 +6523,9 @@
     },
     "node_modules/@rushstack/terminal": {
       "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.14.4.tgz",
+      "integrity": "sha512-NxACqERW0PHq8Rpq1V6v5iTHEwkRGxenjEW+VWqRYQ8T9puUzgmGHmEZUaUEDHAe9Qyvp0/Ew04sAiQw9XjhJg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rushstack/node-core-library": "5.10.1",
         "supports-color": "~8.1.1"
@@ -5313,8 +6541,9 @@
     },
     "node_modules/@rushstack/terminal/node_modules/supports-color": {
       "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5327,8 +6556,9 @@
     },
     "node_modules/@rushstack/ts-command-line": {
       "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.2.tgz",
+      "integrity": "sha512-JJ7XZX5K3ThBBva38aomgsPv1L7FV6XmSOcR6HtM7HDFZJkepqT65imw26h9ggGqMjsY0R9jcl30tzKcVj9aOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rushstack/terminal": "0.14.4",
         "@types/argparse": "1.0.38",
@@ -5338,20 +6568,23 @@
     },
     "node_modules/@rushstack/ts-command-line/node_modules/argparse": {
       "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
     },
     "node_modules/@rushstack/ts-command-line/node_modules/sprintf-js": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "node_modules/@safe-global/safe-apps-provider": {
       "version": "0.18.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.5.tgz",
+      "integrity": "sha512-9v9wjBi3TwLsEJ3C2ujYoexp3pFJ0omDLH/GX91e2QB+uwCKTBYyhxFSrTQ9qzoyQd+bfsk4gjOGW87QcJhf7g==",
       "dependencies": {
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "events": "^3.3.0"
@@ -5359,7 +6592,8 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/@safe-global/safe-apps-sdk": {
       "version": "9.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
+      "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^2.1.1"
@@ -5367,7 +6601,8 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/abitype": {
       "version": "1.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -5386,26 +6621,28 @@
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/isows": {
       "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/@safe-global/safe-apps-provider/node_modules/viem": {
       "version": "2.21.55",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.55.tgz",
+      "integrity": "sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@noble/curves": "1.7.0",
         "@noble/hashes": "1.6.1",
@@ -5428,7 +6665,8 @@
     },
     "node_modules/@safe-global/safe-apps-sdk": {
       "version": "8.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-8.1.0.tgz",
+      "integrity": "sha512-XJbEPuaVc7b9n23MqlF6c+ToYIS3f7P2Sel8f3cSBQ9WORE4xrSuvhMpK9fDSFqJ7by/brc+rmJR/5HViRr0/w==",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^1.0.0"
@@ -5436,21 +6674,24 @@
     },
     "node_modules/@safe-global/safe-gateway-typescript-sdk": {
       "version": "3.22.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.22.4.tgz",
+      "integrity": "sha512-Z7Z8w3GEJdJ/paF+NK23VN4AwqWPadq0AeRYjYLjIBiPWpRB2UO/FKq7ONABEq0YFgNPklazIV4IExQU1gavXA==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@scure/base": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0",
@@ -5462,7 +6703,8 @@
     },
     "node_modules/@scure/bip39": {
       "version": "1.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
       "dependencies": {
         "@noble/hashes": "~1.6.0",
         "@scure/base": "~1.2.1"
@@ -5473,11 +6715,13 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.33.22",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.33.22.tgz",
+      "integrity": "sha512-auUj4k+f4pyrIVf4GW5UKquSZFHJWri06QgARy9C0t9ZTjJLIuNIrr1yl9bWcJWJ1Gz1vOvYN1D+QPaIlNMVkQ=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
       "engines": {
         "node": ">=10"
       },
@@ -5487,11 +6731,13 @@
     },
     "node_modules/@socket.io/component-emitter": {
       "version": "3.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
     },
     "node_modules/@solana/accounts": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-2.0.0.tgz",
+      "integrity": "sha512-1CE4P3QSDH5x+ZtSthMY2mn/ekROBnlT3/4f3CHDJicDvLQsgAq2yCvGHsYkK3ZA0mxhFLuhJVjuKASPnmG1rQ==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -5509,7 +6755,8 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -5522,7 +6769,8 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -5536,7 +6784,8 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -5552,7 +6801,8 @@
     },
     "node_modules/@solana/accounts/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5569,7 +6819,8 @@
     },
     "node_modules/@solana/accounts/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5579,14 +6830,16 @@
     },
     "node_modules/@solana/accounts/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/addresses": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-2.0.0.tgz",
+      "integrity": "sha512-8n3c/mUlH1/z+pM8e7OJ6uDSXw26Be0dgYiokiqblO66DGQ0d+7pqFUFZ5pEGjJ9PU2lDTSfY8rHf4cemOqwzQ==",
       "dependencies": {
         "@solana/assertions": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -5602,7 +6855,8 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -5615,7 +6869,8 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -5629,7 +6884,8 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -5645,7 +6901,8 @@
     },
     "node_modules/@solana/addresses/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5662,7 +6919,8 @@
     },
     "node_modules/@solana/addresses/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5672,14 +6930,16 @@
     },
     "node_modules/@solana/addresses/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/assertions": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-2.0.0.tgz",
+      "integrity": "sha512-NyPPqZRNGXs/GAjfgsw7YS6vCTXWt4ibXveS+ciy5sdmp/0v3pA6DlzYjleF9Sljrew0IiON15rjaXamhDxYfQ==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -5692,7 +6952,8 @@
     },
     "node_modules/@solana/assertions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5709,7 +6970,8 @@
     },
     "node_modules/@solana/assertions/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5719,14 +6981,16 @@
     },
     "node_modules/@solana/assertions/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -5736,7 +7000,8 @@
     },
     "node_modules/@solana/buffer-layout-utils": {
       "version": "0.2.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/web3.js": "^1.32.0",
@@ -5749,7 +7014,8 @@
     },
     "node_modules/@solana/codecs": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-data-structures": "2.0.0-rc.1",
@@ -5763,7 +7029,8 @@
     },
     "node_modules/@solana/codecs-core": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
       "dependencies": {
         "@solana/errors": "2.0.0-rc.1"
       },
@@ -5773,7 +7040,8 @@
     },
     "node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-numbers": "2.0.0-rc.1",
@@ -5785,7 +7053,8 @@
     },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/errors": "2.0.0-rc.1"
@@ -5796,7 +7065,8 @@
     },
     "node_modules/@solana/codecs-strings": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-numbers": "2.0.0-rc.1",
@@ -5809,7 +7079,8 @@
     },
     "node_modules/@solana/errors": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5823,7 +7094,8 @@
     },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5833,14 +7105,16 @@
     },
     "node_modules/@solana/errors/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/fast-stable-stringify": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-2.0.0.tgz",
+      "integrity": "sha512-EsIx9z+eoxOmC+FpzhEb+H67CCYTbs/omAqXD4EdEYnCHWrI1li1oYBV+NoKzfx8fKlX+nzNB7S/9kc4u7Etpw==",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5850,7 +7124,8 @@
     },
     "node_modules/@solana/functional": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-2.0.0.tgz",
+      "integrity": "sha512-Sj+sLiUTimnMEyGnSLGt0lbih2xPDUhxhonnrIkPwA+hjQ3ULGHAxeevHU06nqiVEgENQYUJ5rCtHs4xhUFAkQ==",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -5860,7 +7135,8 @@
     },
     "node_modules/@solana/instructions": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-2.0.0.tgz",
+      "integrity": "sha512-MiTEiNF7Pzp+Y+x4yadl2VUcNHboaW5WP52psBuhHns3GpbbruRv5efMpM9OEQNe1OsN+Eg39vjEidX55+P+DQ==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -5873,7 +7149,8 @@
     },
     "node_modules/@solana/instructions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5890,7 +7167,8 @@
     },
     "node_modules/@solana/instructions/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5900,14 +7178,16 @@
     },
     "node_modules/@solana/instructions/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/keys": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-2.0.0.tgz",
+      "integrity": "sha512-SSLSX8BXRvfLKBqsmBghmlhMKpwHeWd5CHi5zXgTS1BRrtiU6lcrTVC9ie6B+WaNNq7oe3e6K5bdbhu3fFZ+0g==",
       "dependencies": {
         "@solana/assertions": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -5923,7 +7203,8 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -5936,7 +7217,8 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -5950,7 +7232,8 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -5966,7 +7249,8 @@
     },
     "node_modules/@solana/keys/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -5983,7 +7267,8 @@
     },
     "node_modules/@solana/keys/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -5993,14 +7278,16 @@
     },
     "node_modules/@solana/keys/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/options": {
       "version": "2.0.0-rc.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
         "@solana/codecs-data-structures": "2.0.0-rc.1",
@@ -6014,7 +7301,8 @@
     },
     "node_modules/@solana/programs": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-2.0.0.tgz",
+      "integrity": "sha512-JPIKB61pWfODnsvEAaPALc6vR5rn7kmHLpFaviWhBtfUlEVgB8yVTR0MURe4+z+fJCPRV5wWss+svA4EeGDYzQ==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6028,7 +7316,8 @@
     },
     "node_modules/@solana/programs/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6045,7 +7334,8 @@
     },
     "node_modules/@solana/programs/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6055,14 +7345,16 @@
     },
     "node_modules/@solana/programs/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/promises": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-2.0.0.tgz",
+      "integrity": "sha512-4teQ52HDjK16ORrZe1zl+Q9WcZdQ+YEl0M1gk59XG7D0P9WqaVEQzeXGnKSCs+Y9bnB1u5xCJccwpUhHYWq6gg==",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -6072,7 +7364,8 @@
     },
     "node_modules/@solana/rpc": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-2.0.0.tgz",
+      "integrity": "sha512-TumQ9DFRpib/RyaIqLVfr7UjqSo7ldfzpae0tgjM93YjbItB4Z0VcUXc3uAFvkeYw2/HIMb46Zg43mkUwozjDg==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/fast-stable-stringify": "2.0.0",
@@ -6093,7 +7386,8 @@
     },
     "node_modules/@solana/rpc-api": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-2.0.0.tgz",
+      "integrity": "sha512-1FwitYxwADMF/6zKP2kNXg8ESxB6GhNBNW1c4f5dEmuXuBbeD/enLV3WMrpg8zJkIaaYarEFNbt7R7HyFzmURQ==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -6116,7 +7410,8 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6129,7 +7424,8 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6143,7 +7439,8 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6159,7 +7456,8 @@
     },
     "node_modules/@solana/rpc-api/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6176,7 +7474,8 @@
     },
     "node_modules/@solana/rpc-api/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6186,14 +7485,16 @@
     },
     "node_modules/@solana/rpc-api/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-parsed-types": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-2.0.0.tgz",
+      "integrity": "sha512-VCeY/oKVEtBnp8EDOc5LSSiOeIOLFIgLndcxqU0ij/cZaQ01DOoHbhluvhZtU80Z3dUeicec8TiMgkFzed+WhQ==",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -6203,7 +7504,8 @@
     },
     "node_modules/@solana/rpc-spec": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-2.0.0.tgz",
+      "integrity": "sha512-1uIDzj7vocCUqfOifjv1zAuxQ53ugiup/42edVFoQLOnJresoEZLL6WjnsJq4oCTccEAvGhUBI1WWKeZTGNxFQ==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/rpc-spec-types": "2.0.0"
@@ -6217,7 +7519,8 @@
     },
     "node_modules/@solana/rpc-spec-types": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-2.0.0.tgz",
+      "integrity": "sha512-G2lmhFhgtxMQd/D6B04BHGE7bm5dMZdIPQNOqVGhzNAVjrmyapD3JN2hKAbmaYPe97wLfZERw0Ux1u4Y6q7TqA==",
       "engines": {
         "node": ">=20.18.0"
       },
@@ -6227,7 +7530,8 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6244,7 +7548,8 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6254,14 +7559,16 @@
     },
     "node_modules/@solana/rpc-spec/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-2.0.0.tgz",
+      "integrity": "sha512-AdwMJHMrhlj7q1MPjZmVcKq3iLqMW3N0MT8kzIAP2vP+8o/d6Fn4aqGxoz2Hlfn3OYIZoYStN2VBtwzbcfEgMA==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/fast-stable-stringify": "2.0.0",
@@ -6284,7 +7591,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-api": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-2.0.0.tgz",
+      "integrity": "sha512-NAJQvSFXYIIf8zxsMFBCkSbZNZgT32pzPZ1V6ZAd+U2iDEjx3L+yFwoJgfOcHp8kAV+alsF2lIsGBlG4u+ehvw==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/keys": "2.0.0",
@@ -6303,7 +7611,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-2.0.0.tgz",
+      "integrity": "sha512-hSQDZBmcp2t+gLZsSBqs/SqVw4RuNSC7njiP46azyzW7oGg8X2YPV36AHGsHD12KPsc0UpT1OAZ4+AN9meVKww==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/functional": "2.0.0",
@@ -6320,7 +7629,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6337,7 +7647,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6347,14 +7658,16 @@
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-2.0.0.tgz",
+      "integrity": "sha512-VXMiI3fYtU1PkVVTXL87pcY48ZY8aCi1N6FqtxSP2xg/GASL01j1qbwyIL1OvoCqGyRgIxdd/YfaByW9wmWBhA==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/promises": "2.0.0",
@@ -6370,7 +7683,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6387,7 +7701,8 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6397,14 +7712,16 @@
     },
     "node_modules/@solana/rpc-subscriptions-spec/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6421,7 +7738,8 @@
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6431,14 +7749,16 @@
     },
     "node_modules/@solana/rpc-subscriptions/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transformers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-2.0.0.tgz",
+      "integrity": "sha512-H6tN0qcqzUangowsLLQtYXKJsf1Roe3/qJ1Cy0gv9ojY9uEvNbJqpeEj+7blv0MUZfEe+rECAwBhxxRKPMhYGw==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/functional": "2.0.0",
@@ -6454,7 +7774,8 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6471,7 +7792,8 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6481,14 +7803,16 @@
     },
     "node_modules/@solana/rpc-transformers/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transport-http": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-2.0.0.tgz",
+      "integrity": "sha512-UJLhKhhxDd1OPi8hb2AenHsDm1mofCBbhWn4bDCnH2Q3ulwYadUhcNqNbxjJPQ774VNhAf53SSI5A6PQo8IZSQ==",
       "dependencies": {
         "@solana/errors": "2.0.0",
         "@solana/rpc-spec": "2.0.0",
@@ -6504,7 +7828,8 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6521,7 +7846,8 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6531,18 +7857,21 @@
     },
     "node_modules/@solana/rpc-transport-http/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc-transport-http/node_modules/undici-types": {
       "version": "6.21.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/@solana/rpc-types": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-2.0.0.tgz",
+      "integrity": "sha512-o1ApB9PYR0A3XjVSOh//SOVWgjDcqMlR3UNmtqciuREIBmWqnvPirdOa5EJxD3iPhfA4gnNnhGzT+tMDeDW/Kw==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -6559,7 +7888,8 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6572,7 +7902,8 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6586,7 +7917,8 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6602,7 +7934,8 @@
     },
     "node_modules/@solana/rpc-types/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6619,7 +7952,8 @@
     },
     "node_modules/@solana/rpc-types/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6629,14 +7963,16 @@
     },
     "node_modules/@solana/rpc-types/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/rpc/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6653,7 +7989,8 @@
     },
     "node_modules/@solana/rpc/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6663,14 +8000,16 @@
     },
     "node_modules/@solana/rpc/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/signers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-2.0.0.tgz",
+      "integrity": "sha512-JEYJS3x/iKkqPV/3b1nLpX9lHib21wQKV3fOuu1aDLQqmX9OYKrnIIITYdnFDhmvGhpEpkkbPnqu7yVaFIBYsQ==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -6689,7 +8028,8 @@
     },
     "node_modules/@solana/signers/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6702,7 +8042,8 @@
     },
     "node_modules/@solana/signers/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6719,7 +8060,8 @@
     },
     "node_modules/@solana/signers/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6729,14 +8071,16 @@
     },
     "node_modules/@solana/signers/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/spl-token": {
       "version": "0.3.11",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -6752,7 +8096,8 @@
     },
     "node_modules/@solana/spl-token-metadata": {
       "version": "0.1.6",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
       },
@@ -6765,7 +8110,8 @@
     },
     "node_modules/@solana/subscribable": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-2.0.0.tgz",
+      "integrity": "sha512-Ex7d2GnTSNVMZDU3z6nKN4agRDDgCgBDiLnmn1hmt0iFo3alr3gRAqiqa7qGouAtYh9/29pyc8tVJCijHWJPQQ==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6778,7 +8124,8 @@
     },
     "node_modules/@solana/subscribable/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6795,7 +8142,8 @@
     },
     "node_modules/@solana/subscribable/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6805,14 +8153,16 @@
     },
     "node_modules/@solana/subscribable/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/sysvars": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-2.0.0.tgz",
+      "integrity": "sha512-8D4ajKcCYQsTG1p4k30lre2vjxLR6S5MftUGJnIaQObDCzGmaeA9GRti4Kk4gSPWVYFTBoj1ASx8EcEXaB3eIQ==",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/codecs": "2.0.0",
@@ -6828,7 +8178,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -6845,7 +8196,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6858,7 +8210,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6873,7 +8226,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -6887,7 +8241,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -6903,7 +8258,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -6920,7 +8276,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/@solana/options": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -6937,7 +8294,8 @@
     },
     "node_modules/@solana/sysvars/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -6947,14 +8305,16 @@
     },
     "node_modules/@solana/sysvars/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transaction-confirmation": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-2.0.0.tgz",
+      "integrity": "sha512-JkTw5gXLiqQjf6xK0fpVcoJ/aMp2kagtFSD/BAOazdJ3UYzOzbzqvECt6uWa3ConcMswQ2vXalVtI7ZjmYuIeg==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-strings": "2.0.0",
@@ -6976,7 +8336,8 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -6989,7 +8350,8 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7003,7 +8365,8 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7019,7 +8382,8 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7036,7 +8400,8 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7046,14 +8411,16 @@
     },
     "node_modules/@solana/transaction-confirmation/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transaction-messages": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-2.0.0.tgz",
+      "integrity": "sha512-Uc6Fw1EJLBrmgS1lH2ZfLAAKFvprWPQQzOVwZS78Pv8Whsk7tweYTK6S0Upv0nHr50rGpnORJfmdBrXE6OfNGg==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -7073,7 +8440,8 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7086,7 +8454,8 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7101,7 +8470,8 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7115,7 +8485,8 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7132,7 +8503,8 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7142,14 +8514,16 @@
     },
     "node_modules/@solana/transaction-messages/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/transactions": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-2.0.0.tgz",
+      "integrity": "sha512-VfdTE+59WKvuBG//6iE9RPjAB+ZT2kLgY2CDHabaz6RkH6OjOkMez9fWPVa3Xtcus+YQWN1SnQoryjF/xSx04w==",
       "dependencies": {
         "@solana/addresses": "2.0.0",
         "@solana/codecs-core": "2.0.0",
@@ -7172,7 +8546,8 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -7185,7 +8560,8 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7200,7 +8576,8 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -7214,7 +8591,8 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -7230,7 +8608,8 @@
     },
     "node_modules/@solana/transactions/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -7247,7 +8626,8 @@
     },
     "node_modules/@solana/transactions/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -7257,14 +8637,16 @@
     },
     "node_modules/@solana/transactions/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@solana/wallet-adapter-alpha": {
       "version": "0.1.10",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-alpha/-/wallet-adapter-alpha-0.1.10.tgz",
+      "integrity": "sha512-TOUhDyUNSmp8bqeUueN0LPmurTAEmYm3PTrPGSnsq6JFeTzwTv5xZRygtCvULpBzCPZu/7AfIqh/TSoz4P92aw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7277,7 +8659,8 @@
     },
     "node_modules/@solana/wallet-adapter-avana": {
       "version": "0.1.13",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-avana/-/wallet-adapter-avana-0.1.13.tgz",
+      "integrity": "sha512-dvKDzaFo9KgfNh0ohI6qOBTnOU2f6cHKPiDxdtLfXVubdic1mUYzuA2PcrBZQuRc5EBcvHbGCpr3Ds90cGB+xQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7290,7 +8673,8 @@
     },
     "node_modules/@solana/wallet-adapter-base": {
       "version": "0.9.23",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.23.tgz",
+      "integrity": "sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==",
       "dependencies": {
         "@solana/wallet-standard-features": "^1.1.0",
         "@wallet-standard/base": "^1.0.1",
@@ -7306,7 +8690,8 @@
     },
     "node_modules/@solana/wallet-adapter-bitkeep": {
       "version": "0.3.20",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-bitkeep/-/wallet-adapter-bitkeep-0.3.20.tgz",
+      "integrity": "sha512-v6Jd13CZOPNIAX0nFlopAJ3HDvC+MhiB4sde3C8sSnNbjVi9h1WLHBmaUfgqU6mAyhDjWUZjKt4zYlMhLdp/bg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7319,7 +8704,8 @@
     },
     "node_modules/@solana/wallet-adapter-bitpie": {
       "version": "0.5.18",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-bitpie/-/wallet-adapter-bitpie-0.5.18.tgz",
+      "integrity": "sha512-gEflEwAyUbfmU4NEmsoDYt1JNFyoBQGm99BBvrvXdJsDdExvT6PwHNi5YlQKp1A4EAqjqaEj+nQzr6ygUpmCBQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7332,7 +8718,8 @@
     },
     "node_modules/@solana/wallet-adapter-clover": {
       "version": "0.4.19",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-clover/-/wallet-adapter-clover-0.4.19.tgz",
+      "integrity": "sha512-48PoaPte/SRYeU25bvOSmSEqoKCcyOBH9CXebsDcXkrgf+g46KRlAlsY605q1ebzr+iaFEONtTdxW8LthvJtbA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7345,7 +8732,8 @@
     },
     "node_modules/@solana/wallet-adapter-coin98": {
       "version": "0.5.20",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coin98/-/wallet-adapter-coin98-0.5.20.tgz",
+      "integrity": "sha512-gnDFNsFq4IeB6jtQj6fZOUthuuQpvtomCkwkwsOWARNhl8nhnsfbuNs3r4XaT4Q79my07ogNQUBPGKY/8CqjiA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "bs58": "^4.0.1"
@@ -7359,7 +8747,8 @@
     },
     "node_modules/@solana/wallet-adapter-coinbase": {
       "version": "0.1.19",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coinbase/-/wallet-adapter-coinbase-0.1.19.tgz",
+      "integrity": "sha512-hcf9ieAbQxD2g8/5glXVAt67w+3iixpjMMZC7lT7Wa8SJZsq6lmISC9AtZctDEQcWSVV0IkedZp3bg6bp22kng==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7372,7 +8761,8 @@
     },
     "node_modules/@solana/wallet-adapter-coinhub": {
       "version": "0.3.18",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-coinhub/-/wallet-adapter-coinhub-0.3.18.tgz",
+      "integrity": "sha512-yeJo+cHVlUBlH16Q+knnFDJrH9wzEB3zvSq57PXfqvlWSjySm4PkkK7srRoAwfNOxL/eArSJWfBwRprsymttJQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7385,7 +8775,8 @@
     },
     "node_modules/@solana/wallet-adapter-fractal": {
       "version": "0.1.8",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-fractal/-/wallet-adapter-fractal-0.1.8.tgz",
+      "integrity": "sha512-lV/rXOMQSR7sBIEDx8g0jwvXP/fT2Vw/47CSj9BaVYC5LGphhuoYbcI4ko1y0Zv+dJu8JVRTeKbnaiRBjht5DA==",
       "dependencies": {
         "@fractalwagmi/solana-wallet-adapter": "^0.1.1",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -7399,7 +8790,8 @@
     },
     "node_modules/@solana/wallet-adapter-huobi": {
       "version": "0.1.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-huobi/-/wallet-adapter-huobi-0.1.15.tgz",
+      "integrity": "sha512-VKwlK0fE7v97NEWwP86iBY/xgnB3fQJv2/RYaw8ODAcfJqVQZAV6EhDR8fo6++jdS1KkcWc2GcHdBMrqPli3yQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7412,7 +8804,8 @@
     },
     "node_modules/@solana/wallet-adapter-hyperpay": {
       "version": "0.1.14",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-hyperpay/-/wallet-adapter-hyperpay-0.1.14.tgz",
+      "integrity": "sha512-K0qMVpPHbeIVAvhwnn+2GR8jjBe/a5EP514TL/10SQQ8vTLd7ggNWZdTRCjUkHRlsbTOK7yYWAOHu3gx7429rw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7425,7 +8818,8 @@
     },
     "node_modules/@solana/wallet-adapter-keystone": {
       "version": "0.1.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-keystone/-/wallet-adapter-keystone-0.1.15.tgz",
+      "integrity": "sha512-2A31/vuDRAfASOEyWvJ2YjtwCQohwim3/K+KzhPfvG20C4wr6agDbMXi1T2lDWwrd13kyP+dIgOzPfuLn09tWw==",
       "dependencies": {
         "@keystonehq/sol-keyring": "^0.3.1",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -7439,7 +8833,8 @@
     },
     "node_modules/@solana/wallet-adapter-krystal": {
       "version": "0.1.12",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-krystal/-/wallet-adapter-krystal-0.1.12.tgz",
+      "integrity": "sha512-umQV9cbLZcqJFkcjpdOgPvTeDvUjcivRSzWgbx27drmeQ9bi4w9bYH5XkFmbj9iD98q+fjrYQUOK772IHZqrkQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7452,7 +8847,8 @@
     },
     "node_modules/@solana/wallet-adapter-ledger": {
       "version": "0.9.25",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-ledger/-/wallet-adapter-ledger-0.9.25.tgz",
+      "integrity": "sha512-59yD3aveLwlzXqk4zBCaPLobeqAhmtMxPizfUBOjzwRKyepi1Nnnt9AC9Af3JrweU2x4qySRxAaZfU/iNqJ3rQ==",
       "dependencies": {
         "@ledgerhq/devices": "6.27.1",
         "@ledgerhq/hw-transport": "6.27.1",
@@ -7469,7 +8865,8 @@
     },
     "node_modules/@solana/wallet-adapter-mathwallet": {
       "version": "0.9.18",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-mathwallet/-/wallet-adapter-mathwallet-0.9.18.tgz",
+      "integrity": "sha512-sleBX+wB8Wahu2lLBCWihkFtnl64DMJgla/kgsf75PCNmNA93+WLA4gYOK+fFKeBkU12a/Hp5oZKEQsQGFPSOA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7482,7 +8879,8 @@
     },
     "node_modules/@solana/wallet-adapter-neko": {
       "version": "0.2.12",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-neko/-/wallet-adapter-neko-0.2.12.tgz",
+      "integrity": "sha512-ei1QoQZhiYMuH/qm3bnXlueT0jQmH4tZfQvEwudFB8+a0fLtSA8lZU+CYI1jd1YLDjkUEIiXV6R/u32nlCuYDA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7495,7 +8893,8 @@
     },
     "node_modules/@solana/wallet-adapter-nightly": {
       "version": "0.1.16",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-nightly/-/wallet-adapter-nightly-0.1.16.tgz",
+      "integrity": "sha512-JaPzT8R4HHUqGn/QdElx9iRW98h0NaANBt0j3CZZYWlqsdG0f8fFfy2xofILA+qnDL6NaRI9AzQ4NcQGuVZsVQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7508,7 +8907,8 @@
     },
     "node_modules/@solana/wallet-adapter-nufi": {
       "version": "0.1.17",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-nufi/-/wallet-adapter-nufi-0.1.17.tgz",
+      "integrity": "sha512-ggTZKvYPJS3m/9hsMaGSH0F8kqumPqP0WdY7WNihWR6O4Pr401kDBdgXPXNSGorIahdPrRBzp5UrahnrlodvTQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7521,7 +8921,8 @@
     },
     "node_modules/@solana/wallet-adapter-onto": {
       "version": "0.1.7",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-onto/-/wallet-adapter-onto-0.1.7.tgz",
+      "integrity": "sha512-WS4LY0Z0J+NcyEkjdjkD11uKURkRQ/RHMYSFE59U+MuBHggEpXJFZuJzUE9SZbG1ltlLTh13hS5ZuiEz7F+faA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7534,7 +8935,8 @@
     },
     "node_modules/@solana/wallet-adapter-particle": {
       "version": "0.1.12",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-particle/-/wallet-adapter-particle-0.1.12.tgz",
+      "integrity": "sha512-6tD5pbyuyCRDswDVD5LCakVQ/vIwjO2lXlVvJFDLdhGa6MinbjTHigLmE58nkTgKATRScyS8FuCCzGmYcXGbow==",
       "dependencies": {
         "@particle-network/solana-wallet": "^1.3.2",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -7548,7 +8950,8 @@
     },
     "node_modules/@solana/wallet-adapter-phantom": {
       "version": "0.9.24",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-phantom/-/wallet-adapter-phantom-0.9.24.tgz",
+      "integrity": "sha512-D24AxRHmRJ4AYoRvijbiuUb9LmC4xLGKLMSJS2ly+zGxVmaPASPM/ThaY/DlYTDL31QvkYtl8RzSR4yIU1gpLg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7561,7 +8964,8 @@
     },
     "node_modules/@solana/wallet-adapter-safepal": {
       "version": "0.5.18",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-safepal/-/wallet-adapter-safepal-0.5.18.tgz",
+      "integrity": "sha512-E/EIO5j+f0FS9Yj5o5JLJ/qHh3Se/9jP2KdHKhooWTlXWbQDzrxMjV88qIKKl5sgWEndqRYDuDbAdW+2dhw6hw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7574,7 +8978,8 @@
     },
     "node_modules/@solana/wallet-adapter-saifu": {
       "version": "0.1.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-saifu/-/wallet-adapter-saifu-0.1.15.tgz",
+      "integrity": "sha512-4nrziKQ+4QInh+COsICpNNUlUt456EJ60SZLxvG/z1AOGpatuzT0gN1+RdMcwHGUtiPBPCkEneUVhFZhhbMJlg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7587,7 +8992,8 @@
     },
     "node_modules/@solana/wallet-adapter-salmon": {
       "version": "0.1.14",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-salmon/-/wallet-adapter-salmon-0.1.14.tgz",
+      "integrity": "sha512-CMXdbhaj3prloCJwvxO7e1wfAyRd58QiPB8pjvB4GBbznyoSnHbFXmpxZrKX1Dk6FoJOGBgjB71xnreGcc6oMw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "salmon-adapter-sdk": "^1.1.1"
@@ -7601,7 +9007,8 @@
     },
     "node_modules/@solana/wallet-adapter-sky": {
       "version": "0.1.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-sky/-/wallet-adapter-sky-0.1.15.tgz",
+      "integrity": "sha512-1vlk1/jnlOC/WfDDgDoUk3XtEhB3hq1fKtUb+xj0pVuSOg2Db+8ka9vPPYlVaKHoGvjm30iGGfr3ZrCxVfG6OQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7614,7 +9021,8 @@
     },
     "node_modules/@solana/wallet-adapter-solflare": {
       "version": "0.6.28",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-solflare/-/wallet-adapter-solflare-0.6.28.tgz",
+      "integrity": "sha512-iiUQtuXp8p4OdruDawsm1dRRnzUCcsu+lKo8OezESskHtbmZw2Ifej0P99AbJbBAcBw7q4GPI6987Vh05Si5rw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -7631,7 +9039,8 @@
     },
     "node_modules/@solana/wallet-adapter-solong": {
       "version": "0.9.18",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-solong/-/wallet-adapter-solong-0.9.18.tgz",
+      "integrity": "sha512-n40eemFUbJlOP+FKvn8rgq+YAOW51lEsn7uVz5ZjmiaW6MnRQniId9KkGYPPOUjytFyM+6/4x6IXI+QJknlSqA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7644,7 +9053,8 @@
     },
     "node_modules/@solana/wallet-adapter-spot": {
       "version": "0.1.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-spot/-/wallet-adapter-spot-0.1.15.tgz",
+      "integrity": "sha512-daU2iBTSJp1RGfQrB2uV06+2WHfeyW0uhjoJ3zTkz24kXqv5/ycoPHr8Gi2jkDSGMFkewnjWF8g0KMEzq2VYug==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7657,7 +9067,8 @@
     },
     "node_modules/@solana/wallet-adapter-tokenary": {
       "version": "0.1.12",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-tokenary/-/wallet-adapter-tokenary-0.1.12.tgz",
+      "integrity": "sha512-iIsOzzEHfRfDUiwYy2BAVGeMl+xBUu92qYK1yAKeKxQPF5McJrnjS3FXwT/onBU5WMdxI6dWm0HKZUiDwefN6A==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7670,7 +9081,8 @@
     },
     "node_modules/@solana/wallet-adapter-tokenpocket": {
       "version": "0.4.19",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-tokenpocket/-/wallet-adapter-tokenpocket-0.4.19.tgz",
+      "integrity": "sha512-zKXTN+tuKIr/stSxUeG9XPBks9iqeliBWS9JF8eq+8u/Qb/bIDbNSQmd8Z5u1x2lf0puiStc9/iUu/+MLaOSVg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7683,7 +9095,8 @@
     },
     "node_modules/@solana/wallet-adapter-torus": {
       "version": "0.11.28",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-torus/-/wallet-adapter-torus-0.11.28.tgz",
+      "integrity": "sha512-bu1oJQ+AoIZICxz8J1lVcdL+iBBrdbynnEs5N6dxwoM/cMGLbX7PGYqaH0J1dEXisA+1H5AzGAnW4UU05VBmLA==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@toruslabs/solana-embed": "^0.3.4",
@@ -7701,7 +9114,8 @@
     },
     "node_modules/@solana/wallet-adapter-trezor": {
       "version": "0.1.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-trezor/-/wallet-adapter-trezor-0.1.2.tgz",
+      "integrity": "sha512-x4nXntYi1SIv63ZdXWX/Rq/VKwguByKu67WpyUXsu8kOdviksb20bQMuAR7Ue41oJ9zSnLlTxAxA1SuWNkFRBg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@trezor/connect-web": "^9.2.1",
@@ -7716,7 +9130,8 @@
     },
     "node_modules/@solana/wallet-adapter-trust": {
       "version": "0.1.13",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-trust/-/wallet-adapter-trust-0.1.13.tgz",
+      "integrity": "sha512-lkmPfNdyRgx+z0K7i2cDa3a6SOKXpi3FiaYSo8Zozoxkp+Ga/NXVWxlXtMca4GAc/MnJMVp7yF/31kyFIee+3A==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7729,7 +9144,8 @@
     },
     "node_modules/@solana/wallet-adapter-unsafe-burner": {
       "version": "0.1.7",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-unsafe-burner/-/wallet-adapter-unsafe-burner-0.1.7.tgz",
+      "integrity": "sha512-SuBVqQxA1NNUwP4Lo70rLPaM8aWkV1EFAlxkRoRLtwyw/gM8bxTO6+9EVyKCv+ix3yw1rCGIF3B0idXx0i37eQ==",
       "dependencies": {
         "@noble/curves": "^1.1.0",
         "@solana/wallet-adapter-base": "^0.9.23",
@@ -7745,7 +9161,8 @@
     },
     "node_modules/@solana/wallet-adapter-walletconnect": {
       "version": "0.1.16",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-walletconnect/-/wallet-adapter-walletconnect-0.1.16.tgz",
+      "integrity": "sha512-jNaQwSho8hT7gF1ifePE8TJc1FULx8jCF16KX3fZPtzXDxKrj0R4VUpHMGcw4MlDknrnZNLOJAVvyiawAkPCRQ==",
       "dependencies": {
         "@jnwng/walletconnect-solana": "^0.2.0",
         "@solana/wallet-adapter-base": "^0.9.23"
@@ -7759,7 +9176,8 @@
     },
     "node_modules/@solana/wallet-adapter-wallets": {
       "version": "0.19.32",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-wallets/-/wallet-adapter-wallets-0.19.32.tgz",
+      "integrity": "sha512-voZYQiIy1yXuKvm7x7YpnQ53eiJC7NpIYSQjzApOUiswiBRVeYcnPO4O/MMPUwsGkS7iZKqKZjo5CnOaN44n+g==",
       "dependencies": {
         "@solana/wallet-adapter-alpha": "^0.1.10",
         "@solana/wallet-adapter-avana": "^0.1.13",
@@ -7807,7 +9225,8 @@
     },
     "node_modules/@solana/wallet-adapter-xdefi": {
       "version": "0.1.7",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-xdefi/-/wallet-adapter-xdefi-0.1.7.tgz",
+      "integrity": "sha512-d0icfBOQyaY8kpsdU/wQwaBIahZZPzkXkXfBjpMGwjixD8oeZUFfsg8LC7T1rOIUObeczlocaR/lwtEqWpnaeg==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23"
       },
@@ -7820,7 +9239,8 @@
     },
     "node_modules/@solana/wallet-standard-chains": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.0.tgz",
+      "integrity": "sha512-IRJHf94UZM8AaRRmY18d34xCJiVPJej1XVwXiTjihHnmwD0cxdQbc/CKjrawyqFyQAKJx7raE5g9mnJsAdspTg==",
       "dependencies": {
         "@wallet-standard/base": "^1.0.1"
       },
@@ -7830,7 +9250,8 @@
     },
     "node_modules/@solana/wallet-standard-features": {
       "version": "1.2.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.2.0.tgz",
+      "integrity": "sha512-tUd9srDLkRpe1BYg7we+c4UhRQkq+XQWswsr/L1xfGmoRDF47BPSXf4zE7ZU2GRBGvxtGt7lwJVAufQyQYhxTQ==",
       "dependencies": {
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3"
@@ -7841,7 +9262,8 @@
     },
     "node_modules/@solana/wallet-standard-util": {
       "version": "1.1.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.1.tgz",
+      "integrity": "sha512-dPObl4ntmfOc0VAGGyyFvrqhL8UkHXmVsgbj0K9RcznKV4KB3MgjGwzo8CTSX5El5lkb0rDeEzFqvToJXRz3dw==",
       "dependencies": {
         "@noble/curves": "^1.1.0",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -7853,7 +9275,8 @@
     },
     "node_modules/@solana/wallet-standard-wallet-adapter-base": {
       "version": "1.1.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.2.tgz",
+      "integrity": "sha512-DqhzYbgh3disHMgcz6Du7fmpG29BYVapNEEiL+JoVMa+bU9d4P1wfwXUNyJyRpGGNXtwhyZjIk2umWbe5ZBNaQ==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-chains": "^1.1.0",
@@ -7874,7 +9297,8 @@
     },
     "node_modules/@solana/web3.js": {
       "version": "1.98.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.0.tgz",
+      "integrity": "sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -7895,18 +9319,21 @@
     },
     "node_modules/@solana/web3.js/node_modules/@types/ws": {
       "version": "8.5.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+      "integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@solana/web3.js/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@solana/web3.js/node_modules/rpc-websockets": {
       "version": "9.0.4",
-      "license": "LGPL-3.0-only",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.0.4.tgz",
+      "integrity": "sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
         "@types/uuid": "^8.3.4",
@@ -7927,14 +9354,16 @@
     },
     "node_modules/@solana/web3.js/node_modules/superstruct": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@solflare-wallet/metamask-sdk": {
       "version": "1.0.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solflare-wallet/metamask-sdk/-/metamask-sdk-1.0.3.tgz",
+      "integrity": "sha512-os5Px5PTMYKGS5tzOoyjDxtOtj0jZKnbI1Uwt8+Jsw1HHIA+Ib2UACCGNhQ/un2f8sIbTfLD1WuucNMOy8KZpQ==",
       "dependencies": {
         "@solana/wallet-standard-features": "^1.1.0",
         "@wallet-standard/base": "^1.0.1",
@@ -7948,33 +9377,38 @@
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@solflare-wallet/metamask-sdk/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@solflare-wallet/sdk": {
       "version": "1.4.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solflare-wallet/sdk/-/sdk-1.4.2.tgz",
+      "integrity": "sha512-jrseNWipwl9xXZgrzwZF3hhL0eIVxuEtoZOSLmuPuef7FgHjstuTtNJAeT4icA7pzdDV4hZvu54pI2r2f7SmrQ==",
       "dependencies": {
         "bs58": "^5.0.0",
         "eventemitter3": "^5.0.1",
@@ -7986,48 +9420,56 @@
     },
     "node_modules/@solflare-wallet/sdk/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@solflare-wallet/sdk/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@solflare-wallet/sdk/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@solflare-wallet/sdk/node_modules/uuid": {
       "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@stablelib/aead": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/aead/-/aead-1.0.1.tgz",
+      "integrity": "sha512-q39ik6sxGHewqtO0nP4BuSe3db5G1fEJE8ukvngS2gLkBXyy6E7pLubhbYgnkDFv6V8cWaxcE4Xn0t6LWcJkyg=="
     },
     "node_modules/@stablelib/binary": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
       "dependencies": {
         "@stablelib/int": "^1.0.1"
       }
     },
     "node_modules/@stablelib/bytes": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
+      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
     },
     "node_modules/@stablelib/chacha": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha/-/chacha-1.0.1.tgz",
+      "integrity": "sha512-Pmlrswzr0pBzDofdFuVe1q7KdsHKhhU24e8gkEwnTGOmlC7PADzLVxGdn2PoNVBBabdg0l/IfLKg6sHAbTQugg==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -8035,7 +9477,8 @@
     },
     "node_modules/@stablelib/chacha20poly1305": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/chacha20poly1305/-/chacha20poly1305-1.0.1.tgz",
+      "integrity": "sha512-MmViqnqHd1ymwjOQfghRKw2R/jMIGT3wySN7cthjXCBdO+qErNPUBnRzqNpnvIwg7JBCg3LdeCZZO4de/yEhVA==",
       "dependencies": {
         "@stablelib/aead": "^1.0.1",
         "@stablelib/binary": "^1.0.1",
@@ -8047,11 +9490,13 @@
     },
     "node_modules/@stablelib/constant-time": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
+      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
     },
     "node_modules/@stablelib/ed25519": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
+      "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
       "dependencies": {
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha512": "^1.0.1",
@@ -8060,11 +9505,13 @@
     },
     "node_modules/@stablelib/hash": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
     },
     "node_modules/@stablelib/hkdf": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/hkdf/-/hkdf-1.0.1.tgz",
+      "integrity": "sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==",
       "dependencies": {
         "@stablelib/hash": "^1.0.1",
         "@stablelib/hmac": "^1.0.1",
@@ -8073,7 +9520,8 @@
     },
     "node_modules/@stablelib/hmac": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/hmac/-/hmac-1.0.1.tgz",
+      "integrity": "sha512-V2APD9NSnhVpV/QMYgCVMIYKiYG6LSqw1S65wxVoirhU/51ACio6D4yDVSwMzuTJXWZoVHbDdINioBwKy5kVmA==",
       "dependencies": {
         "@stablelib/constant-time": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -8082,18 +9530,21 @@
     },
     "node_modules/@stablelib/int": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
     },
     "node_modules/@stablelib/keyagreement": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
+      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
       "dependencies": {
         "@stablelib/bytes": "^1.0.1"
       }
     },
     "node_modules/@stablelib/poly1305": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
+      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
       "dependencies": {
         "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -8101,7 +9552,8 @@
     },
     "node_modules/@stablelib/random": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
@@ -8109,7 +9561,8 @@
     },
     "node_modules/@stablelib/sha256": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha256/-/sha256-1.0.1.tgz",
+      "integrity": "sha512-GIIH3e6KH+91FqGV42Kcj71Uefd/QEe7Dy42sBTeqppXV95ggCcxLTk39bEr+lZfJmp+ghsR07J++ORkRELsBQ==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -8118,7 +9571,8 @@
     },
     "node_modules/@stablelib/sha512": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
+      "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
@@ -8127,11 +9581,13 @@
     },
     "node_modules/@stablelib/wipe": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
     },
     "node_modules/@stablelib/x25519": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
       "dependencies": {
         "@stablelib/keyagreement": "^1.0.1",
         "@stablelib/random": "^1.0.2",
@@ -8140,13 +9596,15 @@
     },
     "node_modules/@suchipi/femver": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@suchipi/femver/-/femver-1.0.0.tgz",
+      "integrity": "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="
     },
     "node_modules/@swc/core": {
       "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-rQ4dS6GAdmtzKiCRt3LFVxl37FaY1cgL9kSUTnhQ2xc3fmHOd7jdJK/V4pSZMG1ruGTd0bsi34O2R0Olg9Zo/w==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -8181,11 +9639,12 @@
     },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-NyELPp8EsVZtxH/mEqvzSyWpfPJ1lugpTQcSlMduZLj1EASLO4sC8wt8hmL1aizRlsbjCX+r0PyL+l0xQ64/6Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -8194,29 +9653,177 @@
         "node": ">=10"
       }
     },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-L4BNt1fdQ5ZZhAk5qoDfUnXRabDOXKnXBxMDJ+PWLSxOGBbWE6aJTnu4zbGjJvtot0KM46m2LPAPY8ttknqaZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-Y1u9OqCHgvVp2tYQAJ7hcU9qO5brDMIrA5R31rwWQIAKDkJKtv3IlTHF0hrbWk1wPR0ZdngkQSJZple7G+Grvw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-tNQHO/UKdtnqjc7o04iRXng1wTUXPgVd8Y6LI4qIbHVoVPwksZydISjMcilKNLKIwOoUQAkxyJ16SlOAeADzhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-x0L2Pd9weQ6n8dI1z1Isq00VHFvpBClwQJvrt3NHzmR+1wCT/gcYl1tp9P5xHh3ldM8Cn4UjWCw+7PaUgg8FcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-yyYEwQcObV3AUsC79rSzN9z6kiWxKAVJ6Ntwq2N9YoZqSPYph+4/Am5fM1xEQYf/kb99csj0FgOelomJSobxQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-tcaS43Ydd7Fk7sW5ROpaf2Kq1zR+sI5K0RM+0qYLYYurvsJruj3GhBCaiN3gkzd8m/8wkqNqtVklWaQYSDsyqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.1.tgz",
+      "integrity": "sha512-D3Qo1voA7AkbOzQ2UGuKNHfYGKL6eejN8VWOoQYtGHHQi1p5KK/Q7V1ku55oxXBsj79Ny5FRMqiRJpVGad7bjQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.1.tgz",
+      "integrity": "sha512-WalYdFoU3454Og+sDKHM1MrjvxUGwA2oralknXkXL8S0I/8RkWZOB++p3pLaGbTvOO++T+6znFbQdR8KRaa7DA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-JWobfQDbTnoqaIwPKQ3DVSywihVXlQMbDuwik/dDWlj33A8oEHcjPOGs4OqcA3RHv24i+lfCQpM3Mn4FAMfacA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "dev": true,
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "dev": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@swc/types": {
       "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -8226,7 +9833,8 @@
     },
     "node_modules/@tanstack/query-core": {
       "version": "4.36.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.36.1.tgz",
+      "integrity": "sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==",
       "peer": true,
       "funding": {
         "type": "github",
@@ -8235,7 +9843,8 @@
     },
     "node_modules/@tanstack/query-persist-client-core": {
       "version": "4.36.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.36.1.tgz",
+      "integrity": "sha512-eocgCeI7D7TRv1IUUBMfVwOI0wdSmMkBIbkKhqEdTrnUHUQEeOaYac8oeZk2cumAWJdycu6P/wB+WqGynTnzXg==",
       "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.36.1"
@@ -8247,7 +9856,8 @@
     },
     "node_modules/@tanstack/query-sync-storage-persister": {
       "version": "4.36.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.36.1.tgz",
+      "integrity": "sha512-yMEt5hWe2+1eclf1agMtXHnPIkxEida0lYWkfdhR8U6KXk/lO4Vca6piJmhKI85t0NHlx3l/z6zX+t/Fn5O9NA==",
       "peer": true,
       "dependencies": {
         "@tanstack/query-persist-client-core": "4.36.1"
@@ -8259,7 +9869,8 @@
     },
     "node_modules/@tanstack/react-query": {
       "version": "4.36.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.36.1.tgz",
+      "integrity": "sha512-y7ySVHFyyQblPl3J3eQBWpXZkliroki3ARnBKsdJchlgt7yJLRDUcf4B8soufgiYt3pEQIkBWBx1N9/ZPIeUWw==",
       "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.36.1",
@@ -8285,7 +9896,8 @@
     },
     "node_modules/@tanstack/react-query-persist-client": {
       "version": "4.36.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.36.1.tgz",
+      "integrity": "sha512-32I5b9aAu4NCiXZ7Te/KEQLfHbYeTNriVPrKYcvEThnZ9tlW01vLcSoxpUIsMYRsembvJUUAkzYBAiZHLOd6pQ==",
       "peer": true,
       "dependencies": {
         "@tanstack/query-persist-client-core": "4.36.1"
@@ -8300,7 +9912,8 @@
     },
     "node_modules/@toruslabs/base-controllers": {
       "version": "2.9.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/base-controllers/-/base-controllers-2.9.0.tgz",
+      "integrity": "sha512-rKc+bR4QB/wdbH0CxLZC5e2PUZcIgkr9yY7TMd3oIffDklaYBnsuC5ES2/rgK1aRUDRWz+qWbTwLqsY6PlT37Q==",
       "dependencies": {
         "@ethereumjs/util": "^8.0.6",
         "@toruslabs/broadcast-channel": "^6.2.0",
@@ -8320,7 +9933,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -8328,7 +9942,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -8341,7 +9956,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@metamask/rpc-errors": {
       "version": "5.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@metamask/rpc-errors/-/rpc-errors-5.1.1.tgz",
+      "integrity": "sha512-JjZnDi2y2CfvbohhBl+FOQRzmFlJpybcQlIk37zEX8B96eVSPbH/T8S0p7cSF8IE33IWx6JkD8Ycsd+2TXFxCw==",
       "dependencies": {
         "@metamask/utils": "^5.0.0",
         "fast-safe-stringify": "^2.0.6"
@@ -8352,7 +9968,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
+      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -8366,7 +9983,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@toruslabs/openlogin-jrpc": {
       "version": "4.7.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-4.7.2.tgz",
+      "integrity": "sha512-9Eb0cPc0lPuS6v2YkQlgzfbRnZ6fLez9Ike5wznoHSFA2/JVu1onwuI56EV1HwswdDrOWPPQEyzI1j9NriZ0ew==",
       "dependencies": {
         "@metamask/rpc-errors": "^5.1.1",
         "@toruslabs/openlogin-utils": "^4.7.0",
@@ -8387,7 +10005,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/@toruslabs/openlogin-utils": {
       "version": "4.7.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-utils/-/openlogin-utils-4.7.0.tgz",
+      "integrity": "sha512-w6XkHs4WKuufsf/zzteBzs4EJuOknrUmJ+iv5FZ8HzIpMQeL/984CP8HYaFSEYkbGCP4ydAnhY4Uh0QAhpDbPg==",
       "dependencies": {
         "base64url": "^3.0.1"
       },
@@ -8401,7 +10020,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/readable-stream": {
       "version": "4.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.6.0.tgz",
+      "integrity": "sha512-cbAdYt0VcnpN2Bekq7PU+k363ZRsPwJoEEJOEtSJQlJXzwaxt3FIo/uL+KeDSGIjJqtkwyge4KQgD2S2kd+CQw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
@@ -8415,7 +10035,8 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -8425,14 +10046,16 @@
     },
     "node_modules/@toruslabs/base-controllers/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@toruslabs/broadcast-channel": {
       "version": "6.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@toruslabs/broadcast-channel/-/broadcast-channel-6.3.1.tgz",
+      "integrity": "sha512-BEtJQ+9bMfFoGuCsp5NmxyY+C980Ho+3BZIKSiYwRtl5qymJ+jMX5lsoCppoQblcb34dP6FwEjeFw80Y9QC/rw==",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "@toruslabs/eccrypto": "^2.1.1",
@@ -8446,14 +10069,16 @@
     },
     "node_modules/@toruslabs/eccrypto": {
       "version": "2.2.1",
-      "license": "CC0-1.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/eccrypto/-/eccrypto-2.2.1.tgz",
+      "integrity": "sha512-7sviL0wLYsfA5ogEAOIdb0tu/QAOFXfHc9B8ONYtF04x4Mg3Nr89LL35FhjaEm055q8Ru7cUQhEFSiqJqm9GCw==",
       "dependencies": {
         "elliptic": "^6.5.4"
       }
     },
     "node_modules/@toruslabs/http-helpers": {
       "version": "3.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@toruslabs/http-helpers/-/http-helpers-3.4.0.tgz",
+      "integrity": "sha512-CoeJSL32mpp0gmYjxv48odu6pfjHk/rbJHDwCtYPcMHAl+qUQ/DTpVOOn9U0fGkD+fYZrQmZbRkXFgLhiT0ajQ==",
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "loglevel": "^1.8.1"
@@ -8474,7 +10099,8 @@
     },
     "node_modules/@toruslabs/metadata-helpers": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@toruslabs/metadata-helpers/-/metadata-helpers-3.2.0.tgz",
+      "integrity": "sha512-2bCc6PNKd9y+aWfZQ1FXd47QmfyT4NmmqPGfsqk+sQS2o+MlxIyLuh9uh7deMgXo4b4qBDX+RQGbIKM1zVk56w==",
       "dependencies": {
         "@toruslabs/eccrypto": "^2.1.1",
         "@toruslabs/http-helpers": "^3.4.0",
@@ -8492,7 +10118,9 @@
     },
     "node_modules/@toruslabs/openlogin-jrpc": {
       "version": "3.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-jrpc/-/openlogin-jrpc-3.2.0.tgz",
+      "integrity": "sha512-G+K0EHyVUaAEyeD4xGsnAZRpn/ner8lQ2HC2+pGKg6oGmzKI2wGMDcw2KMH6+HKlfBGVJ5/VR9AQfC/tZlLDmQ==",
+      "deprecated": "Not supported. Pls upgrade",
       "dependencies": {
         "@toruslabs/openlogin-utils": "^3.0.0",
         "end-of-stream": "^1.4.4",
@@ -8509,7 +10137,9 @@
     },
     "node_modules/@toruslabs/openlogin-utils": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/openlogin-utils/-/openlogin-utils-3.0.0.tgz",
+      "integrity": "sha512-T5t29/AIFqXc84x4OoAkZWjd0uoP2Lk6iaFndnIIMzCPu+BwwV0spX/jd/3YYNjZ8Po8D+faEnwAhiqemYeK2w==",
+      "deprecated": "Not supported. Pls upgrade",
       "dependencies": {
         "base64url": "^3.0.1",
         "keccak": "^3.0.3",
@@ -8521,7 +10151,8 @@
     },
     "node_modules/@toruslabs/solana-embed": {
       "version": "0.3.4",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@toruslabs/solana-embed/-/solana-embed-0.3.4.tgz",
+      "integrity": "sha512-yj+aBJoBAneap7Jlu9/OOp7irWNuC5CqAhyhVcmb0IjWrCUFnioLdL0U7UfGaqVm/5O0leJh7/Z5Ll+3toWJBg==",
       "dependencies": {
         "@solana/web3.js": "^1.63.1",
         "@toruslabs/base-controllers": "^2.8.0",
@@ -8544,7 +10175,8 @@
     },
     "node_modules/@trezor/analytics": {
       "version": "1.2.5",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/analytics/-/analytics-1.2.5.tgz",
+      "integrity": "sha512-+6DnjUj1XHD9wHffilPYXIPGmIwPNlYJLlS98FhAv5tOVr9rWvomqtXx2GWwtiv2B3oR/h6oMiYGmS/yjpM2cA==",
       "dependencies": {
         "@trezor/env-utils": "1.2.1",
         "@trezor/utils": "9.2.5"
@@ -8555,7 +10187,8 @@
     },
     "node_modules/@trezor/analytics/node_modules/@trezor/utils": {
       "version": "9.2.5",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.5.tgz",
+      "integrity": "sha512-FaGKQxwvivcWOa8vK4qQPdyvUm/AcjH0xOKfcvjNfaBhf+TVDzKn2ORKnioQb2Sgjncb8B2ubqrUI3MIc+RKKw==",
       "dependencies": {
         "bignumber.js": "^9.1.2"
       },
@@ -8565,7 +10198,8 @@
     },
     "node_modules/@trezor/blockchain-link": {
       "version": "2.3.6",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link/-/blockchain-link-2.3.6.tgz",
+      "integrity": "sha512-cuqGJr5d5iTwGNbTAKDskE+m7yL/4RQsagNwA64793tli1fDWeeGT/B2mCvFwpUmIo9dVFDkYb++ZiltUIGZ3w==",
       "dependencies": {
         "@solana-program/token": "^0.4.1",
         "@solana/web3.js": "^2.0.0",
@@ -8586,7 +10220,8 @@
     },
     "node_modules/@trezor/blockchain-link-types": {
       "version": "1.2.5",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-types/-/blockchain-link-types-1.2.5.tgz",
+      "integrity": "sha512-aGxLNGxhQqre4cCYDboy1s1gHAi92tTszLYl3GMhGmtB6EuAl049eO8ngCcMcuOZLTvFYA/1e/3mZoPIMBkeng==",
       "dependencies": {
         "@solana/web3.js": "^2.0.0",
         "@trezor/type-utils": "1.1.4",
@@ -8598,7 +10233,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8615,7 +10251,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8628,7 +10265,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8643,7 +10281,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8657,7 +10296,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8673,7 +10313,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8690,7 +10331,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/options": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8707,7 +10349,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/@solana/web3.js": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
+      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/addresses": "2.0.0",
@@ -8737,7 +10380,8 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8747,14 +10391,16 @@
     },
     "node_modules/@trezor/blockchain-link-types/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@trezor/blockchain-link-utils": {
       "version": "1.2.6",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/blockchain-link-utils/-/blockchain-link-utils-1.2.6.tgz",
+      "integrity": "sha512-6ExuAyKxGH79aZhT3eA6xng9ljYixiE9EBC635BLPc+lafpin2+Aplb0q2zA6f/S5ksl9ges63W627pb7IFgGw==",
       "dependencies": {
         "@mobily/ts-belt": "^3.13.1",
         "@trezor/env-utils": "1.2.1",
@@ -8766,14 +10412,16 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana-program/token": {
       "version": "0.4.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.4.1.tgz",
+      "integrity": "sha512-eSYmjsapzE9jXT2J9xydlMj/zsangMEIZAy9dy75VCXM6kgDCSnH5R7+HsIoKOTvb2VggU7GojC+YhMwWGCIBw==",
       "peerDependencies": {
         "@solana/web3.js": "^2.0.0"
       }
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0.tgz",
+      "integrity": "sha512-xneIG5ppE6WIGaZCK7JTys0uLhzlnEJUdBO8nRVIyerwH6aqCfb0fGe7q5WNNYAVDRSxC0Pc1TDe1hpdx3KWmQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8790,7 +10438,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-core": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0.tgz",
+      "integrity": "sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==",
       "dependencies": {
         "@solana/errors": "2.0.0"
       },
@@ -8803,7 +10452,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0.tgz",
+      "integrity": "sha512-N98Y4jsrC/XeOgqrfsGqcOFIaOoMsKdAxOmy5oqVaEN67YoGSLNC9ROnqamOAOrsZdicTWx9/YLKFmQi9DPh1A==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8818,7 +10468,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-numbers": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0.tgz",
+      "integrity": "sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/errors": "2.0.0"
@@ -8832,7 +10483,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/codecs-strings": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0.tgz",
+      "integrity": "sha512-dNqeCypsvaHcjW86H0gYgAZGGkKVBeKVeh7WXlOZ9kno7PeQ2wNkpccyzDfuzaIsKv+HZUD3v/eo86GCvnKazQ==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-numbers": "2.0.0",
@@ -8848,7 +10500,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/errors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0.tgz",
+      "integrity": "sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==",
       "dependencies": {
         "chalk": "^5.3.0",
         "commander": "^12.1.0"
@@ -8865,7 +10518,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/options": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0.tgz",
+      "integrity": "sha512-OVc4KnYosB8oAukQ/htgrxXSxlUP6gUu5Aau6d/BgEkPQzWd/Pr+w91VWw3i3zZuu2SGpedbyh05RoJBe/hSXA==",
       "dependencies": {
         "@solana/codecs-core": "2.0.0",
         "@solana/codecs-data-structures": "2.0.0",
@@ -8882,7 +10536,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/@solana/web3.js": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-2.0.0.tgz",
+      "integrity": "sha512-x+ZRB2/r5tVK/xw8QRbAfgPcX51G9f2ifEyAQ/J5npOO+6+MPeeCjtr5UxHNDAYs9Ypo0PN+YJATCO4vhzQJGg==",
       "dependencies": {
         "@solana/accounts": "2.0.0",
         "@solana/addresses": "2.0.0",
@@ -8912,7 +10567,8 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/chalk": {
       "version": "5.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.0.tgz",
+      "integrity": "sha512-ZkD35Mx92acjB2yNJgziGqT9oKHEOxjTBTDRpOsRWtdecL/0jM3z5kM/CTzHWvHIen1GvkM85p6TuFfDGfc8/Q==",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -8922,14 +10578,16 @@
     },
     "node_modules/@trezor/blockchain-link/node_modules/commander": {
       "version": "12.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@trezor/connect": {
       "version": "9.4.7",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/connect/-/connect-9.4.7.tgz",
+      "integrity": "sha512-Ky8AMWxhq0ieOCNgZtaIKTQie5qaQjK3uuv+TriUZXuxDqSoJcD8T50TAEY1Lxo1xl8Yv3wT0m6LQkmBn3T+xQ==",
       "dependencies": {
         "@babel/preset-typescript": "^7.24.7",
         "@ethereumjs/common": "^4.4.0",
@@ -8956,7 +10614,8 @@
     },
     "node_modules/@trezor/connect-analytics": {
       "version": "1.2.4",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-analytics/-/connect-analytics-1.2.4.tgz",
+      "integrity": "sha512-x7cbQ/x+THMG6pBttRip9qySDU6SRnTiN0AHUKDLBpUrOV+85fRScxUaX5RddtmG26J96HgNEw7Ydms7tBOlSQ==",
       "dependencies": {
         "@trezor/analytics": "1.2.5"
       },
@@ -8966,7 +10625,8 @@
     },
     "node_modules/@trezor/connect-common": {
       "version": "0.2.7",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-common/-/connect-common-0.2.7.tgz",
+      "integrity": "sha512-m9gYDY0Elitofs4k3E4uAmzgi2DtJHneb47jQVbjBZSLpzROiV7fz49aDxBnz/oPCJnIVF9Gu2OUQEh2GDeZcA==",
       "dependencies": {
         "@trezor/env-utils": "1.2.1",
         "@trezor/utils": "9.2.6"
@@ -8977,7 +10637,8 @@
     },
     "node_modules/@trezor/connect-web": {
       "version": "9.4.7",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/connect-web/-/connect-web-9.4.7.tgz",
+      "integrity": "sha512-mICiGnw1xt60LbELZd2OId+nXGG/NAiywQIXGp5rOY6116I/sqJMw4fuKQrkGJ5zpKzzX/G7Be9GcshICD1ZDg==",
       "dependencies": {
         "@trezor/connect": "9.4.7",
         "@trezor/connect-common": "0.2.7",
@@ -8989,18 +10650,21 @@
     },
     "node_modules/@trezor/connect/node_modules/base-x": {
       "version": "5.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
+      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
     },
     "node_modules/@trezor/connect/node_modules/bs58": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/@trezor/connect/node_modules/bs58check": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -9008,14 +10672,16 @@
     },
     "node_modules/@trezor/connect/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/@trezor/env-utils": {
       "version": "1.2.1",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/env-utils/-/env-utils-1.2.1.tgz",
+      "integrity": "sha512-ESBV+/AWpfJA6qnHk7BgBYFbhNtUKjPZZzQr1LOUiePwFITbVu421b5BHjTSPFVjpbrWo6Ob0IG7u8saJi0G5A==",
       "dependencies": {
         "ua-parser-js": "^1.0.37"
       },
@@ -9039,7 +10705,8 @@
     },
     "node_modules/@trezor/protobuf": {
       "version": "1.2.6",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/protobuf/-/protobuf-1.2.6.tgz",
+      "integrity": "sha512-QN/1T0/NgZk3r5FVGtMVL41Q3UaUdjFsE4LSxWvzreLp9T5jsHp5bL0wT6TCkocNqmKK3ijH2Ro/Dh8VOSZDbQ==",
       "dependencies": {
         "@trezor/schema-utils": "1.2.3",
         "protobufjs": "7.4.0"
@@ -9050,14 +10717,16 @@
     },
     "node_modules/@trezor/protocol": {
       "version": "1.2.2",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/protocol/-/protocol-1.2.2.tgz",
+      "integrity": "sha512-iXD+Wqpk0FpwJpQbAFKw+8AL6ipfDjQ7g+MYZ7lU1H7/gCxM2XqLI4eW7Il+FAwk7orepDuoSbJSVcsNJYKjOA==",
       "peerDependencies": {
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@trezor/schema-utils": {
       "version": "1.2.3",
-      "license": "See LICENSE.md in repo root",
+      "resolved": "https://registry.npmjs.org/@trezor/schema-utils/-/schema-utils-1.2.3.tgz",
+      "integrity": "sha512-+/GmaSTfUf8nEBSSWz/SV0W/0l37YQBfDMygAKXlKMbtXJI03PHqkEF/jQrt+BP2Gh24gjo5GNqCwx7EIlzZug==",
       "dependencies": {
         "@sinclair/typebox": "^0.33.7",
         "ts-mixer": "^6.0.3"
@@ -9068,7 +10737,8 @@
     },
     "node_modules/@trezor/transport": {
       "version": "1.3.7",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/transport/-/transport-1.3.7.tgz",
+      "integrity": "sha512-pxoPbgaDKUg5ElgyzW+vuQ1YLLX75W/bfAk0V6SdPGqpd3V+6NvJaNQVxAnmL6k3qzHheBFrqyhlkkkEdyuuSQ==",
       "dependencies": {
         "@trezor/protobuf": "1.2.6",
         "@trezor/protocol": "1.2.2",
@@ -9084,18 +10754,21 @@
     },
     "node_modules/@trezor/transport/node_modules/cross-fetch": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/@trezor/type-utils": {
       "version": "1.1.4",
-      "license": "See LICENSE.md in repo root"
+      "resolved": "https://registry.npmjs.org/@trezor/type-utils/-/type-utils-1.1.4.tgz",
+      "integrity": "sha512-pzrIdskmTZRocHellMZxCDPQ3IpmTr749qn1xdIN29pIKuI4ms0OfNUPk/rfR4Iug0kEiWt+n+Hw7+lIBzc2LA=="
     },
     "node_modules/@trezor/utils": {
       "version": "9.2.6",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/utils/-/utils-9.2.6.tgz",
+      "integrity": "sha512-8kJYRcOm2uD9uAzktXFivY9Ctkub39MUQCo0TIFzL01erzSDt5i9f81meIgLANm8cgmg3PPVA6SWyitOKRkKpg==",
       "dependencies": {
         "bignumber.js": "^9.1.2"
       },
@@ -9105,7 +10778,8 @@
     },
     "node_modules/@trezor/utxo-lib": {
       "version": "2.2.6",
-      "license": "SEE LICENSE IN LICENSE.md",
+      "resolved": "https://registry.npmjs.org/@trezor/utxo-lib/-/utxo-lib-2.2.6.tgz",
+      "integrity": "sha512-OAwN1d4CXU/7LhczatdL/xKaYcyjxWiURYfG5hOfscTvhaDZ+veFhxo6YHJ2fGGlpZwS+B14JRsmDoXAelIeeA==",
       "dependencies": {
         "@trezor/utils": "9.2.6",
         "bchaddrjs": "^0.5.2",
@@ -9131,18 +10805,21 @@
     },
     "node_modules/@trezor/utxo-lib/node_modules/base-x": {
       "version": "5.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
+      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/@trezor/utxo-lib/node_modules/bs58check": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -9150,23 +10827,27 @@
     },
     "node_modules/@tronweb3/google-protobuf": {
       "version": "3.21.2",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
+      "resolved": "https://registry.npmjs.org/@tronweb3/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-IVcT2GfWX3K6tHUVhs14NP5uzKhQt4KeDya1g9ACxuZsUzsaoGUIGzceK2Ltu7xp1YV94AaHOf4yxLAivlvEkQ=="
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+      "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+      "dev": true
     },
     "node_modules/@types/bn.js": {
       "version": "5.1.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.6.tgz",
+      "integrity": "sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -9176,26 +10857,30 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "dependencies": {
         "@types/ms": "*"
       }
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.6.tgz",
+      "integrity": "sha512-lPByRJUer/iN/xa4qpyL0qmL11DqNW81iU/IG1S3uvRUq4oKagz8VCxZjiWkumgt66YT3vOdDgZ0o32sGKtCEw==",
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
@@ -9203,48 +10888,57 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/lodash": {
       "version": "4.17.13",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
+      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg=="
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
+      "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
       "version": "20.17.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.10.tgz",
+      "integrity": "sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -9252,22 +10946,26 @@
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
     "node_modules/@types/pbkdf2": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-uRwJqmiXmh9++aSu1VNEn3iIxWOhd8AHXNSdlaLfdAAdSTY9jYVeGWnzejM3dvrkbqE3/hyQkQQ29IFATEGlew==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ=="
     },
     "node_modules/@types/react": {
       "version": "18.3.17",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.17.tgz",
+      "integrity": "sha512-opAQ5no6LqJNo9TqnxBKsgnkIYHozW9KSTlFVoSUJYh1Fl/sswkEoqIugRSm7tbh6pABtYjGAjW+GOS23j8qbw==",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -9275,24 +10973,27 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
+      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "devOptional": true,
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/@types/react-infinite-scroller": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-infinite-scroller/-/react-infinite-scroller-1.2.5.tgz",
+      "integrity": "sha512-fJU1jhMgoL6NJFrqTM0Ob7tnd2sQWGxe2ESwiU6FZWbJK/VO/Er5+AOhc+e2zbT0dk5pLygqctsulOLJ8xnSzw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/react-redux": {
       "version": "7.1.34",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
+      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
         "@types/react": "*",
@@ -9302,61 +11003,72 @@
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
       "peerDependencies": {
         "@types/react": "*"
       }
     },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/secp256k1": {
       "version": "4.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.6.tgz",
+      "integrity": "sha512-hHxJU6PAEUn0TP4S/ZOzuTUvJWuZ6eIKeNKb5RBpODvSl6hp1Wrw4s7ATY50rklRCScUDpHzVA/DQdSjJ3UoYQ==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/w3c-web-usb": {
       "version": "1.0.10",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.10.tgz",
+      "integrity": "sha512-CHgUI5kTc/QLMP8hODUHhge0D4vx+9UiAwIGiT0sTy/B2XpdX1U5rJt6JSISgr6ikRT7vxV9EVAFeYZqUnl1gQ=="
     },
     "node_modules/@types/web": {
       "version": "0.0.174",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.174.tgz",
+      "integrity": "sha512-dT8gX38RUQjy+uruZg49EvloEa2S3gR0z2eRi557eTSFKqUSXkSCWYa0IY9uabX9MZPMGOu+1r8Qn6tsvJ1KnQ=="
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
+      "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -9388,8 +11100,9 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
       "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9399,8 +11112,9 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
+      "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -9425,8 +11139,9 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0"
@@ -9441,8 +11156,9 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.62.0.tgz",
+      "integrity": "sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/typescript-estree": "5.62.0",
         "@typescript-eslint/utils": "5.62.0",
@@ -9467,8 +11183,9 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -9479,8 +11196,9 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "@typescript-eslint/visitor-keys": "5.62.0",
@@ -9505,8 +11223,9 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9516,8 +11235,9 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
@@ -9541,8 +11261,9 @@
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
       "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9552,8 +11273,9 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "5.62.0",
         "eslint-visitor-keys": "^3.3.0"
@@ -9568,13 +11290,15 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
+      "integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
+      "dev": true
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react-swc/-/plugin-react-swc-3.7.2.tgz",
+      "integrity": "sha512-y0byko2b2tSVVf5Gpng1eEhX1OvPC7x8yns1Fx8jDzlJp4LS6CMkCPfLw47cjyoMrshQDoQw4qcgjsU9VvlCew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@swc/core": "^1.7.26"
       },
@@ -9584,8 +11308,9 @@
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.0.tgz",
+      "integrity": "sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "1.6.0",
         "@vitest/utils": "1.6.0",
@@ -9597,8 +11322,9 @@
     },
     "node_modules/@vitest/runner": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.0.tgz",
+      "integrity": "sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "1.6.0",
         "p-limit": "^5.0.0",
@@ -9610,8 +11336,9 @@
     },
     "node_modules/@vitest/runner/node_modules/p-limit": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -9624,8 +11351,9 @@
     },
     "node_modules/@vitest/runner/node_modules/yocto-queue": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+      "integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.20"
       },
@@ -9635,8 +11363,9 @@
     },
     "node_modules/@vitest/snapshot": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.0.tgz",
+      "integrity": "sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "magic-string": "^0.30.5",
         "pathe": "^1.1.1",
@@ -9648,8 +11377,9 @@
     },
     "node_modules/@vitest/spy": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
+      "integrity": "sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^2.2.0"
       },
@@ -9659,8 +11389,9 @@
     },
     "node_modules/@vitest/utils": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.0.tgz",
+      "integrity": "sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "diff-sequences": "^29.6.3",
         "estree-walker": "^3.0.3",
@@ -9673,29 +11404,33 @@
     },
     "node_modules/@vitest/utils/node_modules/estree-walker": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
     },
     "node_modules/@volar/language-core": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
+      "integrity": "sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@volar/source-map": "2.4.11"
       }
     },
     "node_modules/@volar/source-map": {
       "version": "2.4.11",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.11.tgz",
+      "integrity": "sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==",
+      "dev": true
     },
     "node_modules/@volar/typescript": {
       "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.11.tgz",
+      "integrity": "sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "2.4.11",
         "path-browserify": "^1.0.1",
@@ -9704,8 +11439,9 @@
     },
     "node_modules/@vue/compiler-core": {
       "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.13.tgz",
+      "integrity": "sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/shared": "3.5.13",
@@ -9716,8 +11452,9 @@
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.13.tgz",
+      "integrity": "sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vue/compiler-core": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -9725,8 +11462,9 @@
     },
     "node_modules/@vue/compiler-vue2": {
       "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "de-indent": "^1.0.2",
         "he": "^1.2.0"
@@ -9734,8 +11472,9 @@
     },
     "node_modules/@vue/language-core": {
       "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.1.10.tgz",
+      "integrity": "sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@volar/language-core": "~2.4.8",
         "@vue/compiler-dom": "^3.5.0",
@@ -9757,16 +11496,18 @@
     },
     "node_modules/@vue/language-core/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@vue/language-core/node_modules/minimatch": {
       "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -9779,11 +11520,14 @@
     },
     "node_modules/@vue/shared": {
       "version": "3.5.13",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
+      "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
+      "dev": true
     },
     "node_modules/@wagmi/connectors": {
       "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-3.1.11.tgz",
+      "integrity": "sha512-wzxp9f9PtSUFjDUP/QDjc1t7HON4D8wrVKsw35ejdO8hToDpx1gU9lwH/47Zo/1zExGezQc392sjoHSszYd7OA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -9794,7 +11538,6 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.6.6",
         "@safe-global/safe-apps-provider": "^0.18.1",
@@ -9818,7 +11561,8 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -9827,7 +11571,8 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -9835,14 +11580,16 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -9854,7 +11601,8 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
+      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -9874,14 +11622,16 @@
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@wagmi/connectors/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -9889,14 +11639,18 @@
     },
     "node_modules/@wagmi/connectors/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@wagmi/connectors/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@wagmi/core": {
       "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-1.4.13.tgz",
+      "integrity": "sha512-ytMCvXbBOgfDu9Qw67279wq/jNEe7EZLjLyekX7ROnvHRADqFr3lwZI6ih41UmtRZAmXAx8Ghyuqy154EjB5mQ==",
       "funding": [
         {
           "type": "gitcoin",
@@ -9907,7 +11661,6 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@wagmi/connectors": "3.1.11",
         "abitype": "0.8.7",
@@ -9926,7 +11679,8 @@
     },
     "node_modules/@wallet-standard/app": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
+      "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -9936,14 +11690,16 @@
     },
     "node_modules/@wallet-standard/base": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wallet-standard/core": {
       "version": "1.0.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/core/-/core-1.0.3.tgz",
+      "integrity": "sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg==",
       "dependencies": {
         "@wallet-standard/app": "^1.0.1",
         "@wallet-standard/base": "^1.0.1",
@@ -9956,7 +11712,8 @@
     },
     "node_modules/@wallet-standard/features": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -9966,7 +11723,8 @@
     },
     "node_modules/@wallet-standard/wallet": {
       "version": "1.1.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
       "dependencies": {
         "@wallet-standard/base": "^1.1.0"
       },
@@ -9976,7 +11734,8 @@
     },
     "node_modules/@walletconnect/browser-utils": {
       "version": "1.8.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/browser-utils/-/browser-utils-1.8.0.tgz",
+      "integrity": "sha512-Wcqqx+wjxIo9fv6eBUFHPsW1y/bGWWRboni5dfD8PtOmrihrEpOCmvRJe4rfl7xgJW8Ea9UqKEaq0bIRLHlK4A==",
       "dependencies": {
         "@walletconnect/safe-json": "1.0.0",
         "@walletconnect/types": "^1.8.0",
@@ -9987,7 +11746,8 @@
     },
     "node_modules/@walletconnect/core": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.17.3.tgz",
+      "integrity": "sha512-57uv0FW4L6H/tmkb1kS2nG41MDguyDgZbGR58nkDUd1TO/HydyiTByVOhFzIxgN331cnY/1G1rMaKqncgdnOFA==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-provider": "1.0.14",
@@ -10013,14 +11773,16 @@
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -10032,18 +11794,21 @@
     },
     "node_modules/@walletconnect/core/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/core/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/crypto": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/crypto/-/crypto-1.0.3.tgz",
+      "integrity": "sha512-+2jdORD7XQs76I2Odgr3wwrtyuLUXD/kprNVsjWRhhhdO9Mt6WqVzOPu0/t7OHSmgal8k7SoBQzUc5hu/8zL/g==",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/environment": "^1.0.1",
@@ -10055,11 +11820,13 @@
     },
     "node_modules/@walletconnect/crypto/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/encoding": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/encoding/-/encoding-1.0.2.tgz",
+      "integrity": "sha512-CrwSBrjqJ7rpGQcTL3kU+Ief+Bcuu9PH6JLOb+wM6NITX1GTxR/MfNwnQfhLKK6xpRAyj2/nM04OOH6wS8Imag==",
       "dependencies": {
         "is-typedarray": "1.0.0",
         "tslib": "1.14.1",
@@ -10068,22 +11835,26 @@
     },
     "node_modules/@walletconnect/encoding/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/environment": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/environment/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.11.0.tgz",
+      "integrity": "sha512-YrTeHVjuSuhlUw7SQ6xBJXDuJ6iAC+RwINm9nVhoKYJSHAy3EVSJZOofMKrnecL0iRMtD29nj57mxAInIBRuZA==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "^1.0.13",
@@ -10099,7 +11870,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/core": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -10122,7 +11894,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -10131,7 +11904,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -10140,7 +11914,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -10148,7 +11923,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -10158,14 +11934,17 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/sign-client": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.0.tgz",
+      "integrity": "sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==",
+      "deprecated": "Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases",
       "dependencies": {
         "@walletconnect/core": "2.11.0",
         "@walletconnect/events": "^1.0.1",
@@ -10180,7 +11959,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -10192,7 +11972,8 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
+      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -10212,14 +11993,16 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -10227,15 +12010,18 @@
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -10254,7 +12040,8 @@
     },
     "node_modules/@walletconnect/events": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -10262,11 +12049,13 @@
     },
     "node_modules/@walletconnect/events/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/heartbeat": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -10275,7 +12064,8 @@
     },
     "node_modules/@walletconnect/jsonrpc-http-connection": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
+      "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -10285,18 +12075,21 @@
     },
     "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-http-connection/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -10305,18 +12098,21 @@
     },
     "node_modules/@walletconnect/jsonrpc-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
       "dependencies": {
         "events": "^3.3.0",
         "keyvaluestorage-interface": "^1.0.0"
@@ -10324,7 +12120,8 @@
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
         "@walletconnect/jsonrpc-types": "^1.0.3",
@@ -10333,11 +12130,13 @@
     },
     "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.16",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -10347,18 +12146,21 @@
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -10377,7 +12179,8 @@
     },
     "node_modules/@walletconnect/keyvaluestorage": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.1",
         "idb-keyval": "^6.2.1",
@@ -10394,18 +12197,21 @@
     },
     "node_modules/@walletconnect/keyvaluestorage/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/keyvaluestorage/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/legacy-client": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-client/-/legacy-client-2.0.0.tgz",
+      "integrity": "sha512-v5L7rYk9loVnfvUf0mF+76bUPFaU5/Vh7mzL6/950CD/yoGdzYZ3Kj+L7mkC6HPMEGeQsBP1+sqBuiVGZ/aODA==",
       "dependencies": {
         "@walletconnect/crypto": "^1.0.3",
         "@walletconnect/encoding": "^1.0.2",
@@ -10421,21 +12227,24 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-client/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -10443,11 +12252,13 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@walletconnect/legacy-client/node_modules/query-string": {
       "version": "6.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -10463,11 +12274,13 @@
     },
     "node_modules/@walletconnect/legacy-client/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/legacy-modal": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-modal/-/legacy-modal-2.0.0.tgz",
+      "integrity": "sha512-jckNd8lMhm4X7dX9TDdxM3bXKJnaqkRs6K2Mo5j6GmbIF9Eyx40jZ5+q457RVxvM6ciZEDT5s1wBHWdWoOo+9Q==",
       "dependencies": {
         "@walletconnect/legacy-types": "^2.0.0",
         "@walletconnect/legacy-utils": "^2.0.0",
@@ -10478,14 +12291,16 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/camelcase": {
       "version": "5.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/cliui": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -10494,11 +12309,13 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/find-up": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -10509,14 +12326,16 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/locate-path": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -10526,7 +12345,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -10539,7 +12359,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/p-locate": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -10549,14 +12370,16 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/pngjs": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/preact": {
       "version": "10.25.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.25.3.tgz",
+      "integrity": "sha512-dzQmIFtM970z+fP9ziQ3yG4e3ULIbwZzJ734vaMVUTaKQ2+Ru1Ou/gjshOYVHCcd1rpAelC6ngjvjDXph98unQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -10564,7 +12387,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/qrcode": {
       "version": "1.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "pngjs": "^5.0.0",
@@ -10579,7 +12403,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10591,7 +12416,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10603,7 +12429,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/yargs": {
       "version": "15.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -10623,7 +12450,8 @@
     },
     "node_modules/@walletconnect/legacy-modal/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -10634,7 +12462,8 @@
     },
     "node_modules/@walletconnect/legacy-provider": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-provider/-/legacy-provider-2.0.0.tgz",
+      "integrity": "sha512-A8xPebMI1A+50HbWwTpFCbwP7G+1NGKdTKyg8BUUg3h3Y9JucpC1W6w/x0v1Xw7qFEqQnz74LoIN/A3ytH9xrQ==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.4",
         "@walletconnect/jsonrpc-provider": "^1.0.6",
@@ -10646,14 +12475,16 @@
     },
     "node_modules/@walletconnect/legacy-types": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-types/-/legacy-types-2.0.0.tgz",
+      "integrity": "sha512-sOVrA7HUdbI1OwKyPOQU0/DdvTSVFlsXWpAk2K2WvP2erTkBWPMTJq6cv2BmKdoJ3p6gLApT7sd+jHi3OF71uw==",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
     },
     "node_modules/@walletconnect/legacy-utils": {
       "version": "2.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/legacy-utils/-/legacy-utils-2.0.0.tgz",
+      "integrity": "sha512-CPWxSVVXw0kgNCxvU126g4GiV3mzXmC8IPJ15twE46aJ1FX+RHEIfAzFMFz2F2+fEhBxL63A7dwNQKDXorRPcQ==",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.4",
@@ -10667,21 +12498,24 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -10689,11 +12523,13 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/query-string": {
       "version": "6.14.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.14.1.tgz",
+      "integrity": "sha512-XDxAeVmpfu1/6IjyT/gXHOl+S0vQ9owggJ30hhWKdHAsNPOcasn5o9BW0eejZqL2e4vMjhAxoW3jVHcD6mbcYw==",
       "dependencies": {
         "decode-uri-component": "^0.2.0",
         "filter-obj": "^1.1.0",
@@ -10709,11 +12545,13 @@
     },
     "node_modules/@walletconnect/legacy-utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/logger": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
+      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
       "dependencies": {
         "@walletconnect/safe-json": "^1.0.2",
         "pino": "7.11.0"
@@ -10721,22 +12559,27 @@
     },
     "node_modules/@walletconnect/logger/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/logger/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/mobile-registry": {
       "version": "1.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@walletconnect/mobile-registry/-/mobile-registry-1.4.0.tgz",
+      "integrity": "sha512-ZtKRio4uCZ1JUF7LIdecmZt7FOLnX72RPSY7aUVu7mj7CSfxDwUn6gBuK6WGtH+NZCldBqDl5DenI5fFSvkKYw==",
+      "deprecated": "Deprecated in favor of dynamic registry available from: https://github.com/walletconnect/walletconnect-registry"
     },
     "node_modules/@walletconnect/modal": {
       "version": "2.6.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.6.2.tgz",
+      "integrity": "sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==",
       "dependencies": {
         "@walletconnect/modal-core": "2.6.2",
         "@walletconnect/modal-ui": "2.6.2"
@@ -10744,14 +12587,16 @@
     },
     "node_modules/@walletconnect/modal-core": {
       "version": "2.6.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.6.2.tgz",
+      "integrity": "sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==",
       "dependencies": {
         "valtio": "1.11.2"
       }
     },
     "node_modules/@walletconnect/modal-ui": {
       "version": "2.6.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.6.2.tgz",
+      "integrity": "sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==",
       "dependencies": {
         "@walletconnect/modal-core": "2.6.2",
         "lit": "2.8.0",
@@ -10761,14 +12606,16 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/camelcase": {
       "version": "5.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/cliui": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -10777,11 +12624,13 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/@walletconnect/modal-ui/node_modules/find-up": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -10792,14 +12641,16 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/locate-path": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -10809,7 +12660,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -10822,7 +12674,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/p-locate": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -10832,14 +12685,16 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/pngjs": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@walletconnect/modal-ui/node_modules/qrcode": {
       "version": "1.5.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -10855,7 +12710,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -10867,7 +12723,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -10879,7 +12736,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/yargs": {
       "version": "15.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -10899,7 +12757,8 @@
     },
     "node_modules/@walletconnect/modal-ui/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -10910,7 +12769,9 @@
     },
     "node_modules/@walletconnect/qrcode-modal": {
       "version": "1.8.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/qrcode-modal/-/qrcode-modal-1.8.0.tgz",
+      "integrity": "sha512-BueaFefaAi8mawE45eUtztg3ZFbsAH4DDXh1UNwdUlsvFMjqcYzLUG0xZvDd6z2eOpbgDg2N3bl6gF0KONj1dg==",
+      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/",
       "dependencies": {
         "@walletconnect/browser-utils": "^1.8.0",
         "@walletconnect/mobile-registry": "^1.4.0",
@@ -10922,7 +12783,8 @@
     },
     "node_modules/@walletconnect/randombytes": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.3.tgz",
+      "integrity": "sha512-35lpzxcHFbTN3ABefC9W+uBpNZl1GC4Wpx0ed30gibfO/y9oLdy1NznbV96HARQKSBV9J9M/rrtIvf6a23jfYw==",
       "dependencies": {
         "@walletconnect/encoding": "^1.0.2",
         "@walletconnect/environment": "^1.0.1",
@@ -10932,18 +12794,21 @@
     },
     "node_modules/@walletconnect/randombytes/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/relay-api": {
       "version": "1.0.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
       "dependencies": {
         "@walletconnect/jsonrpc-types": "^1.0.2"
       }
     },
     "node_modules/@walletconnect/relay-auth": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.0.4.tgz",
+      "integrity": "sha512-kKJcS6+WxYq5kshpPaxGHdwf5y98ZwbfuS4EE/NkQzqrDFm5Cj+dP8LofzWvjrrLkZq7Afy7WrQMXdLy8Sx7HQ==",
       "dependencies": {
         "@stablelib/ed25519": "^1.0.2",
         "@stablelib/random": "^1.0.1",
@@ -10955,22 +12820,26 @@
     },
     "node_modules/@walletconnect/relay-auth/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/relay-auth/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/safe-json": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.0.tgz",
+      "integrity": "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="
     },
     "node_modules/@walletconnect/sign-client": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.17.3.tgz",
+      "integrity": "sha512-OzOWxRTfVGCHU3OOF6ibPkgPfDpivFJjuknfcOUt9PYWpTAv6YKOmT4cyfBPhc7llruyHpV44fYbykMcLIvEcg==",
       "dependencies": {
         "@walletconnect/core": "2.17.3",
         "@walletconnect/events": "1.0.1",
@@ -10985,7 +12854,8 @@
     },
     "node_modules/@walletconnect/sign-client/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -10997,22 +12867,27 @@
     },
     "node_modules/@walletconnect/time": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/time/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
       "version": "1.8.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-1.8.0.tgz",
+      "integrity": "sha512-Cn+3I0V0vT9ghMuzh1KzZvCkiAxTq+1TR2eSqw5E5AVWfmCtECFkVZBP6uUJZ8YjwLqXheI+rnjqPy7sVM4Fyg==",
+      "deprecated": "WalletConnect's v1 SDKs are now deprecated. Please upgrade to a v2 SDK. For details see: https://docs.walletconnect.com/"
     },
     "node_modules/@walletconnect/universal-provider": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.11.0.tgz",
+      "integrity": "sha512-zgJv8jDvIMP4Qse/D9oIRXGdfoNqonsrjPZanQ/CHNe7oXGOBiQND2IIeX+tS0H7uNA0TPvctljCLiIN9nw4eA==",
       "dependencies": {
         "@walletconnect/jsonrpc-http-connection": "^1.0.7",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -11027,7 +12902,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/core": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-2Tjp5BCevI7dbmqo/OrCjX4tqgMqwJNQLlQAlphqPfvwlF9+tIu6pGcVbSN3U9zyXzWIZCeleqEaWUeSeET4Ew==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -11050,7 +12926,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/heartbeat": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.1.tgz",
+      "integrity": "sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/time": "^1.0.2",
@@ -11059,7 +12936,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
@@ -11068,7 +12946,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-types": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -11076,7 +12955,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/jsonrpc-ws-connection": {
       "version": "1.0.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.14.tgz",
+      "integrity": "sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.2",
@@ -11086,14 +12966,17 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/sign-client": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.11.0.tgz",
+      "integrity": "sha512-H2ukscibBS+6WrzQWh+WyVBqO5z4F5et12JcwobdwgHnJSlqIoZxqnUYYWNCI5rUR5UKsKWaUyto4AE9N5dw4Q==",
+      "deprecated": "Reliability and performance greatly improved - please see https://github.com/WalletConnect/walletconnect-monorepo/releases",
       "dependencies": {
         "@walletconnect/core": "2.11.0",
         "@walletconnect/events": "^1.0.1",
@@ -11108,7 +12991,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/types": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
+      "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -11120,7 +13004,8 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/utils": {
       "version": "2.11.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.11.0.tgz",
+      "integrity": "sha512-hxkHPlTlDQILHfIKXlmzgNJau/YcSBC3XHUSuZuKZbNEw3duFT6h6pm3HT/1+j1a22IG05WDsNBuTCRkwss+BQ==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -11140,14 +13025,16 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/universal-provider/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -11155,15 +13042,18 @@
     },
     "node_modules/@walletconnect/universal-provider/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@walletconnect/universal-provider/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/universal-provider/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -11182,7 +13072,8 @@
     },
     "node_modules/@walletconnect/utils": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.17.3.tgz",
+      "integrity": "sha512-tG77UpZNeLYgeOwViwWnifpyBatkPlpKSSayhN0gcjY1lZAUNqtYslpm4AdTxlrA3pL61MnyybXgWYT5eZjarw==",
       "dependencies": {
         "@ethersproject/hash": "5.7.0",
         "@ethersproject/transactions": "5.7.0",
@@ -11208,14 +13099,16 @@
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/safe-json": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/types": {
       "version": "2.17.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.17.3.tgz",
+      "integrity": "sha512-5eFxnbZGJJx0IQyCS99qz+OvozpLJJYfVG96dEHGgbzZMd+C9V1eitYqVClx26uX6V+WQVqVwjpD2Dyzie++Wg==",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
@@ -11227,14 +13120,16 @@
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/window-getters": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
       "dependencies": {
         "tslib": "1.14.1"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/@walletconnect/window-metadata": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.1",
         "tslib": "1.14.1"
@@ -11242,26 +13137,32 @@
     },
     "node_modules/@walletconnect/utils/node_modules/detect-browser": {
       "version": "5.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/@walletconnect/utils/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/window-getters": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.0.tgz",
+      "integrity": "sha512-xB0SQsLaleIYIkSsl43vm8EwETpBzJ2gnzk7e0wMF3ktqiTGS6TFHxcprMl5R44KKh4tCcHCJwolMCaDSwtAaA=="
     },
     "node_modules/@walletconnect/window-metadata": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.0.tgz",
+      "integrity": "sha512-9eFvmJxIKCC3YWOL97SgRkKhlyGXkrHwamfechmqszbypFspaSk+t2jQXAEU7YClHF6Qjw5eYOmy1//zFi9/GA==",
       "dependencies": {
         "@walletconnect/window-getters": "^1.0.0"
       }
     },
     "node_modules/@web3modal/core": {
       "version": "2.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.4.3.tgz",
+      "integrity": "sha512-7Z/sDe9RIYQ2k9ITcxgEa/u7FvlI76vcVVZn9UY4ISivefqrH4JAS3GX4JmVNUUlovwuiZdyqBv4llAQOMK6Rg==",
+      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
       "dependencies": {
         "buffer": "6.0.3",
         "valtio": "1.10.5"
@@ -11269,14 +13170,16 @@
     },
     "node_modules/@web3modal/core/node_modules/use-sync-external-store": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@web3modal/core/node_modules/valtio": {
       "version": "1.10.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.5.tgz",
+      "integrity": "sha512-jTp0k63VXf4r5hPoaC6a6LCG4POkVSh629WLi1+d5PlajLsbynTMd7qAgEiOSPxzoX5iNvbN7iZ/k/g29wrNiQ==",
       "dependencies": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -11295,7 +13198,9 @@
     },
     "node_modules/@web3modal/standalone": {
       "version": "2.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.4.3.tgz",
+      "integrity": "sha512-5ATXBoa4GGm+TIUSsKWsfWCJunv1XevOizpgTFhqyeGgRDmWhqsz9UIPzH/1mk+g0iJ/xqMKs5F6v9D2QeKxag==",
+      "deprecated": "This package has been deprecated in favor of @walletconnect/modal. Please read more at https://docs.walletconnect.com",
       "dependencies": {
         "@web3modal/core": "2.4.3",
         "@web3modal/ui": "2.4.3"
@@ -11303,7 +13208,9 @@
     },
     "node_modules/@web3modal/ui": {
       "version": "2.4.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.4.3.tgz",
+      "integrity": "sha512-J989p8CdtEhI9gZHf/rZ/WFqYlrAHWw9GmAhFoiNODwjAp0BoG/uoaPiijJMchXdngihZOjLGCQwDXU16DHiKg==",
+      "deprecated": "Web3Modal is now Reown AppKit. Please follow the upgrade guide at https://docs.reown.com/appkit/upgrade/from-w3m-to-reown",
       "dependencies": {
         "@web3modal/core": "2.4.3",
         "lit": "2.7.5",
@@ -11313,14 +13220,16 @@
     },
     "node_modules/@web3modal/ui/node_modules/camelcase": {
       "version": "5.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@web3modal/ui/node_modules/cliui": {
       "version": "6.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
@@ -11329,11 +13238,13 @@
     },
     "node_modules/@web3modal/ui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/@web3modal/ui/node_modules/find-up": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
@@ -11344,14 +13255,16 @@
     },
     "node_modules/@web3modal/ui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@web3modal/ui/node_modules/lit": {
       "version": "2.7.5",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.5.tgz",
+      "integrity": "sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -11360,7 +13273,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/locate-path": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
       "dependencies": {
         "p-locate": "^4.1.0"
       },
@@ -11370,7 +13284,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -11383,7 +13298,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/p-locate": {
       "version": "4.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
       "dependencies": {
         "p-limit": "^2.2.0"
       },
@@ -11393,14 +13309,16 @@
     },
     "node_modules/@web3modal/ui/node_modules/pngjs": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/@web3modal/ui/node_modules/qrcode": {
       "version": "1.5.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "encode-utf8": "^1.0.3",
@@ -11416,7 +13334,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -11428,7 +13347,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/wrap-ansi": {
       "version": "6.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -11440,7 +13360,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/yargs": {
       "version": "15.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
       "dependencies": {
         "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
@@ -11460,7 +13381,8 @@
     },
     "node_modules/@web3modal/ui/node_modules/yargs-parser": {
       "version": "18.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -11471,7 +13393,8 @@
     },
     "node_modules/@wormhole-foundation/sdk": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.3.0-beta.3.tgz",
+      "integrity": "sha512-/xHaMGHNQFKNcqREyx7O0VLEkoSaqAEj76Siu9S5OgphapYfvXbbVxVCjb+3vLUi4LG01nfdMAPoK6vwXvEcSA==",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-algorand-core": "1.3.0-beta.3",
@@ -11506,7 +13429,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.3.0-beta.3.tgz",
+      "integrity": "sha512-CJrdj++y/n8q+WqdOxpM1/n22yrEIRxbWFmTTvySv2I9sb3OwMiZmN4+9k3sBQJS91xZ703eHtGunsQoyPTHTg==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "algosdk": "2.7.0"
@@ -11517,7 +13441,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-ziqbbVjDKRDCnX2sEBbBpEVWx/cAMOpp2jCrsI7JQCSlByFqTl/FaQk+ITKnxmQuZQ2lzJDZbMq8Ql1ZtfkrmA==",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -11528,7 +13453,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-BcZ9Y98yQPFtZSu8s10VEptf4/WNSJJy/bM0nQNiLQgao2TqL+nw+0BCKrnIux7vYzGWMAWyZdsXL4nbyetPrA==",
       "dependencies": {
         "@wormhole-foundation/sdk-algorand": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-algorand-core": "1.3.0-beta.3",
@@ -11540,7 +13466,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.3.0-beta.3.tgz",
+      "integrity": "sha512-/O1Hk2KOWHXqZ9IN99uPgKCxBtUjFyJkuoVMsjtDcAqABLA0oZhVOuOT33Nf2zui+/B8a99cXYKZV/HFnVzddg==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "aptos": "1.21.0"
@@ -11551,7 +13478,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-joagrPoKX7QrCXUP7gnKHZgvleyrsRzEyYo0z/2V4CA3wSJZPXINen7ssbVwYYWt5yRLkHHhBVYfkpdWHd+W1g==",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -11562,7 +13490,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-/9I5lqd4P212dQIBuST8osbbD+P4o2ae7M307H+6rPWqjT0HJpILQW5BvQTGWeL2sm3DIZBwePBYPfgW13TS0A==",
       "dependencies": {
         "@wormhole-foundation/sdk-aptos": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -11573,7 +13502,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@noble/hashes": {
       "version": "1.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "engines": {
         "node": ">= 16"
       },
@@ -11583,14 +13513,16 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/base": {
       "version": "1.1.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/@scure/bip39": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
       "dependencies": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
@@ -11601,7 +13533,9 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/aptos": {
       "version": "1.21.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.21.0.tgz",
+      "integrity": "sha512-PRKjoFgL8tVEc9+oS7eJUv8GNxx8n3+0byH2+m7CP3raYOD6yFKOecuwjVMIJmgfpjp6xH0P0HDMGZAXmSyU0Q==",
+      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
       "dependencies": {
         "@aptos-labs/aptos-client": "^0.1.0",
         "@noble/hashes": "1.3.3",
@@ -11616,11 +13550,13 @@
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@wormhole-foundation/sdk-aptos/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11632,7 +13568,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-base": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0-beta.3.tgz",
+      "integrity": "sha512-5j1DL9enxAEMPBu1UEjjWbT9fmXV+iMAvwv6l8/QEhEFzdUpaWAyBApdixnGsoxvF7wEFYK3+voA6Zc5Eu+j8Q==",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
@@ -11640,7 +13577,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.3.0-beta.3.tgz",
+      "integrity": "sha512-8Metv+O+HzUVAFzY4JfwL/4R5dTmNTmy6q6ZTqo6YkPmm5tCc7XHSXLqhwVwENMqvFVraXvwzTpuqAqOEsA7wg==",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-definitions": "1.3.0-beta.3",
@@ -11652,7 +13590,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.3.0-beta.3.tgz",
+      "integrity": "sha512-LL3vwHjXWzdqXdrBt8+CBfapdpXKejt3OlXUzT+svCxBSYgmz+2U6Q027RcGeMEaaDBDFdX/Du57kZ/NEcYCeA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
@@ -11667,7 +13606,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-dj3x/iXQJBafPd0NnelAkrNS44AJrXe0MqVmWYWVKRJPnEiOOVp2bpAM3T61oYCL1MSChHUlPLq+a+5jNCoQFg==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
@@ -11681,7 +13621,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.3.0-beta.3.tgz",
+      "integrity": "sha512-0x6fvSmrKPE2XyHpyux6k5oLc46TzBaAWTsIJom8bAWICwf+ErWRPUjaMFjFnzkzoGpLe6C6CzkdzURqFhb9PA==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
@@ -11697,7 +13638,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-Xjcb8q4vlUtrpgcvnK+wBIPEOgJkihUQjUI7rKh1cGw1h2PXRdrZFStJelCNiGD3Hti3PzEXe0+wyc/s+Oi/jg==",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
@@ -11710,6 +13652,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
       "version": "1.3.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.3.0-beta.3.tgz",
+      "integrity": "sha512-fRdi49L0BBrWgNM1QlA4IS9kSvvMsmiLZFx6AXv6f95CTGVtplxmplTcTRUf9fTiiRBq9AfEWVKiS5vywE686w==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
@@ -11718,6 +13662,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions-ntt/-/sdk-definitions-ntt-0.6.1.tgz",
+      "integrity": "sha512-OVaskp2xFv/y9qloVuTA5xXwDErKBREQkN8mrFYNG9vsI5r/wzItkPt0/RzGBtClT7beWt3ZfLOULzSpi6ktyw==",
       "peerDependencies": {
         "@wormhole-foundation/sdk-base": "^1.0.0",
         "@wormhole-foundation/sdk-definitions": "^1.0.0"
@@ -11725,7 +13671,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.3.0-beta.3.tgz",
+      "integrity": "sha512-I4DS1JXrLvUstjVUn0iZQpqbTrEU3gKmZ5G1W/cXtgNBxcHEBvJW6xl2Y0y1XriXQIQHLyovXArRtq/xVbWxrA==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "ethers": "^6.5.1"
@@ -11736,7 +13683,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.3.0-beta.3.tgz",
+      "integrity": "sha512-ChTV5rNkrNE/HTrhJ2KjVXtEWrsxudxf7W4f+LSl09hD67ytOPUnM0rCpsOe8f7dRiMzFnVjsL3JybvhwrfeNA==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -11748,7 +13696,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-TXPbpmTEK6wurFCxeq9wQRkWaywl7Kt7fcR6bRuOiktp5rh+8PKlVAFVxG/x/lrtJuCNDiZmzbdgljJjdELhCw==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -11760,7 +13709,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-ntt": {
       "version": "0.6.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-ntt/-/sdk-evm-ntt-0.6.1.tgz",
+      "integrity": "sha512-PT/05wur6iRGfmfy52QQb7NSoNtvhQ31DVtSl19ugYBGHM6rccAs+QstihwyQ1AfX2CNzOoxGschIQ2Q06CD+w==",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "ethers": "^6.5.1"
@@ -11777,7 +13727,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.3.0-beta.3.tgz",
+      "integrity": "sha512-odATK5hABkkWtvDRMkG3zqwx5EExhyq16cyCHwz8we5yDrDHTyNqxrIoXGwygBmXSz/lzRgwrTwLVp7vanhlXA==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -11791,7 +13742,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-PdDeQZXV8Qa8+5UysecTMCCq7SMr0HqjSvf/ZirrcF4v/bbWmgPwbqo+2a5yidCyQFPxEiaawcFLTSWGr4qkgA==",
       "dependencies": {
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
         "@wormhole-foundation/sdk-evm": "1.3.0-beta.3",
@@ -11804,14 +13756,16 @@
     },
     "node_modules/@wormhole-foundation/sdk-icons": {
       "version": "1.3.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-icons/-/sdk-icons-1.3.0.tgz",
+      "integrity": "sha512-yz2e8eVhG8+FN3GItiJDmFKjviz3O8hjNZZEsOJXQgy4DoQbvRz3gGSZTrHllQDkEIo7A4liSG2Qf7u1hzyV2Q==",
       "dependencies": {
         "@wormhole-foundation/sdk-base": "1.3.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-icons/node_modules/@wormhole-foundation/sdk-base": {
       "version": "1.3.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.3.0.tgz",
+      "integrity": "sha512-/QpnDN6WBOOZC0mkeEmUWbUv/gLRY5aEl1U1mYXIInglSvIlARzFJtcFhxiuKMOZfufXM81j4G1XsZAWzff6lQ==",
       "dependencies": {
         "@scure/base": "^1.1.3",
         "binary-layout": "^1.0.3"
@@ -11819,7 +13773,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-route-ntt": {
       "version": "0.6.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-route-ntt/-/sdk-route-ntt-0.6.1.tgz",
+      "integrity": "sha512-nR/m7l9PePz9Dk7kXAosS+ei9SCXK0aqsSvyxm4wNwnxoCNU2OotwkPVmaIbAyr1BkZ1J2ii921sOTTWcInILg==",
       "dependencies": {
         "@wormhole-foundation/sdk-definitions-ntt": "0.6.1",
         "@wormhole-foundation/sdk-evm-ntt": "0.6.1",
@@ -11834,7 +13789,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.3.0-beta.3.tgz",
+      "integrity": "sha512-/C2k3gl3dRpE6nTjrLgJygCJLWm8j2TIZCskGBa45Txp5NPVk0sLK7S3oDK2wWzIiYBURTSfpFaxrrcFqR+2yQ==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -11849,7 +13805,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.3.0-beta.3.tgz",
+      "integrity": "sha512-ukJ8tyYgSAyYNreim5XfE0Sq6XCJ1l076ycxwoM5/xI2ikD1wuT+fNeoJq3OLvgthvWfATieh/Rzma1HAhIsYQ==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
@@ -11863,7 +13820,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -11878,7 +13836,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-B+0L22FUcAxxwO7iBt1aCqD60/Zb2e7GSxVU3Fh1EDrqNkQfqJHkJ96Wy+lH3jwSJR/wgntGacD3FDn2fKl56w==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -11892,7 +13851,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-ntt": {
       "version": "0.6.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-ntt/-/sdk-solana-ntt-0.6.1.tgz",
+      "integrity": "sha512-YSumolkZ9wKGvRLOzB12u+RgAzC4Yg1gzN2dUvdngWLsGeikfnDCGOz5fBqAdM5M5nK3ECHDShw8fnfTqNQaGQ==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
@@ -11913,7 +13873,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-ntt/node_modules/@solana/spl-token": {
       "version": "0.4.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.0.tgz",
+      "integrity": "sha512-jjBIBG9IsclqQVl5Y82npGE6utdCh7Z9VFcF5qgJa5EUq2XgspW3Dt1wujWjH/vQDRnkp9zGO+BqQU/HhX/3wg==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -11929,7 +13890,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-PLekAYlc1DBSO7/f1fGmOTEeHl725chibx+C6Ihy1d5iR1RBwZG9PGbBw9g8fHJISVVvPs6fRPCcHvi5vWwH2w==",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
@@ -11944,7 +13906,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -11959,7 +13922,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-solana/node_modules/@solana/spl-token": {
       "version": "0.3.9",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.9.tgz",
+      "integrity": "sha512-1EXHxKICMnab35MvvY/5DBc/K/uQAOJCYnDZXw83McCAYUAfi+rwq6qfd6MmITmSTEhcfBcl/zYxmW/OSN0RmA==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
@@ -11974,7 +13938,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.3.0-beta.3.tgz",
+      "integrity": "sha512-ERSu+/f6362GMx9w96D4WDvpf33ObE7SfotEYAHSJom03UXz4zHfCvfFw74G/gnaL9S9X85SJVmXQVquDH/0qA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3"
@@ -11985,7 +13950,8 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.3.0-beta.3.tgz",
+      "integrity": "sha512-8JWsIbScXkI8mYMH4zokHpjs5dtMwRf1MuevZ4cv+8Tr7gQJistPLcWIAsT3S+Edw6VuurflMSLF08G2NM4/nA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -11997,14 +13963,17 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -12025,25 +13994,29 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.3.0-beta.3.tgz",
+      "integrity": "sha512-iAwLWo/gGQtgHmDiobHvyT3XuO6wb+n9xe2c/OKWnmGdVrv90bYbCNgolzY4iFw2Ls6xbTQMkyaqmn7wZ3d97A==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -12055,14 +14028,17 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -12083,25 +14059,29 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
       "version": "1.3.0-beta.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.3.0-beta.3.tgz",
+      "integrity": "sha512-CGAc/NPy1Rk6ynpYIBZcP3uAaHpASuVPI21h3+mqbMMAsIzDQ9f3p8VV8bOTRoTQ+YEKgglOqcThZMzGVUGmqA==",
       "dependencies": {
         "@mysten/sui.js": "^0.50.1",
         "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -12114,14 +14094,17 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -12142,32 +14125,38 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/bcs": {
       "version": "0.11.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-0.11.1.tgz",
+      "integrity": "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA==",
       "dependencies": {
         "bs58": "^5.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/@mysten/sui.js": {
       "version": "0.50.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui.js/-/sui.js-0.50.1.tgz",
+      "integrity": "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w==",
+      "deprecated": "This package has been renamed to @mysten/sui, please update to use the renamed package.",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@mysten/bcs": "0.11.1",
@@ -12188,25 +14177,29 @@
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/base-x": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/bs58": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
       "dependencies": {
         "base-x": "^4.0.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@wry/caches": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@wry/caches/-/caches-1.0.1.tgz",
+      "integrity": "sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -12216,7 +14209,8 @@
     },
     "node_modules/@wry/context": {
       "version": "0.7.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@wry/context/-/context-0.7.4.tgz",
+      "integrity": "sha512-jmT7Sb4ZQWI5iyu3lobQxICu2nC/vbUhP0vIdd6tHC9PTfenmRmuIFqktc6GH9cgi+ZHnsLWPvfSvc4DrYmKiQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -12226,7 +14220,8 @@
     },
     "node_modules/@wry/equality": {
       "version": "0.5.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@wry/equality/-/equality-0.5.7.tgz",
+      "integrity": "sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -12236,7 +14231,8 @@
     },
     "node_modules/@wry/trie": {
       "version": "0.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@wry/trie/-/trie-0.5.0.tgz",
+      "integrity": "sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -12246,7 +14242,8 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-aptos": {
       "version": "0.0.1-alpha.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-aptos/-/wallet-aggregator-aptos-0.0.1-alpha.14.tgz",
+      "integrity": "sha512-GC6ELtC9TQrF48Of1O5O/Hlx9vhxUJu/0LEQynnYpm/McZG9JSOQkJHkXeQZ2I/PCi+Ojw1evKMldUnb7FWY3w==",
       "dependencies": {
         "@manahippo/aptos-wallet-adapter": "^1.0.8",
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.18"
@@ -12254,18 +14251,21 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-core": {
       "version": "0.0.1-alpha.22",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-core/-/wallet-aggregator-core-0.0.1-alpha.22.tgz",
+      "integrity": "sha512-NzFm0nTSH5KR4pxEY8r8b9BdlT8Q95r0YfiEScERqpowWeYYGP/pZA/x+/iEEF2vpAbINLXz+pwcwGT/5r1xhA==",
       "dependencies": {
         "eventemitter3": "^5.0.0"
       }
     },
     "node_modules/@xlabs-libs/wallet-aggregator-core/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/@xlabs-libs/wallet-aggregator-evm": {
       "version": "0.0.2-alpha.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-evm/-/wallet-aggregator-evm-0.0.2-alpha.5.tgz",
+      "integrity": "sha512-ZWVN9OT5SxHDhtCodMgznJ4jxcPQD4qD4pFySzlNghPBMMLXGCZsXh20WuUnI2MUS/yMvdSBM5PEMnR3MNyH0g==",
       "dependencies": {
         "@binance/w3w-ethereum-provider": "1.1.8-alpha.0",
         "@binance/w3w-utils": "^1.1.6",
@@ -12280,7 +14280,8 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-solana": {
       "version": "0.0.1-alpha.16",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-solana/-/wallet-aggregator-solana-0.0.1-alpha.16.tgz",
+      "integrity": "sha512-arZIpogXIk8r5JiDz2ajOGzAfWDO6hspUDSMqGuFs5ld+l078NRjGoZMqX3EzHLAY1sRF6LNb+xuRTtHb/yfzw==",
       "dependencies": {
         "@solana/wallet-adapter-base": "^0.9.23",
         "@solana/wallet-standard-wallet-adapter-base": "^1.1.1",
@@ -12290,7 +14291,8 @@
     },
     "node_modules/@xlabs-libs/wallet-aggregator-sui": {
       "version": "0.0.1-alpha.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-sui/-/wallet-aggregator-sui-0.0.1-alpha.10.tgz",
+      "integrity": "sha512-AvtN28dZCgjcqQsPbaK5QC+T76AA6npUc10aVLFa3W7Cj4JC2XDJdIju/FDhYcDMVIyNtCAiCnJqQDi/QykB+Q==",
       "dependencies": {
         "@kunalabs-io/sui-snap-wallet": "^0.4.2",
         "@mysten/sui.js": "^0.32.2",
@@ -12300,7 +14302,8 @@
     },
     "node_modules/abitype": {
       "version": "0.8.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.8.7.tgz",
+      "integrity": "sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==",
       "peerDependencies": {
         "typescript": ">=5.0.4",
         "zod": "^3 >=3.19.1"
@@ -12313,7 +14316,8 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -12323,7 +14327,8 @@
     },
     "node_modules/acorn": {
       "version": "8.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12333,16 +14338,18 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -12352,11 +14359,13 @@
     },
     "node_modules/aes-js": {
       "version": "3.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dependencies": {
         "debug": "4"
       },
@@ -12366,7 +14375,8 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -12376,8 +14386,9 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -12391,8 +14402,9 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -12407,8 +14419,9 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12422,19 +14435,22 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "node_modules/algo-msgpack-with-bigint": {
       "version": "2.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/algo-msgpack-with-bigint/-/algo-msgpack-with-bigint-2.1.1.tgz",
+      "integrity": "sha512-F1tGh056XczEaEAqu7s+hlZUDWwOBT70Eq0lfMpBP2YguSQVyxRbprLq5rELXKQOyOaixTWYhMeMQMzP0U5FoQ==",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/algosdk": {
       "version": "2.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/algosdk/-/algosdk-2.7.0.tgz",
+      "integrity": "sha512-sBE9lpV7bup3rZ+q2j3JQaFAE9JwZvjWKX00vPlG8e9txctXbgLL56jZhSWZndqhDI9oI+0P4NldkuQIWdrUyg==",
       "dependencies": {
         "algo-msgpack-with-bigint": "^2.1.1",
         "buffer": "^6.0.3",
@@ -12452,13 +14468,15 @@
     },
     "node_modules/alien-signals": {
       "version": "0.2.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-0.2.2.tgz",
+      "integrity": "sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==",
+      "dev": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
       },
@@ -12471,14 +14489,16 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -12491,11 +14511,13 @@
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -12506,7 +14528,8 @@
     },
     "node_modules/anymatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -12516,7 +14539,9 @@
     },
     "node_modules/aptos": {
       "version": "1.5.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.5.0.tgz",
+      "integrity": "sha512-N7OuRtU7IYHkDkNx+4QS3g/QQGCp+36KzYn3oXPmT7Kttfuv+UKliQVdjy3cLmwd/DCQSh9ObTovwdxnHjUn0g==",
+      "deprecated": "Package aptos is no longer supported, please migrate to https://www.npmjs.com/package/@aptos-labs/ts-sdk",
       "dependencies": {
         "@noble/hashes": "1.1.3",
         "@scure/bip39": "1.1.0",
@@ -12530,30 +14555,33 @@
     },
     "node_modules/aptos/node_modules/@noble/hashes": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/aptos/node_modules/@scure/base": {
       "version": "1.1.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/aptos/node_modules/@scure/bip39": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.1.1",
         "@scure/base": "~1.1.0"
@@ -12561,7 +14589,8 @@
     },
     "node_modules/aptos/node_modules/axios": {
       "version": "0.27.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -12569,7 +14598,8 @@
     },
     "node_modules/aptos/node_modules/form-data": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -12581,24 +14611,28 @@
     },
     "node_modules/arg": {
       "version": "5.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/asn1.js": {
       "version": "4.10.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
       "dependencies": {
         "bn.js": "^4.0.0",
         "inherits": "^2.0.1",
@@ -12607,11 +14641,13 @@
     },
     "node_modules/asn1.js/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/assert": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
       "dependencies": {
         "call-bind": "^1.0.2",
         "is-nan": "^1.3.2",
@@ -12622,33 +14658,38 @@
     },
     "node_modules/assertion-error": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/async-mutex": {
       "version": "0.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
       },
@@ -12671,7 +14712,8 @@
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -12684,8 +14726,9 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.12",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
+      "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.6.3",
@@ -12697,8 +14740,9 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+      "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
         "core-js-compat": "^3.38.0"
@@ -12709,8 +14753,9 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
+      "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -12720,17 +14765,21 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base-x": {
       "version": "3.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
+      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -12744,19 +14793,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/base64url": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/bchaddrjs": {
       "version": "0.5.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bchaddrjs/-/bchaddrjs-0.5.2.tgz",
+      "integrity": "sha512-OO7gIn3m7ea4FVx4cT8gdlWQR2+++EquhdpWQJH9BQjK63tJJ6ngB3QMZDO6DiBoXiIGUsTPHjlrHVxPGcGxLQ==",
       "dependencies": {
         "bs58check": "2.1.2",
         "buffer": "^6.0.3",
@@ -12769,19 +14819,22 @@
     },
     "node_modules/bech32": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="
     },
     "node_modules/big-integer": {
       "version": "1.6.36",
-      "license": "Unlicense",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.36.tgz",
+      "integrity": "sha512-t70bfa7HYEA1D9idDbmuv7YbsbVkQ+Hp+8KFSul4aE5e/i1bjCNIRYJZlA8Q8p0r9T8cF/RVvwUgRA//FydEyg==",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "bindings": "^1.3.0"
       },
@@ -12791,14 +14844,16 @@
     },
     "node_modules/bignumber.js": {
       "version": "9.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "engines": {
         "node": ">=8"
       },
@@ -12808,41 +14863,48 @@
     },
     "node_modules/binary-layout": {
       "version": "1.0.3",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/binary-layout/-/binary-layout-1.0.3.tgz",
+      "integrity": "sha512-kpXCSOko4wbQaQswZk4IPcjVZwN77TKZgjMacdoX54EvUHAn/CzJclCt25SUmpXfzFrGovoq3LkPJkMy10bZxQ=="
     },
     "node_modules/binary-parser": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/binary-parser/-/binary-parser-2.2.1.tgz",
+      "integrity": "sha512-5ATpz/uPDgq5GgEDxTB4ouXCde7q2lqAQlSdBRQVl/AJnxmQmhIfyxJx+0MGu//D5rHQifkfGbWWlaysG0o9NA==",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bip39": {
       "version": "3.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
       "dependencies": {
         "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/bip66": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bip66/-/bip66-2.0.0.tgz",
+      "integrity": "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ=="
     },
     "node_modules/bitcoin-ops": {
       "version": "1.4.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz",
+      "integrity": "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="
     },
     "node_modules/blake-hash": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
+      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^3.0.0",
         "node-gyp-build": "^4.2.2",
@@ -12854,15 +14916,18 @@
     },
     "node_modules/blakejs": {
       "version": "1.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
     },
     "node_modules/borsh": {
       "version": "0.7.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
       "dependencies": {
         "bn.js": "^5.2.0",
         "bs58": "^4.0.0",
@@ -12871,11 +14936,13 @@
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -12883,7 +14950,8 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -12893,23 +14961,27 @@
     },
     "node_modules/brorand": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browser-headers": {
       "version": "0.4.1",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/browser-headers/-/browser-headers-0.4.1.tgz",
+      "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "node_modules/browser-resolve": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+      "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "resolve": "^1.17.0"
       }
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dependencies": {
         "buffer-xor": "^1.0.3",
         "cipher-base": "^1.0.0",
@@ -12921,7 +14993,8 @@
     },
     "node_modules/browserify-cipher": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
       "dependencies": {
         "browserify-aes": "^1.0.4",
         "browserify-des": "^1.0.0",
@@ -12930,7 +15003,8 @@
     },
     "node_modules/browserify-des": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "des.js": "^1.0.0",
@@ -12940,7 +15014,8 @@
     },
     "node_modules/browserify-rsa": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
+      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
       "dependencies": {
         "bn.js": "^5.2.1",
         "randombytes": "^2.1.0",
@@ -12952,7 +15027,8 @@
     },
     "node_modules/browserify-sign": {
       "version": "4.2.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.3.tgz",
+      "integrity": "sha512-JWCZW6SKhfhjJxO8Tyiiy+XYB7cqd2S5/+WeYHsKdNKFlCBhKbblba1A/HN/90YwtxKc8tCErjffZl++UNmGiw==",
       "dependencies": {
         "bn.js": "^5.2.1",
         "browserify-rsa": "^4.1.0",
@@ -12971,11 +15047,13 @@
     },
     "node_modules/browserify-sign/node_modules/isarray": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/browserify-sign/node_modules/readable-stream": {
       "version": "2.3.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -12988,34 +15066,41 @@
     },
     "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/browserify-sign/node_modules/string_decoder": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/browserify-zlib": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "pako": "~1.0.5"
       }
     },
     "node_modules/browserify-zlib/node_modules/pako": {
       "version": "1.0.11",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
       "funding": [
         {
           "type": "opencollective",
@@ -13030,7 +15115,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -13046,14 +15130,16 @@
     },
     "node_modules/bs58": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "dependencies": {
         "base-x": "^3.0.2"
       }
     },
     "node_modules/bs58check": {
       "version": "2.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -13062,6 +15148,8 @@
     },
     "node_modules/buffer": {
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
           "type": "github",
@@ -13076,7 +15164,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -13084,7 +15171,8 @@
     },
     "node_modules/buffer-alloc": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -13092,19 +15180,23 @@
     },
     "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "node_modules/buffer-fill": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-layout": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz",
+      "integrity": "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==",
       "engines": {
         "node": ">=4.5"
       }
@@ -13112,6 +15204,8 @@
     "node_modules/buffer-polyfill": {
       "name": "buffer",
       "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "funding": [
         {
@@ -13127,7 +15221,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -13135,12 +15228,14 @@
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
     "node_modules/bufferutil": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
+      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -13151,27 +15246,31 @@
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "dev": true
     },
     "node_modules/cac": {
       "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
       "engines": {
         "node": ">=10.6.0"
       }
     },
     "node_modules/cacheable-request": {
       "version": "7.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -13187,7 +15286,8 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -13200,7 +15300,8 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
@@ -13216,7 +15317,8 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -13227,7 +15329,8 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "get-intrinsic": "^1.2.6"
@@ -13241,14 +15344,16 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "engines": {
         "node": ">=10"
       },
@@ -13258,13 +15363,16 @@
     },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
       "funding": [
         {
           "type": "opencollective",
@@ -13278,24 +15386,26 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/cashaddrjs": {
       "version": "0.4.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cashaddrjs/-/cashaddrjs-0.4.4.tgz",
+      "integrity": "sha512-xZkuWdNOh0uq/mxJIng6vYWfTowZLd9F4GMAlp2DwFHlcCqCm91NtuAc47RuV4L7r4PYcY5p6Cr2OKNb4hnkWA==",
       "dependencies": {
         "big-integer": "1.6.36"
       }
     },
     "node_modules/cbor-sync": {
       "version": "1.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cbor-sync/-/cbor-sync-1.0.4.tgz",
+      "integrity": "sha512-GWlXN4wiz0vdWWXBU71Dvc1q3aBo0HytqwAZnXF1wOwjqNnDWA1vZ1gDMFLlqohak31VQzmhiYfiCX5QSSfagA=="
     },
     "node_modules/chai": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -13311,8 +15421,9 @@
     },
     "node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13326,8 +15437,9 @@
     },
     "node_modules/check-error": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.2"
       },
@@ -13337,7 +15449,8 @@
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -13359,7 +15472,8 @@
     },
     "node_modules/cipher-base": {
       "version": "1.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.6.tgz",
+      "integrity": "sha512-3Ek9H3X6pj5TgenXYtNWdaBon1tgYCaebd+XPg0keyjEbEfkD4KkmAxkQ/i1vYvxdcT5nscLBfq9VJRmCBcFSw==",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -13370,19 +15484,22 @@
     },
     "node_modules/citty": {
       "version": "0.1.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
       "dependencies": {
         "consola": "^3.2.3"
       }
     },
     "node_modules/classnames": {
       "version": "2.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -13395,8 +15512,9 @@
     },
     "node_modules/cli-truncate": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+      "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "slice-ansi": "^5.0.0",
         "string-width": "^5.0.0"
@@ -13410,7 +15528,8 @@
     },
     "node_modules/clipboardy": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-4.0.0.tgz",
+      "integrity": "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==",
       "dependencies": {
         "execa": "^8.0.1",
         "is-wsl": "^3.1.0",
@@ -13425,7 +15544,8 @@
     },
     "node_modules/clipboardy/node_modules/execa": {
       "version": "8.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -13446,7 +15566,8 @@
     },
     "node_modules/clipboardy/node_modules/get-stream": {
       "version": "8.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "engines": {
         "node": ">=16"
       },
@@ -13456,14 +15577,16 @@
     },
     "node_modules/clipboardy/node_modules/human-signals": {
       "version": "5.0.0",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "engines": {
         "node": ">=16.17.0"
       }
     },
     "node_modules/clipboardy/node_modules/is-stream": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -13473,7 +15596,8 @@
     },
     "node_modules/clipboardy/node_modules/npm-run-path": {
       "version": "5.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -13486,7 +15610,8 @@
     },
     "node_modules/clipboardy/node_modules/path-key": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "engines": {
         "node": ">=12"
       },
@@ -13496,7 +15621,8 @@
     },
     "node_modules/clipboardy/node_modules/signal-exit": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "engines": {
         "node": ">=14"
       },
@@ -13506,7 +15632,8 @@
     },
     "node_modules/cliui": {
       "version": "5.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -13515,14 +15642,16 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/cliui/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -13532,29 +15661,34 @@
     },
     "node_modules/cliui/node_modules/color-convert": {
       "version": "1.9.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/cliui/node_modules/color-name": {
       "version": "1.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -13566,7 +15700,8 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -13576,7 +15711,8 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "5.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -13588,7 +15724,8 @@
     },
     "node_modules/clone-response": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -13598,14 +15735,16 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -13615,16 +15754,19 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/colorette": {
       "version": "2.0.20",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -13634,61 +15776,73 @@
     },
     "node_modules/commander": {
       "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/compare-versions": {
       "version": "6.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/confbox": {
       "version": "0.1.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
     },
     "node_modules/consola": {
       "version": "3.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.2.3.tgz",
+      "integrity": "sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/console-browserify": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
       "dev": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "peer": true
     },
     "node_modules/cookie-es": {
       "version": "1.2.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg=="
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
     },
     "node_modules/core-js-compat": {
       "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
+      "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.24.2"
       },
@@ -13699,11 +15853,13 @@
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -13717,18 +15873,21 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
+      "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ=="
     },
     "node_modules/crc": {
       "version": "3.8.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dependencies": {
         "buffer": "^5.1.0"
       }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
       "bin": {
         "crc32": "bin/crc32.njs"
       },
@@ -13738,6 +15897,8 @@
     },
     "node_modules/crc/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -13752,7 +15913,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -13760,7 +15920,8 @@
     },
     "node_modules/create-ecdh": {
       "version": "4.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "elliptic": "^6.5.3"
@@ -13768,11 +15929,13 @@
     },
     "node_modules/create-ecdh/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -13783,7 +15946,8 @@
     },
     "node_modules/create-hmac": {
       "version": "1.1.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -13795,19 +15959,22 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -13819,14 +15986,16 @@
     },
     "node_modules/crossws": {
       "version": "0.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.1.tgz",
+      "integrity": "sha512-HsZgeVYaG+b5zA+9PbIPGq4+J/CJynJuearykPsXx4V/eMhyQ5EDVg3Ak2FBZtVXCiOLu/U7IiwDHTr9MA+IKw==",
       "dependencies": {
         "uncrypto": "^0.1.3"
       }
     },
     "node_modules/crypto-browserify": {
       "version": "3.12.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
+      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
       "dependencies": {
         "browserify-cipher": "^1.0.1",
         "browserify-sign": "^4.2.3",
@@ -13850,7 +16019,8 @@
     },
     "node_modules/crypto-hash": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/crypto-hash/-/crypto-hash-1.3.0.tgz",
+      "integrity": "sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==",
       "engines": {
         "node": ">=8"
       },
@@ -13860,11 +16030,13 @@
     },
     "node_modules/crypto-js": {
       "version": "4.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "bin": {
         "cssesc": "bin/cssesc"
       },
@@ -13874,21 +16046,25 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true
     },
     "node_modules/debounce": {
       "version": "1.2.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -13903,25 +16079,29 @@
     },
     "node_modules/decamelize": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
       "version": "10.4.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -13934,7 +16114,8 @@
     },
     "node_modules/decompress-response/node_modules/mimic-response": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "engines": {
         "node": ">=10"
       },
@@ -13944,8 +16125,9 @@
     },
     "node_modules/deep-eql": {
       "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-detect": "^4.0.0"
       },
@@ -13955,19 +16137,22 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
     },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -13982,15 +16167,17 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -14005,11 +16192,13 @@
     },
     "node_modules/defu": {
       "version": "6.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
     },
     "node_modules/delay": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
       "engines": {
         "node": ">=10"
       },
@@ -14019,14 +16208,16 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/des.js": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
+      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
@@ -14034,15 +16225,18 @@
     },
     "node_modules/destr": {
       "version": "2.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.3.tgz",
+      "integrity": "sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ=="
     },
     "node_modules/detect-browser": {
       "version": "5.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.2.0.tgz",
+      "integrity": "sha512-tr7XntDAu50BVENgQfajMLzacmSe34D+qZc4zjnniz0ZVuw/TZcLcyxHQjYpJTM36sGEkZZlYLnIM1hH7alTMA=="
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -14052,19 +16246,22 @@
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
@@ -14073,16 +16270,19 @@
     },
     "node_modules/diffie-hellman/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA=="
     },
     "node_modules/dir-glob": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -14092,12 +16292,14 @@
     },
     "node_modules/dlv": {
       "version": "1.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "esutils": "^2.0.2"
       },
@@ -14107,7 +16309,8 @@
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
@@ -14115,8 +16318,9 @@
     },
     "node_modules/domain-browser": {
       "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.22.0.tgz",
+      "integrity": "sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -14126,7 +16330,8 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -14134,7 +16339,8 @@
     },
     "node_modules/draggabilly": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/draggabilly/-/draggabilly-3.0.0.tgz",
+      "integrity": "sha512-aEs+B6prbMZQMxc9lgTpCBfyCUhRur/VFucHhIOvlvvdARTj7TcDmX/cdOUtqbjJJUh7+agyJXR5Z6IFe1MxwQ==",
       "dependencies": {
         "get-size": "^3.0.0",
         "unidragger": "^3.0.0"
@@ -14142,7 +16348,8 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -14154,12 +16361,14 @@
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true
     },
     "node_modules/duplexify": {
       "version": "4.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -14169,22 +16378,27 @@
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/eip1193-provider": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
+      "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@json-rpc-tools/provider": "^1.5.5"
       }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.74",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.74.tgz",
+      "integrity": "sha512-ck3//9RC+6oss/1Bh9tiAVFy5vfSKbRHAFh7Z3/eTRkEqJeWgymloShB17Vg3Z4nmDNp35vAd1BZ6CMW4Wt6Iw=="
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
+      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -14197,26 +16411,31 @@
     },
     "node_modules/elliptic/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/encode-utf8": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/engine.io-client": {
       "version": "6.6.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.2.tgz",
+      "integrity": "sha512-TAr+NKeoVTjEVW8P3iHguO1LO6RlUz9O5Y8o7EY0fU+gY1NYqas7NN3slpFtbXEsLMHk0h90fJMfKjRkQ0qUIw==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
@@ -14227,7 +16446,8 @@
     },
     "node_modules/engine.io-client/node_modules/debug": {
       "version": "4.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -14242,7 +16462,8 @@
     },
     "node_modules/engine.io-client/node_modules/ws": {
       "version": "8.17.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14261,15 +16482,17 @@
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
       "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -14279,8 +16502,9 @@
     },
     "node_modules/env-cmd": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "commander": "^4.0.0",
         "cross-spawn": "^7.0.0"
@@ -14294,36 +16518,41 @@
     },
     "node_modules/env-cmd/node_modules/commander": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
+      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -14333,20 +16562,23 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
       "dependencies": {
         "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -14381,14 +16613,16 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "engines": {
         "node": ">=10"
       },
@@ -14398,8 +16632,10 @@
     },
     "node_modules/eslint": {
       "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -14452,8 +16688,9 @@
     },
     "node_modules/eslint-config-prettier": {
       "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
+      "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -14463,8 +16700,9 @@
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -14474,8 +16712,9 @@
     },
     "node_modules/eslint-scope": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -14486,8 +16725,9 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -14497,8 +16737,9 @@
     },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -14512,16 +16753,18 @@
     },
     "node_modules/eslint/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -14531,8 +16774,9 @@
     },
     "node_modules/eslint/node_modules/globals": {
       "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -14545,8 +16789,9 @@
     },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -14556,8 +16801,9 @@
     },
     "node_modules/espree": {
       "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.9.0",
         "acorn-jsx": "^5.3.2",
@@ -14572,8 +16818,9 @@
     },
     "node_modules/esquery": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -14583,16 +16830,18 @@
     },
     "node_modules/esquery/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -14602,36 +16851,41 @@
     },
     "node_modules/esrecurse/node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/eth-block-tracker": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-7.1.0.tgz",
+      "integrity": "sha512-8YdplnuE1IK4xfqpf4iU7oBxnOYAc35934o083G8ao+8WM8QQtt/mVlAY6yIAdY1eMeLqg4Z//PZjJGmWGPMRg==",
       "dependencies": {
         "@metamask/eth-json-rpc-provider": "^1.0.0",
         "@metamask/safe-event-emitter": "^3.0.0",
@@ -14645,7 +16899,8 @@
     },
     "node_modules/eth-block-tracker/node_modules/@ethereumjs/common": {
       "version": "3.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "dependencies": {
         "@ethereumjs/util": "^8.1.0",
         "crc-32": "^1.2.0"
@@ -14653,7 +16908,8 @@
     },
     "node_modules/eth-block-tracker/node_modules/@ethereumjs/tx": {
       "version": "4.2.0",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "dependencies": {
         "@ethereumjs/common": "^3.2.0",
         "@ethereumjs/rlp": "^4.0.1",
@@ -14666,7 +16922,8 @@
     },
     "node_modules/eth-block-tracker/node_modules/@metamask/utils": {
       "version": "5.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-5.0.2.tgz",
+      "integrity": "sha512-yfmE79bRQtnMzarnKfX7AEJBwFTxvTyw3nBQlu/5rmGXrjAeAMltoGxO62TFurxrQAFMNa/fEjIHNvungZp0+g==",
       "dependencies": {
         "@ethereumjs/tx": "^4.1.2",
         "@types/debug": "^4.1.7",
@@ -14680,7 +16937,8 @@
     },
     "node_modules/eth-block-tracker/node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -14690,14 +16948,16 @@
     },
     "node_modules/eth-block-tracker/node_modules/superstruct": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/eth-json-rpc-filters": {
       "version": "6.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-filters/-/eth-json-rpc-filters-6.0.1.tgz",
+      "integrity": "sha512-ITJTvqoCw6OVMLs7pI8f4gG92n/St6x80ACtHodeS+IXmO0w+t1T5OOzfSt7KLSMLRkVUoexV7tztLgDxg+iig==",
       "dependencies": {
         "@metamask/safe-event-emitter": "^3.0.0",
         "async-mutex": "^0.2.6",
@@ -14711,14 +16971,16 @@
     },
     "node_modules/eth-json-rpc-filters/node_modules/async-mutex": {
       "version": "0.2.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.2.6.tgz",
+      "integrity": "sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==",
       "dependencies": {
         "tslib": "^2.0.0"
       }
     },
     "node_modules/eth-json-rpc-filters/node_modules/pify": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
+      "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
       "engines": {
         "node": ">=10"
       },
@@ -14728,7 +16990,8 @@
     },
     "node_modules/eth-query": {
       "version": "2.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
+      "integrity": "sha512-srES0ZcvwkR/wd5OQBRA1bIJMww1skfGS0s8wlwK3/oNP4+wnds60krvu5R1QbpRQjMmpG5OMIWro5s7gvDPsA==",
       "dependencies": {
         "json-rpc-random-id": "^1.0.0",
         "xtend": "^4.0.1"
@@ -14736,14 +16999,16 @@
     },
     "node_modules/eth-rpc-errors": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz",
+      "integrity": "sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==",
       "dependencies": {
         "fast-safe-stringify": "^2.0.6"
       }
     },
     "node_modules/ethereum-cryptography": {
       "version": "2.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
+      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
@@ -14753,7 +17018,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
       "version": "1.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
+      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
       "dependencies": {
         "@noble/hashes": "1.4.0"
       },
@@ -14763,7 +17029,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "engines": {
         "node": ">= 16"
       },
@@ -14773,14 +17040,16 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/base": {
       "version": "1.1.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip32": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
+      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
       "dependencies": {
         "@noble/curves": "~1.4.0",
         "@noble/hashes": "~1.4.0",
@@ -14792,7 +17061,8 @@
     },
     "node_modules/ethereum-cryptography/node_modules/@scure/bip39": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
+      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
       "dependencies": {
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
@@ -14803,7 +17073,9 @@
     },
     "node_modules/ethereumjs-abi": {
       "version": "0.6.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
+      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
+      "deprecated": "This library has been deprecated and usage is discouraged.",
       "dependencies": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
@@ -14811,18 +17083,21 @@
     },
     "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
       "version": "4.11.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/ethereumjs-abi/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/ethereumjs-abi/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -14843,7 +17118,8 @@
     },
     "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
       "version": "6.2.1",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -14856,7 +17132,8 @@
     },
     "node_modules/ethereumjs-util": {
       "version": "7.1.5",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
+      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -14870,7 +17147,8 @@
     },
     "node_modules/ethereumjs-util/node_modules/ethereum-cryptography": {
       "version": "0.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dependencies": {
         "@types/pbkdf2": "^3.0.0",
         "@types/secp256k1": "^4.0.1",
@@ -14891,6 +17169,8 @@
     },
     "node_modules/ethers": {
       "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.13.4.tgz",
+      "integrity": "sha512-21YtnZVg4/zKkCQPjrDj38B1r4nQvTZLopUGMLQ1ePU2zV/joCfDC3t3iKQjWRzjjjbzR+mdAIoikeBRNkdllA==",
       "funding": [
         {
           "type": "individual",
@@ -14901,7 +17181,6 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.1",
         "@noble/curves": "1.2.0",
@@ -14917,7 +17196,8 @@
     },
     "node_modules/ethers/node_modules/@noble/curves": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -14927,7 +17207,8 @@
     },
     "node_modules/ethers/node_modules/@noble/hashes": {
       "version": "1.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "engines": {
         "node": ">= 16"
       },
@@ -14937,22 +17218,26 @@
     },
     "node_modules/ethers/node_modules/@types/node": {
       "version": "22.7.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
     },
     "node_modules/ethers/node_modules/aes-js": {
       "version": "4.0.0-beta.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/ethers/node_modules/tslib": {
       "version": "2.7.0",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.17.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14971,7 +17256,8 @@
     },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
       "dependencies": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
@@ -14983,29 +17269,34 @@
     },
     "node_modules/ev-emitter": {
       "version": "2.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-2.1.2.tgz",
+      "integrity": "sha512-jQ5Ql18hdCQ4qS+RCrbLfz1n+Pags27q5TwMKvZyhp5hh2UULUYZUy1keqj6k6SYsdqIYjnmz7xyyEY0V67B8Q=="
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "engines": {
         "node": ">=0.8.x"
       }
     },
     "node_modules/evp_bytestokey": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dependencies": {
         "md5.js": "^1.3.4",
         "safe-buffer": "^5.1.1"
@@ -15013,8 +17304,9 @@
     },
     "node_modules/execa": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^6.0.1",
@@ -15035,8 +17327,9 @@
     },
     "node_modules/execa/node_modules/is-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -15046,8 +17339,9 @@
     },
     "node_modules/execa/node_modules/npm-run-path": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -15060,8 +17354,9 @@
     },
     "node_modules/execa/node_modules/path-key": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -15071,11 +17366,13 @@
     },
     "node_modules/exenv": {
       "version": "1.2.2",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
     },
     "node_modules/extension-port-stream": {
       "version": "3.0.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/extension-port-stream/-/extension-port-stream-3.0.0.tgz",
+      "integrity": "sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw==",
       "dependencies": {
         "readable-stream": "^3.6.2 || ^4.4.2",
         "webextension-polyfill": ">=0.10.0 <1.0"
@@ -15086,17 +17383,21 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
       "engines": {
         "node": "> 0.1.90"
       }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -15110,50 +17411,59 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
     },
     "node_modules/fast-redact": {
       "version": "3.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag=="
     },
     "node_modules/fast-uri": {
       "version": "3.0.3",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.3.tgz",
+      "integrity": "sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==",
+      "dev": true
     },
     "node_modules/fastestsmallesttextencoderdecoder": {
       "version": "1.0.22",
-      "license": "CC0-1.0",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
       "peer": true
     },
     "node_modules/fastq": {
       "version": "1.17.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -15163,11 +17473,13 @@
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -15177,19 +17489,22 @@
     },
     "node_modules/filter-obj": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/find-root": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "node_modules/find-up": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -15203,8 +17518,9 @@
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.3",
@@ -15216,18 +17532,20 @@
     },
     "node_modules/flatted": {
       "version": "3.3.2",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "dev": true
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=4.0"
       },
@@ -15239,14 +17557,16 @@
     },
     "node_modules/for-each": {
       "version": "0.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "dependencies": {
         "is-callable": "^1.1.3"
       }
     },
     "node_modules/foreground-child": {
       "version": "3.3.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -15260,7 +17580,8 @@
     },
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "engines": {
         "node": ">=14"
       },
@@ -15270,7 +17591,8 @@
     },
     "node_modules/form-data": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -15282,8 +17604,9 @@
     },
     "node_modules/fs-extra": {
       "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -15295,18 +17618,34 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -15314,22 +17653,25 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.2.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.6.tgz",
+      "integrity": "sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "dunder-proto": "^1.0.0",
@@ -15351,16 +17693,19 @@
     },
     "node_modules/get-port-please": {
       "version": "3.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
+      "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
     },
     "node_modules/get-size": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/get-size/-/get-size-3.0.0.tgz",
+      "integrity": "sha512-Y8aiXLq4leR7807UY0yuKEwif5s3kbVp1nTv+i4jBeoUzByTLKkLWu/HorS6/pB+7gsB0o7OTogC8AoOOeT0Hw=="
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -15370,7 +17715,9 @@
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15388,7 +17735,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -15398,14 +17746,16 @@
     },
     "node_modules/globals": {
       "version": "11.12.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dependencies": {
         "define-properties": "^1.2.1",
         "gopd": "^1.0.1"
@@ -15419,8 +17769,9 @@
     },
     "node_modules/globby": {
       "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -15438,11 +17789,13 @@
     },
     "node_modules/google-protobuf": {
       "version": "3.21.4",
-      "license": "(BSD-3-Clause AND Apache-2.0)"
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.4.tgz",
+      "integrity": "sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ=="
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -15452,7 +17805,8 @@
     },
     "node_modules/got": {
       "version": "11.8.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -15475,7 +17829,8 @@
     },
     "node_modules/gql.tada": {
       "version": "1.8.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
+      "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
       "dependencies": {
         "@0no-co/graphql.web": "^1.0.5",
         "@0no-co/graphqlsp": "^1.12.13",
@@ -15492,24 +17847,28 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
     },
     "node_modules/graphql": {
       "version": "16.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
+      "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-tag": {
       "version": "2.12.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -15522,8 +17881,9 @@
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "duplexer": "^0.1.2"
       },
@@ -15536,7 +17896,8 @@
     },
     "node_modules/h3": {
       "version": "1.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.0.tgz",
+      "integrity": "sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==",
       "dependencies": {
         "cookie-es": "^1.2.2",
         "crossws": ">=0.2.0 <0.4.0",
@@ -15552,15 +17913,17 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -15570,7 +17933,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -15580,7 +17944,8 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -15593,7 +17958,8 @@
     },
     "node_modules/hash-base": {
       "version": "3.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
+      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
       "dependencies": {
         "inherits": "^2.0.4",
         "safe-buffer": "^5.2.1"
@@ -15604,7 +17970,8 @@
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -15612,7 +17979,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -15622,23 +17990,27 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "he": "bin/he"
       }
     },
     "node_modules/hey-listen": {
       "version": "1.0.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/hi-base32": {
       "version": "0.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/hi-base32/-/hi-base32-0.5.1.tgz",
+      "integrity": "sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA=="
     },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -15647,27 +18019,32 @@
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "dependencies": {
         "react-is": "^16.7.0"
       }
     },
     "node_modules/hoist-non-react-statics/node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
     },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-shutdown": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http-shutdown/-/http-shutdown-1.2.2.tgz",
+      "integrity": "sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==",
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
@@ -15675,11 +18052,13 @@
     },
     "node_modules/http-status-codes": {
       "version": "2.3.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
+      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -15690,12 +18069,14 @@
     },
     "node_modules/https-browserify": {
       "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
+      "dev": true
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -15706,23 +18087,26 @@
     },
     "node_modules/human-signals": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=14.18.0"
       }
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "dependencies": {
         "ms": "^2.0.0"
       }
     },
     "node_modules/husky": {
       "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "husky": "lib/bin.js"
       },
@@ -15735,10 +18119,13 @@
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "funding": [
         {
           "type": "github",
@@ -15752,20 +18139,21 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/immer": {
       "version": "9.0.21",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -15773,7 +18161,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -15787,8 +18176,9 @@
     },
     "node_modules/import-from-esm": {
       "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.4.tgz",
+      "integrity": "sha512-7EyUlPFC0HOlBDpUFGfYstsU7XHxZJKAAMzCT8wZ0hMW7b+hG51LIKTDcsgtz8Pu6YC0HqRVbX+rVUtsGMUKvg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
         "import-meta-resolve": "^4.0.0"
@@ -15799,16 +18189,18 @@
     },
     "node_modules/import-lazy": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
+      "integrity": "sha512-I6fiaX09Xivtk+THaMfAwnA3MVA5Big1WHF1Dfx9hFuvNIWpXnorlkzhcQf6ehrqQiiZECRt1poOAkPmer3ruw==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -15816,15 +18208,18 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15832,26 +18227,31 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/injectpromise": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/injectpromise/-/injectpromise-1.0.0.tgz",
+      "integrity": "sha512-qNq5wy4qX4uWHcVFOEU+RqZkoVG65FhvGkyDWbuBxILMjK6A1LFf5A1mgXZkD4nRx5FCorD81X/XvPKp/zVfPA=="
     },
     "node_modules/int64-buffer": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw=="
     },
     "node_modules/interpret": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/ip-address": {
       "version": "9.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -15862,14 +18262,16 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
       }
     },
     "node_modules/is-arguments": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -15883,11 +18285,13 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -15897,7 +18301,8 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -15907,7 +18312,8 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+      "integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -15920,7 +18326,8 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -15933,15 +18340,17 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+      "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -15951,7 +18360,8 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.0.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -15964,7 +18374,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -15974,7 +18385,8 @@
     },
     "node_modules/is-hex-prefixed": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
       "engines": {
         "node": ">=6.5.0",
         "npm": ">=3"
@@ -15982,7 +18394,8 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dependencies": {
         "is-docker": "^3.0.0"
       },
@@ -15998,7 +18411,8 @@
     },
     "node_modules/is-nan": {
       "version": "1.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3"
@@ -16012,22 +18426,25 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "engines": {
         "node": ">=8"
       },
@@ -16037,7 +18454,8 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dependencies": {
         "which-typed-array": "^1.1.16"
       },
@@ -16050,11 +18468,13 @@
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/is-wsl": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
       "dependencies": {
         "is-inside-container": "^1.0.0"
       },
@@ -16067,7 +18487,8 @@
     },
     "node_modules/is64bit": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is64bit/-/is64bit-2.0.0.tgz",
+      "integrity": "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==",
       "dependencies": {
         "system-architecture": "^0.1.0"
       },
@@ -16080,15 +18501,18 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/isomorphic-fetch": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "whatwg-fetch": "^3.4.1"
@@ -16096,15 +18520,17 @@
     },
     "node_modules/isomorphic-timers-promises": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-timers-promises/-/isomorphic-timers-promises-1.0.1.tgz",
+      "integrity": "sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/isomorphic-unfetch": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
+      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
       "dependencies": {
         "node-fetch": "^2.6.1",
         "unfetch": "^4.2.0"
@@ -16112,27 +18538,30 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/isows": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "ws": "*"
       }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
-      "license": "BlueOak-1.0.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -16145,7 +18574,8 @@
     },
     "node_modules/jayson": {
       "version": "4.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.3.tgz",
+      "integrity": "sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -16169,15 +18599,18 @@
     },
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -16196,40 +18629,48 @@
     },
     "node_modules/jiti": {
       "version": "1.21.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "bin": {
         "jiti": "bin/jiti.js"
       }
     },
     "node_modules/jju": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true
     },
     "node_modules/js-base64": {
       "version": "3.7.7",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
     "node_modules/js-sha256": {
       "version": "0.9.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/js-sha512": {
       "version": "0.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-sha512/-/js-sha512-0.8.0.tgz",
+      "integrity": "sha512-PWsmefG6Jkodqt+ePTvBZCSMFgN7Clckjd0O7su3I0+BW2QWUTJNzjktHsztGLhncP2h8mcF9V9Y2Ha59pAViQ=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -16239,22 +18680,26 @@
     },
     "node_modules/jsbi": {
       "version": "3.2.5",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-3.2.5.tgz",
+      "integrity": "sha512-aBE4n43IPvjaddScbvWRA2YlTzKEynHzu7MqOyTipdHucf/VxS63ViCjxYRg86M8Rxwbt/GfzHl1kKERkt45fQ=="
     },
     "node_modules/jsbn": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
     },
     "node_modules/jscrypto": {
       "version": "1.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jscrypto/-/jscrypto-1.0.3.tgz",
+      "integrity": "sha512-lryZl0flhodv4SZHOqyb1bx5sKcJxj0VBo0Kzb4QMAg3L021IC9uGpl0RCZa+9KJwlRGSK2C80ITcwbe19OKLQ==",
       "bin": {
         "jscrypto": "bin/cli.js"
       }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -16264,22 +18709,26 @@
     },
     "node_modules/json-bigint": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
     },
     "node_modules/json-rpc-engine": {
       "version": "6.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-6.1.0.tgz",
+      "integrity": "sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==",
       "dependencies": {
         "@metamask/safe-event-emitter": "^2.0.0",
         "eth-rpc-errors": "^4.0.2"
@@ -16290,11 +18739,13 @@
     },
     "node_modules/json-rpc-engine/node_modules/@metamask/safe-event-emitter": {
       "version": "2.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz",
+      "integrity": "sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q=="
     },
     "node_modules/json-rpc-protocol": {
       "version": "0.13.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/json-rpc-protocol/-/json-rpc-protocol-0.13.2.tgz",
+      "integrity": "sha512-2InSi+c7wGESmvYcEVS0clctpJCodV7gLqLN1BIIPNK07wokXIwhOL8RQWU4O7oX5adChn6HJGtIU6JaUQ1P/A==",
       "dependencies": {
         "make-error": "^1.3.0"
       },
@@ -16304,16 +18755,19 @@
     },
     "node_modules/json-rpc-random-id": {
       "version": "1.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
+      "integrity": "sha512-RJ9YYNCkhVDBuP4zN5BBtYAzEl03yq/jIIsyif0JY9qyJuQQZNeDK7anAPKKlyEtLSj2s8h6hNh2F8zO5q7ScA=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.0.tgz",
+      "integrity": "sha512-ex8jk9BZHBolvbd5cRnAgwyaYcYB0qZldy1e+LCOdcF6+AUmVZ6LcGUMzsRTW83QMeu+GxZGrcLqxqrgfXGvIw==",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -16330,16 +18784,19 @@
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -16350,8 +18807,9 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -16361,28 +18819,32 @@
     },
     "node_modules/jsonify": {
       "version": "0.0.1",
-      "license": "Public Domain",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
       "engines": [
         "node >= 0.2.0"
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/jsonschema": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA==",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/JSONStream": {
       "version": "1.3.5",
-      "license": "(MIT OR Apache-2.0)",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
       "dependencies": {
         "jsonparse": "^1.2.0",
         "through": ">=2.2.7 <3"
@@ -16396,12 +18858,14 @@
     },
     "node_modules/jsqr": {
       "version": "1.4.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="
     },
     "node_modules/keccak": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^2.0.0",
         "node-gyp-build": "^4.2.0",
@@ -16413,11 +18877,13 @@
     },
     "node_modules/keccak/node_modules/node-addon-api": {
       "version": "2.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/keccak256": {
       "version": "1.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.6.tgz",
+      "integrity": "sha512-8GLiM01PkdJVGUhR1e6M/AvWnSqYS0HaERI+K/QtStGDGlSTx2B1zTqZk4Zlqu5TxHJNTxWAdP9Y+WI50OApUw==",
       "dependencies": {
         "bn.js": "^5.2.0",
         "buffer": "^6.0.3",
@@ -16426,24 +18892,28 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
     },
     "node_modules/keyvaluestorage-interface": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g=="
     },
     "node_modules/kolorist": {
       "version": "1.8.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -16454,31 +18924,36 @@
     },
     "node_modules/libsodium-sumo": {
       "version": "0.7.15",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.15.tgz",
+      "integrity": "sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw=="
     },
     "node_modules/libsodium-wrappers-sumo": {
       "version": "0.7.15",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.15.tgz",
+      "integrity": "sha512-aSWY8wKDZh5TC7rMvEdTHoyppVq/1dTSAeAR7H6pzd6QRT3vQWcT5pGwCotLcpPEOLXX6VvqihSPkpEhYAjANA==",
       "dependencies": {
         "libsodium-sumo": "^0.7.15"
       }
     },
     "node_modules/lilconfig": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lint-staged": {
       "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.3.0.tgz",
+      "integrity": "sha512-mPRtrYnipYYv1FEE134ufbWpeggNTo+O/UPzngoaKzbzHAthvR55am+8GfHTnqNRQVRRrYQLGW9ZyUoD7DsBHQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "5.3.0",
         "commander": "11.0.0",
@@ -16503,8 +18978,9 @@
     },
     "node_modules/lint-staged/node_modules/chalk": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -16514,16 +18990,18 @@
     },
     "node_modules/lint-staged/node_modules/commander": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.0.0.tgz",
+      "integrity": "sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/lint-staged/node_modules/debug": {
       "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -16538,8 +19016,9 @@
     },
     "node_modules/lint-staged/node_modules/micromatch": {
       "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -16550,13 +19029,15 @@
     },
     "node_modules/lint-staged/node_modules/ms": {
       "version": "2.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/lint-staged/node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -16566,15 +19047,17 @@
     },
     "node_modules/lint-staged/node_modules/yaml": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
+      "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/listhen": {
       "version": "1.9.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
+      "integrity": "sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==",
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "@parcel/watcher-wasm": "^2.4.1",
@@ -16602,15 +19085,17 @@
     },
     "node_modules/listhen/node_modules/jiti": {
       "version": "2.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/listr2": {
       "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-6.6.1.tgz",
+      "integrity": "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cli-truncate": "^3.1.0",
         "colorette": "^2.0.20",
@@ -16633,12 +19118,14 @@
     },
     "node_modules/listr2/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "dev": true
     },
     "node_modules/lit": {
       "version": "2.8.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -16647,7 +19134,8 @@
     },
     "node_modules/lit-element": {
       "version": "3.3.3",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
@@ -16656,15 +19144,17 @@
     },
     "node_modules/lit-html": {
       "version": "2.8.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/local-pkg": {
       "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.3",
         "pkg-types": "^1.2.1"
@@ -16678,8 +19168,9 @@
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -16692,29 +19183,35 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
     },
     "node_modules/lodash.isequal": {
       "version": "4.5.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/log-update": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-5.0.1.tgz",
+      "integrity": "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-escapes": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -16731,8 +19228,9 @@
     },
     "node_modules/log-update/node_modules/ansi-escapes": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
+      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "type-fest": "^1.0.2"
       },
@@ -16745,8 +19243,9 @@
     },
     "node_modules/log-update/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -16756,8 +19255,9 @@
     },
     "node_modules/log-update/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -16770,8 +19270,9 @@
     },
     "node_modules/log-update/node_modules/type-fest": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -16781,7 +19282,8 @@
     },
     "node_modules/loglevel": {
       "version": "1.9.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "engines": {
         "node": ">= 0.6.0"
       },
@@ -16792,11 +19294,13 @@
     },
     "node_modules/long": {
       "version": "4.0.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -16806,55 +19310,63 @@
     },
     "node_modules/loupe": {
       "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "dependencies": {
         "tslib": "^2.0.3"
       }
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
         "yallist": "^3.0.2"
       }
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "bin": {
         "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "engines": {
         "node": ">=8"
       },
@@ -16864,7 +19376,8 @@
     },
     "node_modules/material-ui-popup-state": {
       "version": "5.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/material-ui-popup-state/-/material-ui-popup-state-5.3.3.tgz",
+      "integrity": "sha512-eaoA4y965neZw1/iPYZ7haCGO369m5QXJT35e0RStzHd4lgrd6PC+UYkYTIRGTrNt+8Vbx8qtYUFDzRjjAGwnw==",
       "dependencies": {
         "@babel/runtime": "^7.20.6",
         "@types/prop-types": "^15.7.3",
@@ -16887,14 +19400,16 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/md5.js": {
       "version": "1.3.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -16903,22 +19418,26 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/micro-ftch": {
       "version": "0.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
+      "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg=="
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -16929,7 +19448,8 @@
     },
     "node_modules/micromatch/node_modules/picomatch": {
       "version": "2.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -16939,7 +19459,8 @@
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dependencies": {
         "bn.js": "^4.0.0",
         "brorand": "^1.0.1"
@@ -16950,11 +19471,13 @@
     },
     "node_modules/miller-rabin/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/mime": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "bin": {
         "mime": "cli.js"
       },
@@ -16964,14 +19487,16 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -16981,7 +19506,8 @@
     },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "engines": {
         "node": ">=12"
       },
@@ -16991,22 +19517,26 @@
     },
     "node_modules/mimic-response": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17016,25 +19546,29 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
       "version": "7.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/mlly": {
       "version": "1.7.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.3.tgz",
+      "integrity": "sha512-xUsx5n/mN0uQf4V548PKQ+YShA4/IW0KI1dZhrNrPCLG+xizETbHTkOa1f8/xut9JRPp8kQuMnz0oqwkTiLo/A==",
       "dependencies": {
         "acorn": "^8.14.0",
         "pathe": "^1.1.2",
@@ -17044,7 +19578,8 @@
     },
     "node_modules/motion": {
       "version": "10.16.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
       "dependencies": {
         "@motionone/animation": "^10.15.1",
         "@motionone/dom": "^10.16.2",
@@ -17056,19 +19591,22 @@
     },
     "node_modules/mrmime": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.0.tgz",
+      "integrity": "sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/msafe-wallet": {
       "version": "2.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/msafe-wallet/-/msafe-wallet-2.1.5.tgz",
+      "integrity": "sha512-azUF0o96WTYh6jJCwVG9FQ4erRlScvEn0z5+l7WNCbqP9oPKUCR2ySttDjaMa0cO06wz5huk3bW59ND7swiH6Q==",
       "dependencies": {
         "buffer": "^6.0.3",
         "json-rpc-protocol": "^0.13.2"
@@ -17076,16 +19614,19 @@
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true
     },
     "node_modules/multiformats": {
       "version": "9.9.0",
-      "license": "(Apache-2.0 AND MIT)"
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
     },
     "node_modules/mz": {
       "version": "2.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "dependencies": {
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
@@ -17094,17 +19635,19 @@
     },
     "node_modules/nan": {
       "version": "2.22.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -17114,17 +19657,20 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true
     },
     "node_modules/natural-compare-lite": {
       "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
+      "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
+      "dev": true
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
@@ -17132,11 +19678,13 @@
     },
     "node_modules/node-addon-api": {
       "version": "3.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -17154,18 +19702,21 @@
     },
     "node_modules/node-fetch-native": {
       "version": "1.6.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.4.tgz",
+      "integrity": "sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ=="
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
-      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "engines": {
         "node": ">= 6.13.0"
       }
     },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -17174,12 +19725,14 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.19",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="
     },
     "node_modules/node-stdlib-browser": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-stdlib-browser/-/node-stdlib-browser-1.3.0.tgz",
+      "integrity": "sha512-g/koYzOr9Fb1Jc+tHUHlFd5gODjGn48tHexUK8q6iqOVriEgSnd3/1T7myBYc+0KBVze/7F7n65ec9rW6OD7xw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assert": "^2.0.0",
         "browser-resolve": "^2.0.0",
@@ -17215,6 +19768,8 @@
     },
     "node_modules/node-stdlib-browser/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -17230,7 +19785,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -17238,14 +19792,16 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
       "engines": {
         "node": ">=10"
       },
@@ -17255,8 +19811,9 @@
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
       },
@@ -17266,22 +19823,25 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/object-hash": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
       "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -17291,7 +19851,8 @@
     },
     "node_modules/object-is": {
       "version": "1.1.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1"
@@ -17305,14 +19866,16 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -17330,11 +19893,13 @@
     },
     "node_modules/oblivious-set": {
       "version": "1.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.1.1.tgz",
+      "integrity": "sha512-Oh+8fK09mgGmAshFdH6hSVco6KZmd1tTwNFWj35OvzdmJTMZtAkbn05zar2iG3v6sDs1JLEtOiBGNb6BHwkb2w=="
     },
     "node_modules/ofetch": {
       "version": "1.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
       "dependencies": {
         "destr": "^2.0.3",
         "node-fetch-native": "^1.6.4",
@@ -17343,22 +19908,26 @@
     },
     "node_modules/ohash": {
       "version": "1.1.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+      "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g=="
     },
     "node_modules/on-exit-leak-free": {
       "version": "0.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/onetime": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
       "dependencies": {
         "mimic-fn": "^4.0.0"
       },
@@ -17371,8 +19940,9 @@
     },
     "node_modules/open": {
       "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "define-lazy-prop": "^2.0.0",
         "is-docker": "^2.1.1",
@@ -17387,8 +19957,9 @@
     },
     "node_modules/open/node_modules/is-docker": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
@@ -17401,8 +19972,9 @@
     },
     "node_modules/open/node_modules/is-wsl": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -17412,15 +19984,17 @@
     },
     "node_modules/opener": {
       "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
       "dev": true,
-      "license": "(WTFPL OR MIT)",
       "bin": {
         "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optimism": {
       "version": "0.18.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/optimism/-/optimism-0.18.1.tgz",
+      "integrity": "sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==",
       "dependencies": {
         "@wry/caches": "^1.0.0",
         "@wry/context": "^0.7.0",
@@ -17430,8 +20004,9 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -17446,18 +20021,20 @@
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+      "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
+      "dev": true
     },
     "node_modules/ox": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
+      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "^1.10.1",
         "@noble/curves": "^1.6.0",
@@ -17478,7 +20055,8 @@
     },
     "node_modules/ox/node_modules/abitype": {
       "version": "1.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -17497,19 +20075,22 @@
     },
     "node_modules/ox/node_modules/eventemitter3": {
       "version": "5.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -17522,8 +20103,9 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -17536,22 +20118,26 @@
     },
     "node_modules/p-try": {
       "version": "2.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "license": "BlueOak-1.0.0"
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
     },
     "node_modules/pako": {
       "version": "2.1.0",
-      "license": "(MIT AND Zlib)"
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -17561,7 +20147,8 @@
     },
     "node_modules/parse-asn1": {
       "version": "5.1.7",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.7.tgz",
+      "integrity": "sha512-CTM5kuWR3sx9IFamcl5ErfPl6ea/N8IYwiJ+vpeB2g+1iknv7zBl5uPwbMbRVznRVbrNY6lGuDoE5b30grmbqg==",
       "dependencies": {
         "asn1.js": "^4.10.1",
         "browserify-aes": "^1.2.0",
@@ -17576,7 +20163,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -17592,37 +20180,43 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
-      "license": "BlueOak-1.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -17636,30 +20230,35 @@
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
       "version": "10.4.3",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pathe": {
       "version": "1.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
     },
     "node_modules/pathval": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/pbkdf2": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+      "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -17673,12 +20272,14 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -17688,8 +20289,9 @@
     },
     "node_modules/pidtree": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "pidtree": "bin/pidtree.js"
       },
@@ -17699,14 +20301,16 @@
     },
     "node_modules/pify": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/pino": {
       "version": "7.11.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
+      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.0.0",
@@ -17726,7 +20330,8 @@
     },
     "node_modules/pino-abstract-transport": {
       "version": "0.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
       "dependencies": {
         "duplexify": "^4.1.2",
         "split2": "^4.0.0"
@@ -17734,19 +20339,22 @@
     },
     "node_modules/pino-std-serializers": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
       "version": "4.0.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
+      "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "find-up": "^5.0.0"
       },
@@ -17756,7 +20364,8 @@
     },
     "node_modules/pkg-types": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
+      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
       "dependencies": {
         "confbox": "^0.1.8",
         "mlly": "^1.7.2",
@@ -17765,27 +20374,32 @@
     },
     "node_modules/pngjs": {
       "version": "3.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/pony-cause": {
       "version": "2.1.11",
-      "license": "0BSD",
+      "resolved": "https://registry.npmjs.org/pony-cause/-/pony-cause-2.1.11.tgz",
+      "integrity": "sha512-M7LhCsdNbNgiLYiP4WjsfLUuFmCfnjdF6jKe2R9NKl4WFN+HZPGHJZ9lnLP7f9ZnKe3U9nuWD0szirmj+migUg==",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+      "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
       "version": "8.4.49",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
       "funding": [
         {
           "type": "opencollective",
@@ -17800,7 +20414,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -17812,7 +20425,8 @@
     },
     "node_modules/postcss-import": {
       "version": "15.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -17827,7 +20441,8 @@
     },
     "node_modules/postcss-js": {
       "version": "4.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
+      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
       "dependencies": {
         "camelcase-css": "^2.0.1"
       },
@@ -17844,6 +20459,8 @@
     },
     "node_modules/postcss-load-config": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
+      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17854,7 +20471,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "lilconfig": "^3.0.0",
         "yaml": "^2.3.4"
@@ -17877,7 +20493,8 @@
     },
     "node_modules/postcss-load-config/node_modules/lilconfig": {
       "version": "3.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "engines": {
         "node": ">=14"
       },
@@ -17887,7 +20504,8 @@
     },
     "node_modules/postcss-load-config/node_modules/yaml": {
       "version": "2.6.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17897,6 +20515,8 @@
     },
     "node_modules/postcss-nested": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17907,7 +20527,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.1.1"
       },
@@ -17920,7 +20539,8 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -17931,11 +20551,13 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
       "version": "10.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.4.1.tgz",
+      "integrity": "sha512-WKrRpCSwL2t3tpOOGhf2WfTpcmbpxaWtDbdJdKdjd0aEiTkvOmS4NBkG6kzlaAHI9AkQ3iVqbFWM3Ei7mZ4o1Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -17943,16 +20565,18 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
     "node_modules/prettier": {
       "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -17965,8 +20589,9 @@
     },
     "node_modules/pretty-format": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -17978,8 +20603,9 @@
     },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -17989,27 +20615,32 @@
     },
     "node_modules/pretty-format/node_modules/react-is": {
       "version": "18.3.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/process": {
       "version": "0.11.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
       "engines": {
         "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/process-warning": {
       "version": "1.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -18018,12 +20649,14 @@
     },
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/protobufjs": {
       "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -18044,19 +20677,23 @@
     },
     "node_modules/protobufjs/node_modules/long": {
       "version": "5.2.3",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/proxy-compare": {
       "version": "2.5.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
+      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
       "dependencies": {
         "bn.js": "^4.1.0",
         "browserify-rsa": "^4.0.0",
@@ -18068,11 +20705,13 @@
     },
     "node_modules/public-encrypt/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/pump": {
       "version": "3.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -18080,23 +20719,27 @@
     },
     "node_modules/punycode": {
       "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true
     },
     "node_modules/pushdata-bitcoin": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pushdata-bitcoin/-/pushdata-bitcoin-1.0.1.tgz",
+      "integrity": "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ==",
       "dependencies": {
         "bitcoin-ops": "^1.3.0"
       }
     },
     "node_modules/qr.js": {
       "version": "0.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
+      "integrity": "sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ=="
     },
     "node_modules/qrcode": {
       "version": "1.4.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.4.4.tgz",
+      "integrity": "sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==",
       "dependencies": {
         "buffer": "^5.4.3",
         "buffer-alloc": "^1.2.0",
@@ -18115,13 +20758,16 @@
     },
     "node_modules/qrcode.react": {
       "version": "3.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/qrcode/node_modules/buffer": {
       "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "funding": [
         {
           "type": "github",
@@ -18136,7 +20782,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -18144,8 +20789,9 @@
     },
     "node_modules/qs": {
       "version": "6.13.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
+      "integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.6"
       },
@@ -18158,7 +20804,8 @@
     },
     "node_modules/query-string": {
       "version": "7.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "dependencies": {
         "decode-uri-component": "^0.2.2",
         "filter-obj": "^1.1.0",
@@ -18174,12 +20821,16 @@
     },
     "node_modules/querystring-es3": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
       "engines": {
         "node": ">=0.4.x"
       }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "funding": [
         {
           "type": "github",
@@ -18193,16 +20844,17 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "engines": {
         "node": ">=10"
       },
@@ -18212,18 +20864,21 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/randomfill": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
@@ -18231,7 +20886,8 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -18241,7 +20897,8 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18252,7 +20909,8 @@
     },
     "node_modules/react-infinite-scroller": {
       "version": "1.2.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-infinite-scroller/-/react-infinite-scroller-1.2.6.tgz",
+      "integrity": "sha512-mGdMyOD00YArJ1S1F3TVU9y4fGSfVVl6p5gh/Vt4u99CJOptfVu/q5V/Wlle72TMgYlBwIhbxK5wF0C/R33PXQ==",
       "dependencies": {
         "prop-types": "^15.5.8"
       },
@@ -18262,15 +20920,18 @@
     },
     "node_modules/react-is": {
       "version": "19.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
+      "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g=="
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "node_modules/react-modal": {
       "version": "3.16.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
       "dependencies": {
         "exenv": "^1.2.0",
         "prop-types": "^15.7.2",
@@ -18284,7 +20945,8 @@
     },
     "node_modules/react-redux": {
       "version": "8.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
+      "integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "@types/hoist-non-react-statics": "^3.3.1",
@@ -18321,18 +20983,21 @@
     },
     "node_modules/react-redux/node_modules/react-is": {
       "version": "18.3.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-timer-hook": {
       "version": "3.0.8",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/react-timer-hook/-/react-timer-hook-3.0.8.tgz",
+      "integrity": "sha512-bi2e7DhPBU1MRPU4ZHaVqBmgM9e2HK0ae8O2AIqwqjcPo4/qR7lVGQonOQLAKOZPQCJSYfV8F5aBWzOLXElzqQ==",
       "peerDependencies": {
         "react": ">=16.8.0"
       }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -18346,21 +21011,24 @@
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
       "dependencies": {
         "pify": "^2.3.0"
       }
     },
     "node_modules/read-cache/node_modules/pify": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -18372,7 +21040,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -18382,7 +21051,8 @@
     },
     "node_modules/readdirp/node_modules/picomatch": {
       "version": "2.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -18392,17 +21062,21 @@
     },
     "node_modules/readonly-date": {
       "version": "1.0.0",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz",
+      "integrity": "sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ=="
     },
     "node_modules/real-require": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
       "engines": {
         "node": ">= 12.13.0"
       }
     },
     "node_modules/rechoir": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dependencies": {
         "resolve": "^1.1.6"
       },
@@ -18412,27 +21086,31 @@
     },
     "node_modules/redux": {
       "version": "4.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
+      "integrity": "sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==",
       "peerDependencies": {
         "redux": "^4"
       }
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -18442,20 +21120,23 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
+      "integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
       }
     },
     "node_modules/regexpu-core": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+      "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -18470,13 +21151,15 @@
     },
     "node_modules/regjsgen": {
       "version": "0.8.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true
     },
     "node_modules/regjsparser": {
       "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+      "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -18486,8 +21169,9 @@
     },
     "node_modules/regjsparser/node_modules/jsesc": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -18497,7 +21181,8 @@
     },
     "node_modules/rehackt": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
+      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "*"
@@ -18513,30 +21198,35 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/require-main-filename": {
       "version": "2.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
     "node_modules/reselect": {
       "version": "4.1.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
+      "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.9",
-      "license": "MIT",
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
       "dependencies": {
         "is-core-module": "^2.16.0",
         "path-parse": "^1.0.7",
@@ -18545,31 +21235,38 @@
       "bin": {
         "resolve": "bin/resolve"
       },
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/response-iterator": {
       "version": "0.2.6",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/response-iterator/-/response-iterator-0.2.6.tgz",
+      "integrity": "sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/responselike": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },
@@ -18579,8 +21276,9 @@
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -18594,16 +21292,18 @@
     },
     "node_modules/restore-cursor/node_modules/mimic-fn": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/restore-cursor/node_modules/onetime": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -18616,7 +21316,8 @@
     },
     "node_modules/reusify": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -18624,13 +21325,16 @@
     },
     "node_modules/rfdc": {
       "version": "1.4.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18643,7 +21347,8 @@
     },
     "node_modules/ripemd160": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -18651,7 +21356,8 @@
     },
     "node_modules/ripple-address-codec": {
       "version": "4.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ripple-address-codec/-/ripple-address-codec-4.3.1.tgz",
+      "integrity": "sha512-Qa3+9wKVvpL/xYtT6+wANsn0A1QcC5CT6IMZbRJZ/1lGt7gmwIfsrCuz1X0+LCEO7zgb+3UT1I1dc0k/5dwKQQ==",
       "dependencies": {
         "base-x": "^3.0.9",
         "create-hash": "^1.1.2"
@@ -18662,7 +21368,8 @@
     },
     "node_modules/ripple-binary-codec": {
       "version": "1.11.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ripple-binary-codec/-/ripple-binary-codec-1.11.0.tgz",
+      "integrity": "sha512-g7+gs3T+NfoeW6vIq5dcN0CkIT4t/zwRzFxz8X2RzfbrWRnewPUKqQbmBgs05tXLX5NuWPaneiaAVpFpYBcdfw==",
       "dependencies": {
         "assert": "^2.0.0",
         "big-integer": "^1.6.48",
@@ -18677,14 +21384,16 @@
     },
     "node_modules/ripple-binary-codec/node_modules/big-integer": {
       "version": "1.6.52",
-      "license": "Unlicense",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/ripple-keypairs": {
       "version": "1.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ripple-keypairs/-/ripple-keypairs-1.3.1.tgz",
+      "integrity": "sha512-dmPlraWKJciFJxHcoubDahGnoIalG5e/BtV6HNDUs7wLXmtnLMHt6w4ed9R8MTL2zNrVPiIdI/HCtMMo0Tm7JQ==",
       "dependencies": {
         "bn.js": "^5.1.1",
         "brorand": "^1.0.5",
@@ -18698,7 +21407,9 @@
     },
     "node_modules/ripple-lib": {
       "version": "1.10.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ripple-lib/-/ripple-lib-1.10.1.tgz",
+      "integrity": "sha512-OQk+Syl2JfxKxV2KuF/kBMtnh012I5tNnziP3G4WDGCGSIAgeqkOgkR59IQ0YDNrs1YW8GbApxrdMSRi/QClcA==",
+      "deprecated": "ripple-lib is deprecated. Please migrate to xrpl.js using this migration guide: https://xrpl.org/xrpljs2-migration-guide.html",
       "dependencies": {
         "@types/lodash": "^4.14.136",
         "@types/ws": "^7.2.0",
@@ -18719,7 +21430,8 @@
     },
     "node_modules/ripple-lib-transactionparser": {
       "version": "0.8.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/ripple-lib-transactionparser/-/ripple-lib-transactionparser-0.8.2.tgz",
+      "integrity": "sha512-1teosQLjYHLyOQrKUQfYyMjDR3MAq/Ga+MJuLUfpBMypl4LZB4bEoMcmG99/+WVTEiZOezJmH9iCSvm/MyxD+g==",
       "dependencies": {
         "bignumber.js": "^9.0.0",
         "lodash": "^4.17.15"
@@ -18727,7 +21439,8 @@
     },
     "node_modules/ripple-lib/node_modules/ws": {
       "version": "7.5.10",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -18746,7 +21459,8 @@
     },
     "node_modules/rlp": {
       "version": "2.2.7",
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
+      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
       "dependencies": {
         "bn.js": "^5.2.0"
       },
@@ -18756,8 +21470,9 @@
     },
     "node_modules/rollup": {
       "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.1.tgz",
+      "integrity": "sha512-61fXYl/qNVinKmGSTHAZ6Yy8I3YIJC/r2m9feHo6SwVAVcLT5MPwOUFe7EuURA/4m0NR8lXG4BBXuo/IZEsjMg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -18793,8 +21508,9 @@
     },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
+      "integrity": "sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "open": "^8.4.0",
         "picomatch": "^2.3.1",
@@ -18818,8 +21534,9 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -18831,21 +21548,24 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/rollup-plugin-visualizer/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -18855,16 +21575,18 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
       "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/string-width": {
       "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -18876,8 +21598,9 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -18892,16 +21615,18 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/y18n": {
       "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
       "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -18917,15 +21642,17 @@
     },
     "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
       "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/rpc-websockets": {
       "version": "7.11.2",
-      "license": "LGPL-3.0-only",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.2.tgz",
+      "integrity": "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==",
       "dependencies": {
         "eventemitter3": "^4.0.7",
         "uuid": "^8.3.2",
@@ -18942,7 +21669,8 @@
     },
     "node_modules/rtcpeerconnection-shim": {
       "version": "1.2.15",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/rtcpeerconnection-shim/-/rtcpeerconnection-shim-1.2.15.tgz",
+      "integrity": "sha512-C6DxhXt7bssQ1nHb154lqeL0SXz5Dx4RczXZu2Aa/L1NJFnEVDxFwCBo3fqtuljhHIGceg5JKBV4XJ0gW5JKyw==",
       "dependencies": {
         "sdp": "^2.6.0"
       },
@@ -18953,6 +21681,8 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -18967,14 +21697,14 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
       "version": "6.6.7",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dependencies": {
         "tslib": "^1.9.0"
       },
@@ -18984,10 +21714,13 @@
     },
     "node_modules/rxjs/node_modules/tslib": {
       "version": "1.14.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "funding": [
         {
           "type": "github",
@@ -19001,23 +21734,25 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
+      ]
     },
     "node_modules/safe-json-utils": {
       "version": "1.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safe-json-utils/-/safe-json-utils-1.1.1.tgz",
+      "integrity": "sha512-SAJWGKDs50tAbiDXLf89PDwt9XYkWyANFWVzn4dTXl5QyI8t2o/bW5/OJl3lvc2WVU4MEpTo9Yz5NVFNsp+OJQ=="
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/salmon-adapter-sdk": {
       "version": "1.1.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/salmon-adapter-sdk/-/salmon-adapter-sdk-1.1.1.tgz",
+      "integrity": "sha512-28ysSzmDjx2AbotxSggqdclh9MCwlPJUldKkCph48oS5Xtwu0QOg8T9ZRHS2Mben4Y8sTq6VvxXznKssCYFBJA==",
       "dependencies": {
         "@project-serum/sol-wallet-adapter": "^0.2.6",
         "eventemitter3": "^4.0.7"
@@ -19028,23 +21763,27 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
     },
     "node_modules/scrypt-js": {
       "version": "3.0.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/sdp": {
       "version": "2.12.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-2.12.0.tgz",
+      "integrity": "sha512-jhXqQAQVM+8Xj5EjJGVweuEzgtGWb3tmEEpl3CLP3cStInSbVHSg0QWOGQzNq8pSID4JkpeV2mPqlMDLrm0/Vw=="
     },
     "node_modules/secp256k1": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
+      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "elliptic": "^6.5.7",
         "node-addon-api": "^5.0.0",
@@ -19056,22 +21795,26 @@
     },
     "node_modules/secp256k1/node_modules/node-addon-api": {
       "version": "5.1.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -19086,11 +21829,13 @@
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
-      "license": "(MIT AND BSD-3-Clause)",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -19101,14 +21846,16 @@
     },
     "node_modules/sha3": {
       "version": "2.1.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-2.1.4.tgz",
+      "integrity": "sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==",
       "dependencies": {
         "buffer": "6.0.3"
       }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -19118,14 +21865,16 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shelljs": {
       "version": "0.8.5",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
       "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
@@ -19140,7 +21889,8 @@
     },
     "node_modules/shx": {
       "version": "0.3.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz",
+      "integrity": "sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==",
       "dependencies": {
         "minimist": "^1.2.3",
         "shelljs": "^0.8.5"
@@ -19154,8 +21904,9 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -19172,8 +21923,9 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -19187,8 +21939,9 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -19204,8 +21957,9 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -19222,18 +21976,21 @@
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "dev": true,
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/sirv": {
       "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@polka/url": "^1.0.0-next.24",
         "mrmime": "^2.0.0",
@@ -19245,16 +22002,18 @@
     },
     "node_modules/slash": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.0.0",
         "is-fullwidth-code-point": "^4.0.0"
@@ -19268,8 +22027,9 @@
     },
     "node_modules/slice-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -19279,7 +22039,8 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -19287,7 +22048,8 @@
     },
     "node_modules/snake-case": {
       "version": "3.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+      "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
@@ -19295,7 +22057,8 @@
     },
     "node_modules/snakecase-keys": {
       "version": "5.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-5.5.0.tgz",
+      "integrity": "sha512-r3kRtnoPu3FxGJ3fny6PKNnU3pteb29o6qAa0ugzhSseKNWRkw1dw8nIjXMyyKaU9vQxxVIE62Mb3bKbdrgpiw==",
       "dependencies": {
         "map-obj": "^4.1.0",
         "snake-case": "^3.0.4",
@@ -19307,7 +22070,8 @@
     },
     "node_modules/snakecase-keys/node_modules/type-fest": {
       "version": "3.13.1",
-      "license": "(MIT OR CC0-1.0)",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+      "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
       "engines": {
         "node": ">=14.16"
       },
@@ -19317,7 +22081,8 @@
     },
     "node_modules/socket.io-client": {
       "version": "4.8.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -19330,7 +22095,8 @@
     },
     "node_modules/socket.io-client/node_modules/debug": {
       "version": "4.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -19345,7 +22111,8 @@
     },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -19356,7 +22123,8 @@
     },
     "node_modules/socket.io-parser/node_modules/debug": {
       "version": "4.3.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -19371,7 +22139,8 @@
     },
     "node_modules/socks": {
       "version": "2.8.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -19383,7 +22152,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
+      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
       "dependencies": {
         "agent-base": "^7.1.1",
         "debug": "^4.3.4",
@@ -19395,66 +22165,77 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "7.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
       "version": "2.8.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
+      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/split2": {
       "version": "4.2.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
-      "license": "BSD-3-Clause"
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/stackback": {
       "version": "0.0.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
     },
     "node_modules/std-env": {
       "version": "3.8.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
     },
     "node_modules/store2": {
       "version": "2.14.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/store2/-/store2-2.14.3.tgz",
+      "integrity": "sha512-4QcZ+yx7nzEFiV4BMLnr/pRa5HYzNITX2ri0Zh6sT9EyQHbBHacC6YigllUPU9X3D0f/22QCgfokpKs52YRrUg=="
     },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+      "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
@@ -19462,8 +22243,9 @@
     },
     "node_modules/stream-http": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "builtin-status-codes": "^3.0.0",
         "inherits": "^2.0.4",
@@ -19473,37 +22255,43 @@
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
     },
     "node_modules/strict-event-emitter-types": {
       "version": "2.0.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
+      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
     },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -19519,7 +22307,8 @@
     "node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19531,18 +22320,21 @@
     },
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "engines": {
         "node": ">=12"
       },
@@ -19552,7 +22344,8 @@
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -19565,7 +22358,8 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19576,7 +22370,8 @@
     "node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -19586,15 +22381,17 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/strip-final-newline": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
       "engines": {
         "node": ">=12"
       },
@@ -19604,7 +22401,8 @@
     },
     "node_modules/strip-hex-prefix": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
       "dependencies": {
         "is-hex-prefixed": "1.0.0"
       },
@@ -19615,8 +22413,9 @@
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -19626,8 +22425,9 @@
     },
     "node_modules/strip-literal": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -19637,16 +22437,19 @@
     },
     "node_modules/strip-literal/node_modules/js-tokens": {
       "version": "9.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true
     },
     "node_modules/stylis": {
       "version": "4.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/sucrase": {
       "version": "3.35.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
+      "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
         "commander": "^4.0.0",
@@ -19666,21 +22469,24 @@
     },
     "node_modules/sucrase/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
     },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/sucrase/node_modules/glob": {
       "version": "10.4.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -19698,7 +22504,8 @@
     },
     "node_modules/sucrase/node_modules/minimatch": {
       "version": "9.0.5",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -19711,12 +22518,14 @@
     },
     "node_modules/superstruct": {
       "version": "0.15.5",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-0.15.5.tgz",
+      "integrity": "sha512-4AOeU+P5UuE/4nOUkmcQdW5y7i9ndt1cQd/3iUe+LTz3RxESf/W/5lg4B74HbDMMv8PHnPnGCQFH45kBcrQYoQ=="
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -19726,7 +22535,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -19736,14 +22546,16 @@
     },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
+      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/system-architecture": {
       "version": "0.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/system-architecture/-/system-architecture-0.1.0.tgz",
+      "integrity": "sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==",
       "engines": {
         "node": ">=18"
       },
@@ -19753,7 +22565,8 @@
     },
     "node_modules/tailwindcss": {
       "version": "3.4.17",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -19788,7 +22601,8 @@
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {
       "version": "6.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -19798,7 +22612,8 @@
     },
     "node_modules/tailwindcss/node_modules/lilconfig": {
       "version": "3.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "engines": {
         "node": ">=14"
       },
@@ -19807,23 +22622,28 @@
       }
     },
     "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dependencies": {
         "any-promise": "^1.0.0"
       }
     },
     "node_modules/thenify-all": {
       "version": "1.6.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
       },
@@ -19833,19 +22653,22 @@
     },
     "node_modules/thread-stream": {
       "version": "0.15.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
+      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
       "dependencies": {
         "real-require": "^0.1.0"
       }
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+      "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "setimmediate": "^1.0.4"
       },
@@ -19855,13 +22678,15 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tiny-secp256k1": {
       "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.7.tgz",
+      "integrity": "sha512-eb+F6NabSnjbLwNoC+2o5ItbmP1kg7HliWue71JgLegQt6A5mTN8YbvTLCazdlg6e5SV6A+r8OGvZYskdlmhqQ==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "bindings": "^1.3.0",
         "bn.js": "^4.11.8",
@@ -19875,40 +22700,46 @@
     },
     "node_modules/tiny-secp256k1/node_modules/bn.js": {
       "version": "4.12.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
+      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
     },
     "node_modules/tinypool": {
       "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -19918,27 +22749,32 @@
     },
     "node_modules/toggle-selection": {
       "version": "1.0.6",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toml": {
       "version": "3.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/totalist": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tronweb": {
       "version": "5.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tronweb/-/tronweb-5.3.2.tgz",
+      "integrity": "sha512-iPcIjMCxb6H7FXMntAj47F3L+7jSideyQ7ZOvRj9MeZBh46SHevMrDDR57HzakUa/tT8VvlPFHtqFK4hzTLkXw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@ethersproject/abi": "^5.7.0",
@@ -19957,22 +22793,26 @@
     },
     "node_modules/tronweb/node_modules/eventemitter3": {
       "version": "3.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
     "node_modules/tronweb/node_modules/semver": {
       "version": "5.7.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-invariant": {
       "version": "0.10.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -19982,12 +22822,14 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/ts-unused-exports": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ts-unused-exports/-/ts-unused-exports-10.1.0.tgz",
+      "integrity": "sha512-QA11Dpwkm5Apfe9s/UkFzHEpbiBxKy0VQ72YRAoqq9VgNbxvvIOcS5Kgm1MCitOec9YU6nf51DEWnmL6jkP2Yg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
         "tsconfig-paths": "^3.9.0"
@@ -20009,8 +22851,9 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.2",
@@ -20020,8 +22863,9 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -20031,11 +22875,13 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tss-react": {
       "version": "4.9.14",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tss-react/-/tss-react-4.9.14.tgz",
+      "integrity": "sha512-nAj4RCQk3ADzrmtxmTcmN1B9EKxPMIxuCfJ3ll964CksndJ2/ZImF6rAMo2Kud5yE3ENXHpPIBHCyuMtgptMvw==",
       "dependencies": {
         "@emotion/cache": "*",
         "@emotion/serialize": "*",
@@ -20059,8 +22905,9 @@
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -20073,26 +22920,31 @@
     },
     "node_modules/tsutils/node_modules/tslib": {
       "version": "1.14.1",
-      "dev": true,
-      "license": "0BSD"
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tty-browserify": {
       "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+      "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "license": "Unlicense"
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
-      "license": "Unlicense"
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -20102,16 +22954,18 @@
     },
     "node_modules/type-detect": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/type-fest": {
       "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
       "dev": true,
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -20121,18 +22975,21 @@
     },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
     },
     "node_modules/typeforce": {
       "version": "1.18.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g=="
     },
     "node_modules/typescript": {
       "version": "5.7.2",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -20143,6 +23000,8 @@
     },
     "node_modules/ua-parser-js": {
       "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.39.tgz",
+      "integrity": "sha512-k24RCVWlEcjkdOxYmVJgeD/0a1TiSpqLg+ZalVGV9lsnr4yqu0w7tX/x2xX6G4zpkgQnRf89lxuZ1wsbjXM8lw==",
       "funding": [
         {
           "type": "opencollective",
@@ -20157,7 +23016,6 @@
           "url": "https://github.com/sponsors/faisalman"
         }
       ],
-      "license": "MIT",
       "bin": {
         "ua-parser-js": "script/cli.js"
       },
@@ -20167,33 +23025,39 @@
     },
     "node_modules/ufo": {
       "version": "1.5.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
     },
     "node_modules/uint8array-tools": {
       "version": "0.0.8",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uint8array-tools/-/uint8array-tools-0.0.8.tgz",
+      "integrity": "sha512-xS6+s8e0Xbx++5/0L+yyexukU7pz//Yg6IHg3BKhXotg1JcYtgxVcUctQ0HxLByiJzpAkNFawz1Nz5Xadzo82g==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/uint8arrays": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
+      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
       "dependencies": {
         "multiformats": "^9.4.2"
       }
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="
     },
     "node_modules/undici-types": {
       "version": "6.19.8",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
     },
     "node_modules/unenv": {
       "version": "1.10.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
       "dependencies": {
         "consola": "^3.2.3",
         "defu": "^6.1.4",
@@ -20204,20 +23068,23 @@
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-match-property-ecmascript": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -20228,45 +23095,51 @@
     },
     "node_modules/unicode-match-property-value-ecmascript": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unidragger": {
       "version": "3.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unidragger/-/unidragger-3.0.1.tgz",
+      "integrity": "sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==",
       "dependencies": {
         "ev-emitter": "^2.0.0"
       }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
       }
     },
     "node_modules/unload": {
       "version": "2.4.1",
-      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.4.1.tgz",
+      "integrity": "sha512-IViSAm8Z3sRBYA+9wc0fLQmU9Nrxb16rcDmIiR6Y9LJSZzI7QY5QsDhqPpKOjAn0O9/kfK1TfNEMMAGPTIraPw==",
       "funding": {
         "url": "https://github.com/sponsors/pubkey"
       }
     },
     "node_modules/unstorage": {
       "version": "1.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.14.0.tgz",
+      "integrity": "sha512-FjkD8JSdZyktjzPUR9KbR1Pc2tD9b+rEMMNMyvrlpBwQCftL9WgU7iAvb95QDBi5wDL75SQyTovQASBPzt3a9g==",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^3.6.0",
@@ -20358,11 +23231,13 @@
     },
     "node_modules/unstorage/node_modules/lru-cache": {
       "version": "10.4.3",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
     },
     "node_modules/untun": {
       "version": "0.1.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
+      "integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
       "dependencies": {
         "citty": "^0.1.5",
         "consola": "^3.2.3",
@@ -20374,6 +23249,8 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -20388,7 +23265,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.0"
@@ -20402,28 +23278,32 @@
     },
     "node_modules/uqr": {
       "version": "0.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
+      "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/uri-js/node_modules/punycode": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/url": {
       "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -20434,8 +23314,9 @@
     },
     "node_modules/usb": {
       "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.14.0.tgz",
+      "integrity": "sha512-I3lzVOH21BsO6qPYvx1C7Ji08lbuM0qmsEtNGAphqlhNME5cz/vExY+jIXZl+HQIRybI/sTxdyLab5tALsL69w==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@types/w3c-web-usb": "^1.0.6",
         "node-addon-api": "^8.0.0",
@@ -20447,14 +23328,16 @@
     },
     "node_modules/usb/node_modules/node-addon-api": {
       "version": "8.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
+      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
       "engines": {
         "node": "^18 || ^20 || >= 21"
       }
     },
     "node_modules/use-debounce": {
       "version": "9.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-9.0.4.tgz",
+      "integrity": "sha512-6X8H/mikbrt0XE8e+JXRtZ8yYVvKkdYRfmIhWZYsP8rcNs9hk3APV8Ua2mFkKRLcJKVdnX2/Vwrmg2GWKUQEaQ==",
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -20464,15 +23347,17 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.4.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
@@ -20483,7 +23368,8 @@
     },
     "node_modules/util": {
       "version": "0.12.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -20494,18 +23380,22 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
       "version": "8.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uuidv4": {
       "version": "6.2.13",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
+      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@types/uuid": "8.3.4",
         "uuid": "8.3.2"
@@ -20513,14 +23403,16 @@
     },
     "node_modules/validator": {
       "version": "13.12.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/valtio": {
       "version": "1.11.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.11.2.tgz",
+      "integrity": "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==",
       "dependencies": {
         "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
@@ -20543,21 +23435,24 @@
     },
     "node_modules/valtio/node_modules/use-sync-external-store": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/varuint-bitcoin": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-2.0.0.tgz",
+      "integrity": "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog==",
       "dependencies": {
         "uint8array-tools": "^0.0.8"
       }
     },
     "node_modules/versions": {
       "version": "10.4.3",
-      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/versions/-/versions-10.4.3.tgz",
+      "integrity": "sha512-pD7dDotmV6dTffxQUHjsjbG7K/MFTnNcF0KpFYRD9BwHV+vQEf8VRmd3/CTn9Xu8BxNhrLac+x25Ny1SA2Lp/w==",
       "bin": {
         "versions": "bin/versions.js"
       },
@@ -20567,13 +23462,14 @@
     },
     "node_modules/viem": {
       "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.21.4.tgz",
+      "integrity": "sha512-BNVYdSaUjeS2zKQgPs+49e5JKocfo60Ib2yiXOWBT6LuVxY1I/6fFX3waEtpXvL1Xn4qu+BVitVtMh9lyThyhQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@adraffy/ens-normalize": "1.10.0",
         "@noble/curves": "1.2.0",
@@ -20595,11 +23491,13 @@
     },
     "node_modules/viem/node_modules/@adraffy/ens-normalize": {
       "version": "1.10.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
     },
     "node_modules/viem/node_modules/@noble/curves": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -20609,7 +23507,8 @@
     },
     "node_modules/viem/node_modules/@noble/hashes": {
       "version": "1.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
       "engines": {
         "node": ">= 16"
       },
@@ -20619,14 +23518,16 @@
     },
     "node_modules/viem/node_modules/@scure/base": {
       "version": "1.1.9",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/viem/node_modules/@scure/bip32": {
       "version": "1.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
       "dependencies": {
         "@noble/curves": "~1.2.0",
         "@noble/hashes": "~1.3.2",
@@ -20638,7 +23539,8 @@
     },
     "node_modules/viem/node_modules/@scure/bip39": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
       "dependencies": {
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
@@ -20649,13 +23551,14 @@
     },
     "node_modules/viem/node_modules/abitype": {
       "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5.0.4",
         "zod": "^3 >=3.19.1"
@@ -20671,7 +23574,8 @@
     },
     "node_modules/viem/node_modules/ws": {
       "version": "8.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -20690,8 +23594,9 @@
     },
     "node_modules/vite": {
       "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -20748,8 +23653,9 @@
     },
     "node_modules/vite-bundle-visualizer": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vite-bundle-visualizer/-/vite-bundle-visualizer-1.2.1.tgz",
+      "integrity": "sha512-cwz/Pg6+95YbgIDp+RPwEToc4TKxfsFWSG/tsl2DSZd9YZicUag1tQXjJ5xcL7ydvEoaC2FOZeaXOU60t9BRXw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "import-from-esm": "^1.3.3",
@@ -20765,8 +23671,9 @@
     },
     "node_modules/vite-node": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.0.tgz",
+      "integrity": "sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.3.4",
@@ -20786,8 +23693,9 @@
     },
     "node_modules/vite-plugin-dts": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-dts/-/vite-plugin-dts-4.4.0.tgz",
+      "integrity": "sha512-CJ6phvnnPLF+aFk8Jz2ZcMBLleJ4gKJOXb9We5Kzmsp5bPuD+uMDeVefjFNYSXZ+wdcqnf+Yp2P7oA5hBKQTlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@microsoft/api-extractor": "^7.48.1",
         "@rollup/pluginutils": "^5.1.4",
@@ -20814,8 +23722,9 @@
     },
     "node_modules/vitest": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.0.tgz",
+      "integrity": "sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/expect": "1.6.0",
         "@vitest/runner": "1.6.0",
@@ -20878,8 +23787,9 @@
     },
     "node_modules/vitest/node_modules/execa": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
         "get-stream": "^8.0.1",
@@ -20900,8 +23810,9 @@
     },
     "node_modules/vitest/node_modules/get-stream": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16"
       },
@@ -20911,16 +23822,18 @@
     },
     "node_modules/vitest/node_modules/human-signals": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=16.17.0"
       }
     },
     "node_modules/vitest/node_modules/is-stream": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -20930,8 +23843,9 @@
     },
     "node_modules/vitest/node_modules/npm-run-path": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0"
       },
@@ -20944,8 +23858,9 @@
     },
     "node_modules/vitest/node_modules/path-key": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -20955,8 +23870,9 @@
     },
     "node_modules/vitest/node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -20966,25 +23882,29 @@
     },
     "node_modules/vlq": {
       "version": "2.0.4",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-2.0.4.tgz",
+      "integrity": "sha512-aodjPa2wPQFkra1G8CzJBTHXhgk3EVSwxSWXNPr1fgdFLUb8kvLV1iEb6rFgasIsjP82HWI6dsb5Io26DDnasA=="
     },
     "node_modules/vm-browserify": {
       "version": "1.1.2",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
     },
     "node_modules/vscode-jsonrpc": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimatch": "^3.0.4",
         "semver": "^7.3.4",
@@ -20996,8 +23916,9 @@
     },
     "node_modules/vscode-languageclient/node_modules/semver": {
       "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -21007,8 +23928,9 @@
     },
     "node_modules/vscode-languageserver": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-7.0.0.tgz",
+      "integrity": "sha512-60HTx5ID+fLRcgdHfmz0LDZAXYEV68fzwG0JWwEPBode9NuMYTIxuYXPg4ngO8i8+Ou0lM7y6GzaYWbiDL0drw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-languageserver-protocol": "3.16.0"
       },
@@ -21018,8 +23940,9 @@
     },
     "node_modules/vscode-languageserver-protocol": {
       "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "vscode-jsonrpc": "6.0.0",
         "vscode-languageserver-types": "3.16.0"
@@ -21027,21 +23950,26 @@
     },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true
     },
     "node_modules/vscode-languageserver-types": {
       "version": "3.16.0",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA==",
+      "dev": true
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+      "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==",
+      "dev": true
     },
     "node_modules/wagmi": {
       "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-1.4.13.tgz",
+      "integrity": "sha512-AScVYFjqNt1wMgL99Bob7MLdhoTZ3XKiOZL5HVBdy4W1sh7QodA3gQ8IsmTuUrQ7oQaTxjiXEhwg7sWNrPBvJA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -21052,7 +23980,6 @@
           "url": "https://github.com/sponsors/wagmi-dev"
         }
       ],
-      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@tanstack/query-sync-storage-persister": "^4.27.1",
@@ -21075,24 +24002,27 @@
     },
     "node_modules/warning": {
       "version": "4.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
     },
     "node_modules/web-vitals": {
       "version": "2.1.4",
-      "license": "Apache-2.0"
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
+      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "node_modules/webauthn-p256": {
       "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
+      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/wevm"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.4.0"
@@ -21100,16 +24030,19 @@
     },
     "node_modules/webextension-polyfill": {
       "version": "0.10.0",
-      "license": "MPL-2.0"
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
+      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "license": "BSD-2-Clause"
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack-bundle-analyzer": {
       "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.2.tgz",
+      "integrity": "sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@discoveryjs/json-ext": "0.5.7",
         "acorn": "^8.0.4",
@@ -21133,16 +24066,18 @@
     },
     "node_modules/webpack-bundle-analyzer/node_modules/commander": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
       "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -21161,7 +24096,8 @@
     },
     "node_modules/webrtc-adapter": {
       "version": "7.7.1",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.7.1.tgz",
+      "integrity": "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A==",
       "dependencies": {
         "rtcpeerconnection-shim": "^1.2.15",
         "sdp": "^2.12.0"
@@ -21173,11 +24109,13 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -21185,7 +24123,8 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -21198,11 +24137,13 @@
     },
     "node_modules/which-module": {
       "version": "2.0.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.18",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
@@ -21220,8 +24161,9 @@
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -21235,25 +24177,29 @@
     },
     "node_modules/wif": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-5.0.0.tgz",
+      "integrity": "sha512-iFzrC/9ne740qFbNjTZ2FciSRJlHIXoxqk/Y5EnE08QOXu1WjJyCCswwDTYbohAOEnlCtLaAAQBhyaLRFh2hMA==",
       "dependencies": {
         "bs58check": "^4.0.0"
       }
     },
     "node_modules/wif/node_modules/base-x": {
       "version": "5.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.0.tgz",
+      "integrity": "sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ=="
     },
     "node_modules/wif/node_modules/bs58": {
       "version": "6.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
       "dependencies": {
         "base-x": "^5.0.0"
       }
     },
     "node_modules/wif/node_modules/bs58check": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
       "dependencies": {
         "@noble/hashes": "^1.2.0",
         "bs58": "^6.0.0"
@@ -21261,15 +24207,17 @@
     },
     "node_modules/word-wrap": {
       "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -21285,7 +24233,8 @@
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -21300,18 +24249,21 @@
     },
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -21323,7 +24275,8 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "engines": {
         "node": ">=12"
       },
@@ -21333,7 +24286,8 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
       "engines": {
         "node": ">=12"
       },
@@ -21343,7 +24297,8 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -21356,11 +24311,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.18.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -21379,13 +24336,16 @@
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/xstream": {
       "version": "11.14.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/xstream/-/xstream-11.14.0.tgz",
+      "integrity": "sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==",
       "dependencies": {
         "globalthis": "^1.0.1",
         "symbol-observable": "^2.0.3"
@@ -21393,36 +24353,42 @@
     },
     "node_modules/xstream/node_modules/symbol-observable": {
       "version": "2.0.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-2.0.3.tgz",
+      "integrity": "sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==",
       "engines": {
         "node": ">=0.10"
       }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
       "version": "4.0.3",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "engines": {
         "node": ">= 6"
       }
     },
     "node_modules/yargs": {
       "version": "13.3.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -21438,7 +24404,8 @@
     },
     "node_modules/yargs-parser": {
       "version": "13.1.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -21446,25 +24413,29 @@
     },
     "node_modules/yargs-parser/node_modules/camelcase": {
       "version": "5.3.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "4.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "7.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "node_modules/yargs/node_modules/find-up": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -21474,14 +24445,16 @@
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/yargs/node_modules/locate-path": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -21492,7 +24465,8 @@
     },
     "node_modules/yargs/node_modules/p-limit": {
       "version": "2.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dependencies": {
         "p-try": "^2.0.0"
       },
@@ -21505,7 +24479,8 @@
     },
     "node_modules/yargs/node_modules/p-locate": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -21515,14 +24490,16 @@
     },
     "node_modules/yargs/node_modules/path-exists": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "3.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -21534,7 +24511,8 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -21544,8 +24522,9 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -21555,18 +24534,21 @@
     },
     "node_modules/zen-observable": {
       "version": "0.8.15",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ=="
     },
     "node_modules/zen-observable-ts": {
       "version": "1.2.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dependencies": {
         "zen-observable": "0.8.15"
       }
     },
     "node_modules/zustand": {
       "version": "4.5.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+      "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
       "dependencies": {
         "use-sync-external-store": "1.2.2"
       },
@@ -21592,7 +24574,8 @@
     },
     "node_modules/zustand/node_modules/use-sync-external-store": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -48,7 +48,7 @@
     "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
     "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",
     "aptos": "1.5.0",
-    "axios": "^1.7.9",
+    "axios": "1.4.0",
     "binary-parser": "^2.2.1",
     "ethers": "^6.4.2",
     "lz-string": "^1.5.0",
@@ -133,9 +133,11 @@
   },
   "overrides": {
     "@injectivelabs/sdk-ts@1.10.72": {
-      "@injectivelabs/token-metadata": "1.10.42"
+      "@injectivelabs/token-metadata": "1.10.42",
+      "axios": "1.4.0"
     },
     "@injectivelabs/sdk-ts@1.14.11": {
+      "axios": "1.4.0",
       "ethers": "5.7.2"
     },
     "@ledgerhq/hw-transport@6.27.1": {
@@ -147,6 +149,9 @@
       "@ledgerhq/errors": "6.10.2",
       "@ledgerhq/logs": "6.12.0",
       "@ledgerhq/devices": "6.27.1"
+    },
+    "@wormhole-foundation/sdk": {
+      "axios": "1.4.0"
     },
     "@mayanfinance/wormhole-sdk-route": {
       "@wormhole-foundation/sdk-connect": "1.3.0-beta.3",
@@ -179,7 +184,10 @@
       "axios": "0.27.2"
     },
     "@aptos-labs/aptos-client": {
-      "axios": "1.7.9"
+      "axios": "1.4.0"
+    },
+    "tronweb": {
+      "axios": "1.4.0"
     },
     "vite-plugin-dts": {
       "vue-tsc": "2.0.0"

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -18,13 +18,8 @@
   ],
   "dependencies": {
     "@coral-xyz/anchor": "^0.29.0",
-    "@cosmjs/cosmwasm-stargate": "^0.31.3",
-    "@cosmjs/stargate": "^0.31.3",
-    "@cosmjs/tendermint-rpc": "^0.31.3",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@injectivelabs/sdk-ts": "1.10.72",
-    "@injectivelabs/token-metadata": "1.10.42",
     "@ledgerhq/devices": "6.27.1",
     "@ledgerhq/errors": "6.10.2",
     "@ledgerhq/hw-transport": "6.27.1",
@@ -53,9 +48,8 @@
     "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
     "@xlabs-libs/wallet-aggregator-sui": "^0.0.1-alpha.10",
     "aptos": "1.5.0",
-    "axios": "^1.2.4",
+    "axios": "^1.7.9",
     "binary-parser": "^2.2.1",
-    "cosmjs-types": "^0.9.0",
     "ethers": "^6.4.2",
     "lz-string": "^1.5.0",
     "material-ui-popup-state": "^5.0.4",
@@ -180,6 +174,12 @@
     },
     "@wormhole-foundation/wormhole-connect": {
       "aptos": "1.5.0"
+    },
+    "@json-rpc-tools/provider": {
+      "axios": "0.27.2"
+    },
+    "@aptos-labs/aptos-client": {
+      "axios": "1.7.9"
     },
     "vite-plugin-dts": {
       "vue-tsc": "2.0.0"

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -140,6 +140,15 @@
       "axios": "1.4.0",
       "ethers": "5.7.2"
     },
+    "@injectivelabs/utils": {
+      "axios": "1.4.0"
+    },
+    "@injectivelabs/test-utils": {
+      "axios": "1.4.0"
+    },
+    "@cosmjs/tendermint-rpc": {
+      "axios": "1.4.0"
+    },
     "@ledgerhq/hw-transport@6.27.1": {
       "@ledgerhq/errors": "6.10.2",
       "@ledgerhq/logs": "6.12.0",

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -33,8 +33,6 @@ import evm from '@wormhole-foundation/sdk/evm';
 import solana from '@wormhole-foundation/sdk/solana';
 import aptos from '@wormhole-foundation/sdk/aptos';
 import sui from '@wormhole-foundation/sdk/sui';
-import cosmwasm from '@wormhole-foundation/sdk/cosmwasm';
-import algorand from '@wormhole-foundation/sdk/algorand';
 import RouteOperator from 'routes/operator';
 import { getTokenDecimals, getWrappedToken } from 'utils';
 import { CHAIN_ORDER } from './constants';
@@ -230,7 +228,7 @@ export async function newWormholeContextV2(): Promise<WormholeV2<Network>> {
 
   return await getWormholeV2(
     config.network,
-    [evm, solana, aptos, cosmwasm, sui, algorand],
+    [evm, solana, aptos, sui],
     v2Config,
   );
 }


### PR DESCRIPTION
This fixes the stubborn SyntaxError caused by buggy nextjs+rsc:

![telegram-cloud-photo-size-5-6271534426013942627-y](https://github.com/user-attachments/assets/43cee44e-ba34-4e20-ba65-c7cf7b0f5f15)

it is caused by rsc fucking up when minifying axios 1.7, which uses anonymous functions with unnamed parameters. the unnamed parameters are given duplicate identifier.