### PR TITLE
Fix Typo in Button.tsx  

### DIFF
--- a/wormhole-connect/src/components/v2/Button.tsx
+++ b/wormhole-connect/src/components/v2/Button.tsx
@@ -28,7 +28,7 @@ type Props = Omit<ButtonProps, 'variant'> & { variant?: string };
 
 /**
  * Custom Button component that extends MUI Button
- * @param variant:  Optional propoerty to specify the style variant of the button
+ * @param variant:  Optional property to specify the style variant of the button
  *                  Primary: The main CTA
  *
  */


### PR DESCRIPTION
# Pull Request: Fix Typo in Button.tsx  

## Description  
This PR fixes a minor typo in the `Button.tsx` file, correcting the comment for the `variant` property. The change ensures clarity and accuracy in the documentation.  

## Related Issue  
No specific issue reported.  

## Changes Made  
- Corrected the typo in the comment for the `variant` property:  
  From: `Optional propoerty`  
  To: `Optional property`.  

## Testing  
No functionality was affected. No tests are required.  

## Checklist  
- [x] Typo has been fixed.  
- [x] Comment now reflects the correct spelling.  

## Additional Notes  
This is a simple textual correction in the documentation comments, ensuring better readability and professionalism in the codebase.  
