### PR TITLE
Fix token type checking in LS validation for widget

### DIFF
--- a/wormhole-connect/src/utils/inProgressTxCache.ts
+++ b/wormhole-connect/src/utils/inProgressTxCache.ts
@@ -56,7 +56,7 @@ const validateSingleTransaction = (
       eta: 'number',
       fromChain: 'string',
       toChain: 'string',
-      tokenKey: 'string',
+      token: 'object',
     })
   ) {
     return false;
@@ -67,6 +67,15 @@ const validateSingleTransaction = (
     !validateChildPropTypes(tx.txDetails.amount, {
       amount: 'string',
       decimals: 'number',
+    })
+  ) {
+    return false;
+  }
+
+  if (
+    !validateChildPropTypes(tx.txDetails.token, {
+      0: 'string',
+      1: 'string',
     })
   ) {
     return false;


### PR DESCRIPTION
This was a regression after tokenKey was removed from tx details and we have a new token array property.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/3196