### PR TITLE
Token refactor follow-up: config updates

### DIFF
--- a/wormhole-connect/src/config/devnet/tokens.ts
+++ b/wormhole-connect/src/config/devnet/tokens.ts
@@ -2,7 +2,6 @@ import { TokenIcon, TokenConfig } from '../types';
 
 export const DEVNET_TOKENS: TokenConfig[] = [
   {
-    key: 'ETH',
     symbol: 'ETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -12,7 +11,6 @@ export const DEVNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'WETH',
     symbol: 'WETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -22,7 +20,6 @@ export const DEVNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'TKN',
     symbol: 'TKN',
     icon: TokenIcon.ETH,
     decimals: 18,

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -81,10 +81,10 @@ export function buildConfig(
 
   const ui = createUiConfig(customConfig.ui ?? {});
 
-  if (customConfig.tokens && ui.disableArbitraryTokens === undefined) {
+  if (customConfig.tokens && ui.disableUserInputtedTokens === undefined) {
     // If the integrator has provided a whitelist of tokens, we can reasonably assume they also don't want
     // users pasting in arbitrary token addresses.
-    ui.disableArbitraryTokens = true;
+    ui.disableUserInputtedTokens = true;
   }
 
   return {

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -79,6 +79,14 @@ export function buildConfig(
     validateDefaults(customConfig.ui.defaultInputs, networkData.chains, tokens);
   }
 
+  const ui = createUiConfig(customConfig.ui ?? {});
+
+  if (customConfig.tokens) {
+    // If the integrator has provided a whitelist of tokens, we can reasonably assume they also don't want
+    // users pasting in arbitrary token addresses.
+    ui.disableArbitraryTokens = true;
+  }
+
   return {
     whLegacy,
     sdkConfig,
@@ -138,14 +146,7 @@ export function buildConfig(
         return 0;
       }),
     tokens,
-
-    /*
-    // For token bridge =^_^=
-    wrappedTokenAddressCache: new WrappedTokenAddressCache(
-      tokens,
-      wrappedTokens,
-    ),
-    */
+    tokenWhitelist: customConfig.tokens,
 
     routes: new RouteOperator(customConfig.routes),
 

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -81,7 +81,7 @@ export function buildConfig(
 
   const ui = createUiConfig(customConfig.ui ?? {});
 
-  if (customConfig.tokens) {
+  if (customConfig.tokens && ui.disableArbitraryTokens === undefined) {
     // If the integrator has provided a whitelist of tokens, we can reasonably assume they also don't want
     // users pasting in arbitrary token addresses.
     ui.disableArbitraryTokens = true;

--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -81,7 +81,11 @@ export function buildConfig(
 
   const ui = createUiConfig(customConfig.ui ?? {});
 
-  if (customConfig.tokens && ui.disableUserInputtedTokens === undefined) {
+  if (
+    customConfig.tokens &&
+    customConfig.tokens.length > 0 &&
+    ui.disableUserInputtedTokens === undefined
+  ) {
     // If the integrator has provided a whitelist of tokens, we can reasonably assume they also don't want
     // users pasting in arbitrary token addresses.
     ui.disableUserInputtedTokens = true;

--- a/wormhole-connect/src/config/mainnet/tokens.ts
+++ b/wormhole-connect/src/config/mainnet/tokens.ts
@@ -2,14 +2,12 @@ import { TokenIcon, TokenConfig } from '../types';
 
 export const MAINNET_TOKENS: TokenConfig[] = [
   {
-    key: 'ETH',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.ETH,
     tokenId: { chain: 'Ethereum', address: 'native' },
   },
   {
-    key: 'WETH',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -19,7 +17,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCeth',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -29,7 +26,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'WBTC',
     symbol: 'WBTC',
     decimals: 8,
     icon: TokenIcon.WBTC,
@@ -39,7 +35,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDT',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -49,7 +44,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'DAI',
     symbol: 'DAI',
     decimals: 18,
     icon: TokenIcon.DAI,
@@ -59,7 +53,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'BUSD',
     symbol: 'BUSD',
     decimals: 18,
     icon: TokenIcon.BUSD,
@@ -69,14 +62,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'POL',
     symbol: 'POL',
     decimals: 18,
     icon: TokenIcon.POLYGON,
     tokenId: { chain: 'Polygon', address: 'native' },
   },
   {
-    key: 'WPOL',
     symbol: 'WPOL',
     decimals: 18,
     icon: TokenIcon.POLYGON,
@@ -86,7 +77,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'WETHpolygon',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -96,7 +86,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCpolygon',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -106,7 +95,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTpolygon',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -116,14 +104,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'BNB',
     symbol: 'BNB',
     decimals: 18,
     icon: TokenIcon.BNB,
     tokenId: { chain: 'Bsc', address: 'native' },
   },
   {
-    key: 'WBNB',
     symbol: 'WBNB',
     decimals: 18,
     icon: TokenIcon.BNB,
@@ -133,7 +119,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCbnb',
     symbol: 'USDC',
     decimals: 18,
     icon: TokenIcon.USDC,
@@ -143,14 +128,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'AVAX',
     symbol: 'AVAX',
     decimals: 18,
     icon: TokenIcon.AVAX,
     tokenId: { chain: 'Avalanche', address: 'native' },
   },
   {
-    key: 'WAVAX',
     symbol: 'WAVAX',
     decimals: 18,
     icon: TokenIcon.AVAX,
@@ -160,7 +143,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCavax',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -170,7 +152,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTavax',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -180,7 +161,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'WETHavax',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -190,14 +170,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'FTM',
     symbol: 'FTM',
     decimals: 18,
     icon: TokenIcon.FANTOM,
     tokenId: { chain: 'Fantom', address: 'native' },
   },
   {
-    key: 'WFTM',
     symbol: 'WFTM',
     name: 'Wrapped Fantom',
     decimals: 18,
@@ -208,7 +186,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCfantom',
     symbol: 'USDC.e',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -218,7 +195,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'CELO',
     symbol: 'CELO',
     decimals: 18,
     icon: TokenIcon.CELO,
@@ -228,7 +204,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTcelo',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -238,14 +213,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'GLMR',
     symbol: 'GLMR',
     decimals: 18,
     icon: TokenIcon.GLMR,
     tokenId: { chain: 'Moonbeam', address: 'native' },
   },
   {
-    key: 'WGLMR',
     symbol: 'WGLMR',
     decimals: 18,
     icon: TokenIcon.GLMR,
@@ -255,14 +228,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'SOL',
     symbol: 'SOL',
     decimals: 9,
     icon: TokenIcon.SOLANA,
     tokenId: { chain: 'Solana', address: 'native' },
   },
   {
-    key: 'WSOL',
     symbol: 'WSOL',
     decimals: 9,
     tokenId: {
@@ -272,7 +243,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.SOLANA,
   },
   {
-    key: 'USDCsol',
     symbol: 'USDC',
     decimals: 6,
     tokenId: {
@@ -282,7 +252,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.USDC,
   },
   {
-    key: 'USDTsol',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -292,14 +261,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'SUI',
     symbol: 'SUI',
     decimals: 9,
     tokenId: { chain: 'Sui', address: 'native' },
     icon: TokenIcon.SUI,
   },
   {
-    key: 'USDCsui',
     symbol: 'USDC',
     decimals: 6,
     tokenId: {
@@ -310,21 +277,18 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.USDC,
   },
   {
-    key: 'APT',
     symbol: 'APT',
     decimals: 8,
     tokenId: { chain: 'Aptos', address: 'native' },
     icon: TokenIcon.APT,
   },
   {
-    key: 'ETHarbitrum',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.ETH,
     tokenId: { chain: 'Arbitrum', address: 'native' },
   },
   {
-    key: 'WETHarbitrum',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -334,7 +298,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCarbitrum',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -344,7 +307,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTarbitrum',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -354,14 +316,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHoptimism',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.ETH,
     tokenId: { chain: 'Optimism', address: 'native' },
   },
   {
-    key: 'WETHoptimism',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -371,7 +331,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCoptimism',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -381,7 +340,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDToptimism',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -391,7 +349,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'WETHbsc',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -401,7 +358,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTbsc',
     symbol: 'USDT',
     decimals: 18,
     icon: TokenIcon.USDT,
@@ -411,14 +367,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHbase',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.ETH,
     tokenId: { chain: 'Base', address: 'native' },
   },
   {
-    key: 'WETHbase',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.ETH,
@@ -428,7 +382,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCbase',
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -438,7 +391,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDTbase',
     symbol: 'USDT',
     decimals: 6,
     icon: TokenIcon.USDT,
@@ -448,7 +400,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'wstETHbase',
     symbol: 'wstETH',
     decimals: 18,
     tokenId: {
@@ -458,7 +409,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    key: 'wstETH',
     symbol: 'wstETH',
     decimals: 18,
     tokenId: {
@@ -468,7 +418,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    key: 'wstETHarbitrum',
     symbol: 'wstETH',
     decimals: 18,
     tokenId: {
@@ -478,7 +427,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    key: 'wstETHoptimism',
     symbol: 'wstETH',
     decimals: 18,
     tokenId: {
@@ -488,7 +436,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    key: 'wstETHpolygon',
     symbol: 'wstETH',
     decimals: 18,
     tokenId: {
@@ -498,14 +445,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    key: 'KLAY',
     symbol: 'KLAY',
     decimals: 18,
     icon: TokenIcon.KLAY,
     tokenId: { chain: 'Klaytn', address: 'native' },
   },
   {
-    key: 'WKLAY',
     symbol: 'WKLAY',
     decimals: 18,
     name: 'wKLAY',
@@ -516,7 +461,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'PYTH',
     symbol: 'PYTH',
     decimals: 6,
     tokenId: {
@@ -526,14 +470,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.PYTH,
   },
   {
-    key: 'ETHscroll',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.SCROLL,
     tokenId: { chain: 'Scroll', address: 'native' },
   },
   {
-    key: 'WETHscroll',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.SCROLL,
@@ -543,14 +485,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHblast',
     symbol: 'ETH',
     decimals: 18,
     icon: TokenIcon.BLAST,
     tokenId: { chain: 'Blast', address: 'native' },
   },
   {
-    key: 'WETHblast',
     symbol: 'WETH',
     decimals: 18,
     icon: TokenIcon.BLAST,
@@ -560,14 +500,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'OKB',
     symbol: 'OKB',
     decimals: 18,
     icon: TokenIcon.XLAYER,
     tokenId: { chain: 'Xlayer', address: 'native' },
   },
   {
-    key: 'WOKB',
     symbol: 'WOKB',
     decimals: 18,
     icon: TokenIcon.XLAYER,
@@ -577,14 +515,12 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'MNT',
     symbol: 'MNT',
     decimals: 18,
     icon: TokenIcon.MANTLE,
     tokenId: { chain: 'Mantle', address: 'native' },
   },
   {
-    key: 'WMNT',
     symbol: 'WMNT',
     decimals: 18,
     icon: TokenIcon.MANTLE,
@@ -594,7 +530,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'tBTC',
     symbol: 'tBTC',
     decimals: 18,
     tokenId: {
@@ -604,7 +539,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'tBTCpolygon',
     symbol: 'tBTC',
     decimals: 18,
     tokenId: {
@@ -614,7 +548,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'tBTCoptimism',
     symbol: 'tBTC',
     decimals: 18,
     tokenId: {
@@ -624,7 +557,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'tBTCarbitrum',
     symbol: 'tBTC',
     decimals: 18,
     tokenId: {
@@ -634,7 +566,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'tBTCbase',
     symbol: 'tBTC',
     decimals: 18,
     tokenId: {
@@ -644,7 +575,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'tBTCsol',
     symbol: 'tBTC',
     decimals: 8,
     tokenId: {
@@ -654,7 +584,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.TBTC,
   },
   {
-    key: 'ETHworldchain',
     symbol: 'ETH',
     tokenId: {
       chain: 'Worldchain',
@@ -664,7 +593,6 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WORLDCHAIN,
   },
   {
-    key: 'WETHworldchain',
     symbol: 'WETH',
     tokenId: {
       chain: 'Worldchain',

--- a/wormhole-connect/src/config/testnet/tokens.ts
+++ b/wormhole-connect/src/config/testnet/tokens.ts
@@ -2,14 +2,12 @@ import { TokenIcon, TokenConfig } from '../types';
 
 export const TESTNET_TOKENS: TokenConfig[] = [
   {
-    key: 'BNB',
     symbol: 'BNB',
     icon: TokenIcon.BNB,
     decimals: 18,
     tokenId: { chain: 'Bsc', address: 'native' },
   },
   {
-    key: 'WBNB',
     symbol: 'WBNB',
     icon: TokenIcon.BNB,
     decimals: 18,
@@ -19,14 +17,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'AVAX',
     symbol: 'AVAX',
     icon: TokenIcon.AVAX,
     decimals: 18,
     tokenId: { chain: 'Avalanche', address: 'native' },
   },
   {
-    key: 'WAVAX',
     symbol: 'WAVAX',
     icon: TokenIcon.AVAX,
     decimals: 18,
@@ -36,7 +32,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCavax',
     symbol: 'USDC',
     icon: TokenIcon.USDC,
     decimals: 6,
@@ -46,14 +41,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'FTM',
     symbol: 'FTM',
     icon: TokenIcon.FANTOM,
     decimals: 18,
     tokenId: { chain: 'Fantom', address: 'native' },
   },
   {
-    key: 'WFTM',
     symbol: 'WFTM',
     icon: TokenIcon.FANTOM,
     decimals: 18,
@@ -63,7 +56,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'CELO',
     symbol: 'CELO',
     icon: TokenIcon.CELO,
     decimals: 18,
@@ -73,7 +65,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCalfajores',
     symbol: 'USDC.e',
     icon: TokenIcon.USDC,
     decimals: 6,
@@ -83,14 +74,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'GLMR',
     symbol: 'GLMR',
     icon: TokenIcon.GLMR,
     decimals: 18,
     tokenId: { chain: 'Moonbeam', address: 'native' },
   },
   {
-    key: 'WGLMR',
     symbol: 'WGLMR',
     icon: TokenIcon.GLMR,
     decimals: 18,
@@ -100,14 +89,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'SOL',
     symbol: 'SOL',
     icon: TokenIcon.SOLANA,
     decimals: 9,
     tokenId: { chain: 'Solana', address: 'native' },
   },
   {
-    key: 'WSOL',
     symbol: 'WSOL',
     tokenId: {
       chain: 'Solana',
@@ -117,7 +104,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     decimals: 9,
   },
   {
-    key: 'USDCsol',
     symbol: 'USDC',
     tokenId: {
       chain: 'Solana',
@@ -127,14 +113,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     decimals: 6,
   },
   {
-    key: 'SUI',
     symbol: 'SUI',
     tokenId: { chain: 'Sui', address: 'native' },
     icon: TokenIcon.SUI,
     decimals: 9,
   },
   {
-    key: 'USDCsui',
     symbol: 'USDC',
     decimals: 6,
     tokenId: {
@@ -145,21 +129,18 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.USDC,
   },
   {
-    key: 'APT',
     symbol: 'APT',
     tokenId: { chain: 'Aptos', address: 'native' },
     icon: TokenIcon.APT,
     decimals: 8,
   },
   {
-    key: 'KLAY',
     symbol: 'KLAY',
     icon: TokenIcon.KLAY,
     decimals: 18,
     tokenId: { chain: 'Klaytn', address: 'native' },
   },
   {
-    key: 'WKLAY',
     symbol: 'WKLAY',
     name: 'wKLAY',
     icon: TokenIcon.KLAY,
@@ -170,14 +151,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHsepolia',
     symbol: 'ETH',
     icon: TokenIcon.ETH,
     decimals: 18,
     tokenId: { chain: 'Sepolia', address: 'native' },
   },
   {
-    key: 'WETHsepolia',
     symbol: 'WETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -187,7 +166,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'USDCsepolia',
     symbol: 'USDC',
     icon: TokenIcon.USDC,
     decimals: 6,
@@ -197,14 +175,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHarbitrum_sepolia',
     symbol: 'ETH',
     icon: TokenIcon.ETH,
     decimals: 18,
     tokenId: { chain: 'ArbitrumSepolia', address: 'native' },
   },
   {
-    key: 'WETHarbitrum_sepolia',
     symbol: 'WETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -214,14 +190,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHbase_sepolia',
     symbol: 'ETH',
     icon: TokenIcon.ETH,
     decimals: 18,
     tokenId: { chain: 'BaseSepolia', address: 'native' },
   },
   {
-    key: 'WETHbase_sepolia',
     symbol: 'WETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -231,14 +205,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHoptimism_sepolia',
     symbol: 'ETH',
     icon: TokenIcon.ETH,
     decimals: 18,
     tokenId: { chain: 'OptimismSepolia', address: 'native' },
   },
   {
-    key: 'WETHoptimism_sepolia',
     symbol: 'WETH',
     icon: TokenIcon.ETH,
     decimals: 18,
@@ -248,14 +220,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHscroll',
     symbol: 'ETH',
     icon: TokenIcon.SCROLL,
     decimals: 18,
     tokenId: { chain: 'Scroll', address: 'native' },
   },
   {
-    key: 'WETHscroll',
     symbol: 'WETH',
     icon: TokenIcon.SCROLL,
     decimals: 18,
@@ -265,14 +235,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHblast',
     symbol: 'ETH',
     icon: TokenIcon.BLAST,
     decimals: 18,
     tokenId: { chain: 'Blast', address: 'native' },
   },
   {
-    key: 'WETHblast',
     symbol: 'WETH',
     icon: TokenIcon.BLAST,
     decimals: 18,
@@ -282,14 +250,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'OKB',
     symbol: 'OKB',
     icon: TokenIcon.XLAYER,
     decimals: 18,
     tokenId: { chain: 'Xlayer', address: 'native' },
   },
   {
-    key: 'WOKB',
     symbol: 'WOKB',
     icon: TokenIcon.XLAYER,
     decimals: 18,
@@ -299,14 +265,12 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'MNT',
     symbol: 'MNT',
     icon: TokenIcon.MANTLE,
     decimals: 18,
     tokenId: { chain: 'Mantle', address: 'native' },
   },
   {
-    key: 'WMNT',
     symbol: 'WMNT',
     icon: TokenIcon.MANTLE,
     decimals: 18,
@@ -316,7 +280,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     },
   },
   {
-    key: 'ETHworldchain',
     symbol: 'ETH',
     tokenId: {
       chain: 'Worldchain',
@@ -326,7 +289,6 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WORLDCHAIN,
   },
   {
-    key: 'WETHworldchain',
     symbol: 'WETH',
     tokenId: {
       chain: 'Worldchain',

--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -405,7 +405,7 @@ export class TokenCache extends TokenMapping<Token> {
 
         mapping.setLocalStorageKey(localStorageKey);
 
-        for (const [_key, tokenData] of Object.entries(asJson.tokens)) {
+        for (const [, tokenData] of Object.entries(asJson.tokens)) {
           const token = Token.fromJson(tokenData as TokenJson);
           mapping.add(token);
         }

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -140,10 +140,8 @@ export interface InternalConfig<N extends Network> {
   tokens: TokenCache;
   tokenWhitelist?: (string | TokenTuple)[];
 
-  // White lists
   chains: ChainsConfig;
   chainsArr: ChainConfig[];
-  tokensConfig?: TokensConfig;
 
   routes: RouteOperator;
 
@@ -159,7 +157,6 @@ export interface InternalConfig<N extends Network> {
 }
 
 export type TokenConfig = {
-  key: string;
   symbol: string;
   name?: string;
   decimals: number;

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -24,7 +24,7 @@ import {
 import RouteOperator from 'routes/operator';
 import { UiConfig } from './ui';
 import { TransferInfo } from 'utils/sdkv2';
-import { Token, TokenCache } from './tokens';
+import { Token, TokenCache, TokenTuple } from './tokens';
 
 export enum TokenIcon {
   'AVAX' = 1,
@@ -97,7 +97,7 @@ export interface WormholeConnectConfig {
 
   // White lists
   chains?: Chain[];
-  tokens?: string[];
+  tokens?: (string | TokenTuple)[];
   routes?: routes.RouteConstructor<any>[];
 
   // Custom tokens
@@ -138,6 +138,7 @@ export interface InternalConfig<N extends Network> {
   coinGeckoApiKey?: string;
 
   tokens: TokenCache;
+  tokenWhitelist?: (string | TokenTuple)[];
 
   // White lists
   chains: ChainsConfig;

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -28,8 +28,8 @@ export type UiConfig = {
 export interface DefaultInputs {
   fromChain?: Chain;
   toChain?: Chain;
-  tokenKey?: string;
-  toTokenKey?: string;
+  fromToken?: string; // Address or symbol
+  toToken?: string; // Address or symbol
   requiredChain?: Chain;
   preferredRouteName?: string;
 }

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -22,7 +22,7 @@ export type UiConfig = {
   showInProgressWidget?: boolean;
 
   // Set to true to disable the ability to paste in a token address
-  disableArbitraryTokens?: boolean;
+  disableUserInputtedTokens?: boolean;
 };
 
 export interface DefaultInputs {

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -20,6 +20,9 @@ export type UiConfig = {
 
   // Shows in-progress widgets
   showInProgressWidget?: boolean;
+
+  // Set to true to disable the ability to paste in a token address
+  disableArbitraryTokens?: boolean;
 };
 
 export interface DefaultInputs {

--- a/wormhole-connect/src/config/utils.ts
+++ b/wormhole-connect/src/config/utils.ts
@@ -176,27 +176,32 @@ export const validateDefaults = (
     }
   }
 
-  if (defaults.fromChain && defaults.tokenKey) {
-    const token =
-      tokens.get(defaults.fromChain, defaults.tokenKey) ||
-      tokens.findBySymbol(defaults.fromChain, defaults.tokenKey);
+  if (defaults.fromChain && defaults.fromToken) {
+    const token = tokens.findByAddressOrSymbol(
+      defaults.fromChain,
+      defaults.fromToken,
+    );
     if (!token) {
       error(
-        `Invalid token "${defaults.tokenKey}" specified for defaultInputs.tokenKey`,
+        `Invalid token "${defaults.fromToken}" specified for defaultInputs.fromToken`,
       );
-      delete defaults.tokenKey;
+      delete defaults.fromToken;
     }
   }
 
-  if (defaults.fromChain && defaults.tokenKey) {
-    const chain = chains[defaults.fromChain]!;
-    const { tokenId, nativeChain } = tokens[defaults.tokenKey]!;
-    if (!tokenId && nativeChain !== chain.key) {
+  if (defaults.toChain && defaults.toToken) {
+    const token = tokens.findByAddressOrSymbol(
+      defaults.toChain,
+      defaults.toToken,
+    );
+    if (!token) {
       error(
-        `Invalid token "${defaults.tokenKey}" specified for defaultInputs.tokenKey. It does not exist on "${defaults.fromChain}"`,
+        `Invalid token "${defaults.toToken}" specified for defaultInputs.toToken`,
       );
+      delete defaults.toToken;
     }
   }
+
   return defaults;
 };
 

--- a/wormhole-connect/src/store/transferInput.ts
+++ b/wormhole-connect/src/store/transferInput.ts
@@ -86,12 +86,17 @@ export interface TransferInputState {
 
 // This is a function because config might have changed since we last cleared this store
 function getInitialState(): TransferInputState {
-  const { fromChain, toChain, tokenKey, toTokenKey } =
+  const { fromChain, toChain, fromToken, toToken } =
     config.ui.defaultInputs || {};
+
   const fromTokenTuple =
-    fromChain && tokenKey ? ([fromChain, tokenKey] as TokenTuple) : undefined;
+    fromChain && fromToken
+      ? config.tokens.findByAddressOrSymbol(fromChain, fromToken)?.tuple
+      : undefined;
   const toTokenTuple =
-    toChain && toTokenKey ? ([toChain, toTokenKey] as TokenTuple) : undefined;
+    toChain && toToken
+      ? config.tokens.findByAddressOrSymbol(toChain, toToken)?.tuple
+      : undefined;
 
   return {
     showValidationState: false,

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -49,7 +49,7 @@ type Props = {
 const TokenList = (props: Props) => {
   const { classes } = useStyles();
   const theme = useTheme();
-  const tokenPastingIsEnabled = config.ui.disableArbitraryTokens !== true;
+  const tokenPastingIsEnabled = config.ui.disableUserInputtedTokens !== true;
 
   const { getOrFetchToken, isFetchingToken, getTokenPrice } = useTokens();
 

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -196,7 +196,7 @@ const TokenList = (props: Props) => {
       //
       // The integrator can also specify exact tokens using TokenTuples like ["Solana", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"].
 
-      let filteredTokens: Set<string> = new Set();
+      const filteredTokens: Set<string> = new Set();
       const desiredSymbols: string[] = [];
 
       for (const item of config.tokenWhitelist) {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -182,7 +182,7 @@ const TokenList = (props: Props) => {
       });
     }
 
-    if (config.tokenWhitelist) {
+    if (config.tokenWhitelist && config.tokenWhitelist.length > 0) {
       // If integrator has specified a token whitelist, the last step is to filter the token list by this whitelist.
       //
       // The logic behind how this works is a little complicated. The whitelist is an array of (string | TokenTuple).

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -220,7 +220,6 @@ const TokenList = (props: Props) => {
             if (!token.isTokenBridgeWrappedToken) {
               filteredTokens.add(token.address.toString());
               foundNative = true;
-              break;
             } else {
               wrapped.push(token);
             }


### PR DESCRIPTION
This makes some breaking changes to the config, so that it works with the new arbitrary tokens system.

## Breaking changes

### Token whitelist

The token whitelist used to reference tokens by their "keys" like this:

```js
{
  tokens: ["USDCeth", "USDCsol"]
}
```

Since tokens no longer have these custom keys, we now support two other means of whitelisting tokens:

1. Integrators can easily whitelist a single token across all chains by providing its symbol
2. Integrators can also be more granular by providing token tuples ([chain, address]).

```js
{
  tokens: ["USDC", ["Solana", "2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump"]]
}
```

This config whitelists USDC coin on all chains, and Pnut the Squirrel on Solana. There is some nuance to how this works because of wrapped tokens, which is [explained here](https://github.com/wormhole-foundation/wormhole-connect/pull/3200/files#diff-5af62c97f00fccc78c30b47c00a74b134d098b4a4d840bb5d8caacf857c8d9cfR186-R197).

![image](https://github.com/user-attachments/assets/44d9e2a3-75dd-4b64-a5c8-8123958e540b)

### Default tokens

The `DefaultInputs` config now has to be either the symbol or the address for the token.

```js
{
  ui: {
    defaultInputs: {
      fromChain: 'Solana',
      fromToken: '2qEHjDLDLbuBgRYvsxhc5D6uDWAivNFZGan56P1tpump',
      toChain: 'Ethereum',
      toToken: 'USDC',
    }
  }
}
```

## New properties

This also adds a new config option which disables the ability to paste in token addresses:

```js
{
  ui: {
    disableUserInputtedTokens: true
  }
}
```

This is set to true by default if an integrator provides the `tokens` whitelist.