### PR TITLE
Update wallet aggregator aptos package to the latest version

### DIFF
--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -34,7 +34,7 @@
         "@wormhole-foundation/sdk-icons": "^1.0.0",
         "@wormhole-foundation/sdk-route-ntt": "^0.6.1",
         "@wormhole-foundation/sdk-solana-ntt": "^0.6.1",
-        "@xlabs-libs/wallet-aggregator-aptos": "^1.0.0-alpha.1",
+        "@xlabs-libs/wallet-aggregator-aptos": "^1.0.0-alpha.2",
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.22",
         "@xlabs-libs/wallet-aggregator-evm": "^0.0.2-alpha.5",
         "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",
@@ -5379,25 +5379,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@msafe/aptos-wallet": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@msafe/aptos-wallet/-/aptos-wallet-6.1.1.tgz",
-      "integrity": "sha512-g/2TPRqyChciaw/S69EBr7CgzYJBT1LJulU0nMNnkehJc+ZX/fNN+5JXEuea+a0rXsk/flcbCSfvT2JtS0+/mQ==",
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "json-rpc-protocol": "^0.13.2"
-      }
-    },
-    "node_modules/@msafe/aptos-wallet-adapter": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@msafe/aptos-wallet-adapter/-/aptos-wallet-adapter-1.1.3.tgz",
-      "integrity": "sha512-/5ftbNac9j2Vc6YOqET4IdkhiJnMzuy9LcnGP8ptLWHVuye5P/pAjIpv0A07gOM4/siUJQzlXkBxXdLYF9p8wQ==",
-      "dependencies": {
-        "@aptos-labs/wallet-adapter-core": "^4.1.2",
-        "@msafe/aptos-wallet": "^6.1.1",
-        "aptos": "^1.4.0"
-      }
-    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.12",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.16.12.tgz",
@@ -5883,15 +5864,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@okwallet/aptos-wallet-adapter": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@okwallet/aptos-wallet-adapter/-/aptos-wallet-adapter-0.0.7.tgz",
-      "integrity": "sha512-n6Uhh8uzj6pRRXppKYUPRDxzb3x/wH9xy3uXqYMbjJbiPb5LrWhm8LYYkRpw3ZFFNH3B/taMILd2qygzWVDH5w==",
-      "peerDependencies": {
-        "@aptos-labs/wallet-adapter-core": "3.5.0",
-        "aptos": "^1.21.0"
       }
     },
     "node_modules/@open-rpc/client-js": {
@@ -11242,24 +11214,6 @@
         "bs58": "^6.0.0"
       }
     },
-    "node_modules/@trustwallet/aptos-wallet-adapter": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@trustwallet/aptos-wallet-adapter/-/aptos-wallet-adapter-0.1.6.tgz",
-      "integrity": "sha512-vlu5JuxqMpGMLanayNKQpTC87zn4NMRo3k96iVI+IdwEeyIgiJbbFq+XqUAezzQG/U88u4jv3vK2x7cbPnNFIw==",
-      "dependencies": {
-        "@aptos-labs/wallet-adapter-core": "0.1.7",
-        "aptos": "^1.4.0"
-      }
-    },
-    "node_modules/@trustwallet/aptos-wallet-adapter/node_modules/@aptos-labs/wallet-adapter-core": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@aptos-labs/wallet-adapter-core/-/wallet-adapter-core-0.1.7.tgz",
-      "integrity": "sha512-g3HvX31kuFT5HqEe9Vh0ZgV1u0Otsfx54yeAwL7RO8CioBVBjYELhMsOYz0BOjecmAKhQ14G60VU8MqDyzYkIA==",
-      "dependencies": {
-        "aptos": "^1.3.17",
-        "eventemitter3": "^4.0.7"
-      }
-    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -14698,19 +14652,16 @@
       }
     },
     "node_modules/@xlabs-libs/wallet-aggregator-aptos": {
-      "version": "1.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-aptos/-/wallet-aggregator-aptos-1.0.0-alpha.1.tgz",
-      "integrity": "sha512-xrsR6g+9gYfBa+NzCZX7l5JKl5+3Tnf/LbJascShwUNCIQ75PBwYtSU4Gq3NJTik8QLvhY80yyoQL3KGgiguRw==",
+      "version": "1.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@xlabs-libs/wallet-aggregator-aptos/-/wallet-aggregator-aptos-1.0.0-alpha.2.tgz",
+      "integrity": "sha512-Lirl4fhxSPKWUdYPeVMvjBB0S5TTOs2a/T3RvrSUEGtdqW2eMJvfnEKRyQ71CwhM6ZYCrL2IUPj1+/h08PZhmA==",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
         "@aptos-labs/wallet-adapter-core": "^4.23.0",
         "@aptos-labs/wallet-standard": "^0.2.0",
         "@bitget-wallet/aptos-wallet-adapter": "^0.1.2",
         "@martianwallet/aptos-wallet-adapter": "^0.0.5",
-        "@msafe/aptos-wallet-adapter": "^1.1.3",
-        "@okwallet/aptos-wallet-adapter": "^0.0.7",
         "@pontem/wallet-adapter-plugin": "^0.2.1",
-        "@trustwallet/aptos-wallet-adapter": "^0.1.6",
         "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.22",
         "fewcha-plugin-wallet-adapter": "^0.1.3",
         "petra-plugin-wallet-adapter": "^0.4.5"
@@ -19383,17 +19334,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "node_modules/json-rpc-protocol": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/json-rpc-protocol/-/json-rpc-protocol-0.13.2.tgz",
-      "integrity": "sha512-2InSi+c7wGESmvYcEVS0clctpJCodV7gLqLN1BIIPNK07wokXIwhOL8RQWU4O7oX5adChn6HJGtIU6JaUQ1P/A==",
-      "dependencies": {
-        "make-error": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/json-rpc-random-id": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-rpc-random-id/-/json-rpc-random-id-1.0.1.tgz",
@@ -20011,11 +19951,6 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/map-obj": {
       "version": "4.3.0",

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -43,7 +43,7 @@
     "@wormhole-foundation/sdk-icons": "^1.0.0",
     "@wormhole-foundation/sdk-route-ntt": "^0.6.1",
     "@wormhole-foundation/sdk-solana-ntt": "^0.6.1",
-    "@xlabs-libs/wallet-aggregator-aptos": "^1.0.0-alpha.1",
+    "@xlabs-libs/wallet-aggregator-aptos": "^1.0.0-alpha.2",
     "@xlabs-libs/wallet-aggregator-core": "^0.0.1-alpha.22",
     "@xlabs-libs/wallet-aggregator-evm": "^0.0.2-alpha.5",
     "@xlabs-libs/wallet-aggregator-solana": "^0.0.1-alpha.15",


### PR DESCRIPTION
This update will remove Aptos wallets that have an old driver interface and will not work with the latest Aptos wallet driver library.