### PR TITLE
Arbitrary destination address support

### DIFF
--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -5,7 +5,7 @@ import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
 import { maybeLogSdkError } from 'utils/errors';
-import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
 
 type HookReturn = {
   supportedRoutes: string[];

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -39,7 +39,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
       setIsFetching(true);
       const _routes: string[] = [];
       await config.routes.forEach(async (name, route) => {
-        // Disable manual routes when the receiving wallet is an AddressOnlyWallet
+        // Disable manual routes when the receiving wallet is a ReadOnlyWallet
         // because the receiving wallet can't sign/complete the transaction
         if (
           !route.AUTOMATIC_DEPOSIT &&

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -5,7 +5,7 @@ import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
 import { maybeLogSdkError } from 'utils/errors';
-import { AddressOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
 
 type HookReturn = {
   supportedRoutes: string[];
@@ -43,7 +43,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
         // because the receiving wallet can't sign/complete the transaction
         if (
           !route.AUTOMATIC_DEPOSIT &&
-          receivingWallet.name === AddressOnlyWallet.NAME
+          receivingWallet.name === ReadOnlyWallet.NAME
         ) {
           return;
         }

--- a/wormhole-connect/src/store/wallet.ts
+++ b/wormhole-connect/src/store/wallet.ts
@@ -5,7 +5,7 @@ import {
   swapWalletConnections,
   TransferWallet,
 } from 'utils/wallet';
-import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
 
 export type WalletData = {
   type: Context | undefined;

--- a/wormhole-connect/src/store/wallet.ts
+++ b/wormhole-connect/src/store/wallet.ts
@@ -5,7 +5,7 @@ import {
   swapWalletConnections,
   TransferWallet,
 } from 'utils/wallet';
-import { AddressOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
 
 export type WalletData = {
   type: Context | undefined;
@@ -109,9 +109,9 @@ export const walletSlice = createSlice({
 
       swapWalletConnections();
 
-      // If the new sending wallet is an AddressOnlyWallet,
+      // If the new sending wallet is a ReadOnlyWallet,
       // disconnect it since it can't be used for signing
-      if (state.sending.name === AddressOnlyWallet.NAME) {
+      if (state.sending.name === ReadOnlyWallet.NAME) {
         disconnect(TransferWallet.SENDING);
         state[TransferWallet.SENDING] = NO_WALLET;
       }

--- a/wormhole-connect/src/store/wallet.ts
+++ b/wormhole-connect/src/store/wallet.ts
@@ -5,6 +5,7 @@ import {
   swapWalletConnections,
   TransferWallet,
 } from 'utils/wallet';
+import { AddressOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
 
 export type WalletData = {
   type: Context | undefined;
@@ -105,7 +106,15 @@ export const walletSlice = createSlice({
       const tmp = state.sending;
       state.sending = state.receiving;
       state.receiving = tmp;
+
       swapWalletConnections();
+
+      // If the new sending wallet is an AddressOnlyWallet,
+      // disconnect it since it can't be used for signing
+      if (state.sending.name === AddressOnlyWallet.NAME) {
+        disconnect(TransferWallet.SENDING);
+        state[TransferWallet.SENDING] = NO_WALLET;
+      }
     },
   },
 });

--- a/wormhole-connect/src/utils/address.ts
+++ b/wormhole-connect/src/utils/address.ts
@@ -1,0 +1,60 @@
+import { Chain, chainToPlatform, Wormhole } from '@wormhole-foundation/sdk';
+import { isValidSuiAddress } from '@mysten/sui.js';
+import { PublicKey } from '@solana/web3.js';
+import { getAddress } from 'ethers';
+
+function isEvmAddress(address: string): boolean {
+  if (!/^0x[0-9a-fA-F]{40}$/.test(address)) return false;
+  try {
+    getAddress(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isSolanaAddress(address: string): boolean {
+  try {
+    new PublicKey(address);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isAptosAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{64}$/.test(address);
+}
+
+export function isValidWalletAddress(chain: Chain, address: string): boolean {
+  const platform = chainToPlatform(chain);
+
+  // Wormhole.chainAddress() is permissive and accepts various address formats,
+  // including ICAP Ethereum addresses, hex-encoded Solana addresses, and attempts to parse as a UniversalAddress if parsing fails.
+  // We are being more restrictive here to prevent the user from accidentally using an incorrect address.
+  switch (platform) {
+    case 'Evm':
+      if (!isEvmAddress(address)) return false;
+      break;
+    case 'Solana':
+      if (!isSolanaAddress(address)) return false;
+      break;
+    case 'Sui':
+      if (!isValidSuiAddress(address)) return false;
+      break;
+    case 'Aptos':
+      if (!isAptosAddress(address)) return false;
+      break;
+    default:
+      break;
+  }
+
+  try {
+    // This will throw an error if the address is invalid
+    Wormhole.chainAddress(chain, address);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}

--- a/wormhole-connect/src/utils/address.ts
+++ b/wormhole-connect/src/utils/address.ts
@@ -49,7 +49,7 @@ export function validateWalletAddress(
 ): NativeAddress<Chain> | null {
   const platform = chainToPlatform(chain);
 
-  // Wormhole.chainAddress() is permissive and accepts various address formats,
+  // toNative() is permissive and accepts various address formats,
   // including ICAP Ethereum addresses, hex-encoded Solana addresses, and attempts to parse as a UniversalAddress if parsing fails.
   // We are being more restrictive here to prevent the user from accidentally using an incorrect address.
   switch (platform) {

--- a/wormhole-connect/src/utils/address.ts
+++ b/wormhole-connect/src/utils/address.ts
@@ -8,7 +8,7 @@ import { isValidSuiAddress } from '@mysten/sui.js';
 import { PublicKey } from '@solana/web3.js';
 import { getAddress } from 'ethers';
 
-function isEvmAddress(address: string): boolean {
+function isValidEvmAddress(address: string): boolean {
   if (
     !address.startsWith('0x') ||
     address.length !== 42 ||
@@ -25,7 +25,7 @@ function isEvmAddress(address: string): boolean {
   }
 }
 
-function isSolanaAddress(address: string): boolean {
+function isValidSolanaAddress(address: string): boolean {
   try {
     new PublicKey(address);
     return true;
@@ -34,7 +34,7 @@ function isSolanaAddress(address: string): boolean {
   }
 }
 
-function isAptosAddress(address: string): boolean {
+function isValidAptosAddress(address: string): boolean {
   return (
     address.startsWith('0x') &&
     address.length === 66 &&
@@ -50,16 +50,16 @@ export function isValidWalletAddress(chain: Chain, address: string): boolean {
   // We are being more restrictive here to prevent the user from accidentally using an incorrect address.
   switch (platform) {
     case 'Evm':
-      if (!isEvmAddress(address)) return false;
+      if (!isValidEvmAddress(address)) return false;
       break;
     case 'Solana':
-      if (!isSolanaAddress(address)) return false;
+      if (!isValidSolanaAddress(address)) return false;
       break;
     case 'Sui':
       if (!isValidSuiAddress(address)) return false;
       break;
     case 'Aptos':
-      if (!isAptosAddress(address)) return false;
+      if (!isValidAptosAddress(address)) return false;
       break;
     default:
       throw new Error(`Unsupported platform: ${platform}`);

--- a/wormhole-connect/src/utils/transferValidation.ts
+++ b/wormhole-connect/src/utils/transferValidation.ts
@@ -111,7 +111,7 @@ export const validateAmount = (
   return '';
 };
 
-const checkAddressIsSanctioned = (address: string): boolean =>
+export const checkAddressIsSanctioned = (address: string): boolean =>
   SANCTIONED_WALLETS.has(address) || SANCTIONED_WALLETS.has('0x' + address);
 
 export const validateWallet = async (

--- a/wormhole-connect/src/utils/wallet/AddressOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/AddressOnlyWallet.ts
@@ -1,0 +1,99 @@
+import {
+  Address,
+  ChainId,
+  IconSource,
+  SendTransactionResult,
+  Wallet,
+} from '@xlabs-libs/wallet-aggregator-core';
+import { Chain, chainToChainId } from '@wormhole-foundation/sdk';
+
+export class AddressOnlyWallet extends Wallet {
+  private readonly _address: string;
+  private readonly _chain: Chain;
+  private _isConnected: boolean = true;
+
+  static readonly NAME = 'AddressOnlyWallet';
+
+  constructor(address: string, chain: Chain) {
+    super();
+    this._address = address;
+    this._chain = chain;
+  }
+
+  getName(): string {
+    return AddressOnlyWallet.NAME;
+  }
+
+  getUrl(): string {
+    return '';
+  }
+
+  async connect(): Promise<Address[]> {
+    this._isConnected = true;
+    this.emit('connect');
+    return [this._address];
+  }
+
+  async disconnect(): Promise<void> {
+    this._isConnected = false;
+    this.emit('disconnect');
+  }
+
+  getChainId(): ChainId {
+    // TODO: wallet aggregator should use SDK ChainId type
+    return chainToChainId(this._chain) as ChainId;
+  }
+
+  getNetworkInfo() {
+    throw new Error('Method not implemented.');
+  }
+
+  getAddress(): Address {
+    return this._address;
+  }
+
+  getAddresses(): Address[] {
+    return [this._address];
+  }
+
+  setMainAddress(address: Address): void {
+    // No-op: can't change address for read-only wallet
+  }
+
+  async getBalance(): Promise<string> {
+    // Could implement this to fetch balance from RPC if needed
+    throw new Error('Address only wallet cannot fetch balance');
+  }
+
+  isConnected(): boolean {
+    return this._isConnected;
+  }
+
+  getIcon(): IconSource {
+    return '';
+  }
+
+  async signTransaction(tx: any): Promise<any> {
+    throw new Error('Address only wallet cannot sign transactions');
+  }
+
+  async sendTransaction(tx: any): Promise<SendTransactionResult<any>> {
+    throw new Error('Address only wallet cannot send transactions');
+  }
+
+  async signMessage(msg: any): Promise<any> {
+    throw new Error('Address only wallet cannot sign messages');
+  }
+
+  async signAndSendTransaction(tx: any): Promise<SendTransactionResult<any>> {
+    throw new Error('Address only wallet cannot sign or send transactions');
+  }
+
+  getFeatures(): string[] {
+    return [];
+  }
+
+  supportsChain(chainId: ChainId): boolean {
+    return this.getChainId() === chainId;
+  }
+}

--- a/wormhole-connect/src/utils/wallet/AddressOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/AddressOnlyWallet.ts
@@ -7,12 +7,12 @@ import {
 } from '@xlabs-libs/wallet-aggregator-core';
 import { Chain, chainToChainId } from '@wormhole-foundation/sdk';
 
-export class AddressOnlyWallet extends Wallet {
+export class ReadOnlyWallet extends Wallet {
   private readonly _address: string;
   private readonly _chain: Chain;
   private _isConnected: boolean = true;
 
-  static readonly NAME = 'AddressOnlyWallet';
+  static readonly NAME = 'ReadyOnlyWallet';
 
   constructor(address: string, chain: Chain) {
     super();
@@ -21,7 +21,7 @@ export class AddressOnlyWallet extends Wallet {
   }
 
   getName(): string {
-    return AddressOnlyWallet.NAME;
+    return ReadOnlyWallet.NAME;
   }
 
   getUrl(): string {

--- a/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
@@ -8,16 +8,12 @@ import {
 import { Chain, chainToChainId } from '@wormhole-foundation/sdk';
 
 export class ReadOnlyWallet extends Wallet {
-  private readonly _address: string;
-  private readonly _chain: Chain;
   private _isConnected: boolean = true;
 
   static readonly NAME = 'ReadyOnlyWallet';
 
-  constructor(address: string, chain: Chain) {
+  constructor(readonly _address: string, readonly _chain: Chain) {
     super();
-    this._address = address;
-    this._chain = chain;
   }
 
   getName(): string {

--- a/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
@@ -5,14 +5,14 @@ import {
   SendTransactionResult,
   Wallet,
 } from '@xlabs-libs/wallet-aggregator-core';
-import { Chain, chainToChainId } from '@wormhole-foundation/sdk';
+import { Chain, chainToChainId, NativeAddress } from '@wormhole-foundation/sdk';
 
 export class ReadOnlyWallet extends Wallet {
   private _isConnected = true;
 
   static readonly NAME = 'ReadyOnlyWallet';
 
-  constructor(readonly _address: string, readonly _chain: Chain) {
+  constructor(readonly _address: NativeAddress<Chain>, readonly _chain: Chain) {
     super();
   }
 
@@ -27,7 +27,7 @@ export class ReadOnlyWallet extends Wallet {
   async connect(): Promise<Address[]> {
     this._isConnected = true;
     this.emit('connect');
-    return [this._address];
+    return [this._address.toString()];
   }
 
   async disconnect(): Promise<void> {
@@ -45,11 +45,11 @@ export class ReadOnlyWallet extends Wallet {
   }
 
   getAddress(): Address {
-    return this._address;
+    return this._address.toString();
   }
 
   getAddresses(): Address[] {
-    return [this._address];
+    return [this.getAddress()];
   }
 
   setMainAddress(address: Address): void {

--- a/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
+++ b/wormhole-connect/src/utils/wallet/ReadOnlyWallet.ts
@@ -8,7 +8,7 @@ import {
 import { Chain, chainToChainId } from '@wormhole-foundation/sdk';
 
 export class ReadOnlyWallet extends Wallet {
-  private _isConnected: boolean = true;
+  private _isConnected = true;
 
   static readonly NAME = 'ReadyOnlyWallet';
 

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -33,6 +33,7 @@ import {
   AptosChains,
 } from '@wormhole-foundation/sdk-aptos';
 import { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
+import { ReadOnlyWallet } from './ReadOnlyWallet';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -122,7 +123,9 @@ export const connectWallet = async (
     }
   });
 
-  localStorage.setItem(`wormhole-connect:wallet:${context}`, name);
+  if (name !== ReadOnlyWallet.NAME) {
+    localStorage.setItem(`wormhole-connect:wallet:${context}`, name);
+  }
 };
 
 // Checks localStorage for previously used wallet for this chain

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -33,7 +33,7 @@ import {
   AptosChains,
 } from '@wormhole-foundation/sdk-aptos';
 import { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
-import { ReadOnlyWallet } from './AddressOnlyWallet';
+import { ReadOnlyWallet } from './ReadOnlyWallet';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -56,10 +56,6 @@ export const walletAcceptedChains = (context: Context | undefined): Chain[] => {
 
 export const setWalletConnection = (type: TransferWallet, wallet: Wallet) => {
   walletConnection[type] = wallet;
-};
-
-export const clearWalletConnection = (type: TransferWallet) => {
-  walletConnection[type] = undefined;
 };
 
 export const connectWallet = async (
@@ -124,7 +120,7 @@ export const connectWallet = async (
 
   localStorage.setItem(`wormhole-connect:wallet:${context}`, name);
 
-  // if the wallet is an address only wallet, store the address in localStorage
+  // if the wallet is a ReadOnlyWallet, store the address in localStorage
   // for automatic connection on next visit
   if (wallet.getName() === ReadOnlyWallet.NAME) {
     localStorage.setItem(`wormhole-connect:wallet:${context}:address`, address);
@@ -170,7 +166,6 @@ export const connectLastUsedWallet = async (
 
   if (lastUsedWallet !== 'WalletConnect') {
     const options = await getWalletOptions(chainConfig);
-    // TODO: need to add AddressOnlyWallet to the list of wallets
     const wallet = options.find((w) => w.name === lastUsedWallet);
     if (wallet) {
       await connectWallet(type, chain, wallet, dispatch);

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -33,7 +33,7 @@ import {
   AptosChains,
 } from '@wormhole-foundation/sdk-aptos';
 import { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
-import { AddressOnlyWallet } from './AddressOnlyWallet';
+import { ReadOnlyWallet } from './AddressOnlyWallet';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -126,7 +126,7 @@ export const connectWallet = async (
 
   // if the wallet is an address only wallet, store the address in localStorage
   // for automatic connection on next visit
-  if (wallet.getName() === AddressOnlyWallet.NAME) {
+  if (wallet.getName() === ReadOnlyWallet.NAME) {
     localStorage.setItem(`wormhole-connect:wallet:${context}:address`, address);
   }
 };
@@ -144,19 +144,19 @@ export const connectLastUsedWallet = async (
   );
 
   if (
-    lastUsedWallet === AddressOnlyWallet.NAME &&
+    lastUsedWallet === ReadOnlyWallet.NAME &&
     type === TransferWallet.RECEIVING
   ) {
     const address = localStorage.getItem(
       `wormhole-connect:wallet:${chainConfig.context}:address`,
     );
     if (address) {
-      const wallet = new AddressOnlyWallet(address, chain);
+      const wallet = new ReadOnlyWallet(address, chain);
       await connectWallet(
         type,
         chain,
         {
-          name: AddressOnlyWallet.NAME,
+          name: ReadOnlyWallet.NAME,
           type: chainConfig.context,
           icon: wallet.getIcon(),
           isReady: true,

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -99,10 +99,15 @@ export const connectWallet = async (
     dispatch(connectReceivingWallet(payload));
   }
 
-  // clear wallet when the user manually disconnects from outside the app
+  // Clear wallet when the user manually disconnects from outside the app
   wallet.on('disconnect', () => {
     wallet.removeAllListeners();
-    dispatch(clearWallet(type));
+    // Use setTimeout to defer the dispatch call to the next event loop tick.
+    // This ensures that the dispatch does not occur while a reducer is executing,
+    // preventing the "You may not call store.getState() while the reducer is executing" error.
+    setTimeout(() => {
+      dispatch(clearWallet(type));
+    }, 0);
     localStorage.removeItem(`wormhole-connect:wallet:${context}`);
   });
 

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -33,7 +33,6 @@ import {
   AptosChains,
 } from '@wormhole-foundation/sdk-aptos';
 import { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
-import { ReadOnlyWallet } from './ReadOnlyWallet';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -124,12 +123,6 @@ export const connectWallet = async (
   });
 
   localStorage.setItem(`wormhole-connect:wallet:${context}`, name);
-
-  // if the wallet is a ReadOnlyWallet, store the address in localStorage
-  // for automatic connection on next visit
-  if (wallet.getName() === ReadOnlyWallet.NAME) {
-    localStorage.setItem(`wormhole-connect:wallet:${context}:address`, address);
-  }
 };
 
 // Checks localStorage for previously used wallet for this chain
@@ -144,32 +137,7 @@ export const connectLastUsedWallet = async (
     `wormhole-connect:wallet:${chainConfig.context}`,
   );
 
-  if (
-    lastUsedWallet === ReadOnlyWallet.NAME &&
-    type === TransferWallet.RECEIVING
-  ) {
-    const address = localStorage.getItem(
-      `wormhole-connect:wallet:${chainConfig.context}:address`,
-    );
-    if (address) {
-      const wallet = new ReadOnlyWallet(address, chain);
-      await connectWallet(
-        type,
-        chain,
-        {
-          name: ReadOnlyWallet.NAME,
-          type: chainConfig.context,
-          icon: wallet.getIcon(),
-          isReady: true,
-          wallet,
-        },
-        dispatch,
-      );
-    }
-    return;
-  }
-
-  if (lastUsedWallet !== 'WalletConnect') {
+  if (lastUsedWallet && lastUsedWallet !== 'WalletConnect') {
     const options = await getWalletOptions(chainConfig);
     const wallet = options.find((w) => w.name === lastUsedWallet);
     if (wallet) {

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -137,6 +137,7 @@ export const connectLastUsedWallet = async (
     `wormhole-connect:wallet:${chainConfig.context}`,
   );
 
+  // if the last used wallet is not WalletConnect, try to connect to it
   if (lastUsedWallet && lastUsedWallet !== 'WalletConnect') {
     const options = await getWalletOptions(chainConfig);
     const wallet = options.find((w) => w.name === lastUsedWallet);

--- a/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/ReviewTransaction/index.tsx
@@ -255,7 +255,7 @@ const ReviewTransaction = (props: Props) => {
         ),
         receivedTokenKey: config.tokens[destToken].key, // TODO: possibly wrong (e..g if portico swap fails)
         relayerFee,
-        receiveAmount: (quote.destinationToken.amount),
+        receiveAmount: quote.destinationToken.amount,
         receiveNativeAmount,
         eta: quote.eta || 0,
       };

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Controller.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Controller.tsx
@@ -168,6 +168,7 @@ const ConnectedWallet = (props: Props) => {
         onClose={() => {
           setIsOpen(false);
         }}
+        showAddressInput={props.type === TransferWallet.RECEIVING}
       />
     </>
   );

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -119,7 +119,7 @@ const WalletSidebar = (props: Props) => {
     const chainConfig = config.chains[selectedChain];
     if (!chainConfig) return;
 
-    const nativeAddress = validateWalletAddress(selectedChain, address);
+    const nativeAddress = await validateWalletAddress(selectedChain, address);
     if (!nativeAddress) {
       setAddressError('Invalid Address');
       return;

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -26,6 +26,7 @@ import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
 import { validateWalletAddress } from 'utils/address';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
+import { checkAddressIsSanctioned } from 'utils/transferValidation';
 
 const useStyles = makeStyles()((theme) => ({
   listButton: {
@@ -121,6 +122,12 @@ const WalletSidebar = (props: Props) => {
     const nativeAddress = validateWalletAddress(selectedChain, address);
     if (!nativeAddress) {
       setAddressError('Invalid Address');
+      return;
+    }
+
+    const isSanctioned = checkAddressIsSanctioned(nativeAddress.toString());
+    if (isSanctioned) {
+      setAddressError('Sanctioned Address');
       return;
     }
 

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -25,7 +25,7 @@ import AlertBannerV2 from 'components/v2/AlertBanner';
 import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
 import { isValidWalletAddress } from 'utils/address';
-import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
 
 const useStyles = makeStyles()((theme) => ({
   listButton: {

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -26,7 +26,7 @@ import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
 import { validateWalletAddress } from 'utils/address';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
-import { checkAddressIsSanctioned } from 'utils/transferValidation';
+import { SANCTIONED_WALLETS } from 'consts/wallet';
 
 const useStyles = makeStyles()((theme) => ({
   listButton: {
@@ -125,10 +125,11 @@ const WalletSidebar = (props: Props) => {
       return;
     }
 
-    const isSanctioned = checkAddressIsSanctioned(nativeAddress.toString());
-    if (isSanctioned) {
-      setAddressError('Sanctioned Address');
-      return;
+    for (const sanctioned of SANCTIONED_WALLETS) {
+      if (nativeAddress.toString().toLowerCase() === sanctioned.toLowerCase()) {
+        setAddressError('Sanctioned Address');
+        return;
+      }
     }
 
     const wallet = new ReadOnlyWallet(nativeAddress, selectedChain);

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -24,7 +24,7 @@ import { TransferWallet, WalletData, connectWallet } from 'utils/wallet';
 import AlertBannerV2 from 'components/v2/AlertBanner';
 import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
-import { isValidWalletAddress } from 'utils/address';
+import { validateWalletAddress } from 'utils/address';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
 
 const useStyles = makeStyles()((theme) => ({
@@ -118,12 +118,13 @@ const WalletSidebar = (props: Props) => {
     const chainConfig = config.chains[selectedChain];
     if (!chainConfig) return;
 
-    if (!isValidWalletAddress(selectedChain, address)) {
+    const nativeAddress = validateWalletAddress(selectedChain, address);
+    if (!nativeAddress) {
       setAddressError('Invalid Address');
       return;
     }
 
-    const wallet = new ReadOnlyWallet(address, selectedChain);
+    const wallet = new ReadOnlyWallet(nativeAddress, selectedChain);
 
     const walletInfo: WalletData = {
       name: wallet.getName(),

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/Sidebar.tsx
@@ -25,7 +25,7 @@ import AlertBannerV2 from 'components/v2/AlertBanner';
 import { useAvailableWallets } from 'hooks/useAvailableWallets';
 import WalletIcon from 'icons/WalletIcons';
 import { isValidWalletAddress } from 'utils/address';
-import { AddressOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
+import { ReadOnlyWallet } from 'utils/wallet/AddressOnlyWallet';
 
 const useStyles = makeStyles()((theme) => ({
   listButton: {
@@ -123,7 +123,7 @@ const WalletSidebar = (props: Props) => {
       return;
     }
 
-    const wallet = new AddressOnlyWallet(address, selectedChain);
+    const wallet = new ReadOnlyWallet(address, selectedChain);
 
     const walletInfo: WalletData = {
       name: wallet.getName(),

--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -46,7 +46,7 @@ type Props = {
 };
 
 // Parent component to display Connect Wallet CTA
-// and the sidebar for the lsit of available wallets.
+// and the sidebar for the list of available wallets.
 const WalletConnector = (props: Props) => {
   const { disabled = false, type } = props;
 
@@ -100,7 +100,13 @@ const WalletConnector = (props: Props) => {
           onClick={() => connectWallet()}
         >
           <Typography textTransform="none">
-            {mobile ? 'Connect' : `Connect ${props.side} wallet`}
+            {mobile
+              ? props.side === 'source'
+                ? 'Connect'
+                : 'Select wallet'
+              : `${props.side === 'source' ? 'Connect' : 'Select'} ${
+                  props.side
+                } wallet`}
           </Typography>
         </Button>
       </span>
@@ -122,6 +128,7 @@ const WalletConnector = (props: Props) => {
             onClose={() => {
               setIsOpen(false);
             }}
+            showAddressInput={props.type === TransferWallet.RECEIVING}
           />
         </>
       );


### PR DESCRIPTION
Allows the user to set an arbitrary destination address.

Manual routes are disabled when the destination wallet is not connected.