### PR TITLE
Reset manual claim error during a new claim action

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -680,6 +680,7 @@ const Redeem = () => {
     // This will be set back to false by a hook above which looks out for isTxComplete=true
     setIsClaimInProgress(true);
     setClaimError('');
+    setUnhandledManualClaimError(undefined);
 
     if (!routeName) {
       throw new Error('Unknown route, can not claim');


### PR DESCRIPTION
This happens when manual claim errors and user clicks to claim one more time.