### PR TITLE
WEB-6: useTrackTransfer optimization: sleep until 1 minute before transfer ETA

### DIFF
--- a/wormhole-connect/src/hooks/useTrackTransfer.ts
+++ b/wormhole-connect/src/hooks/useTrackTransfer.ts
@@ -60,12 +60,11 @@ const useTrackTransfer = (props: Props): ReturnProps => {
 
       while (isActive && !isCompleted(receipt)) {
         if (eta !== undefined) {
-          // If we have an ETA, and it's longer than 2 minutes out, we wait until 2 minutes are left
+          // If we have an ETA, and it's longer than 1 minute out, we wait until 1 minute is left
           // before trying to track the transfer's progress.
           const msRemaining = millisUntilEta(eta);
 
           if (msRemaining > MINIMUM_ETA) {
-            // Sleep until 1 minute from ETA
             await sleep(msRemaining - MINIMUM_ETA);
           }
         }

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -190,10 +190,36 @@ const Redeem = () => {
 
   const getUSDAmount = useUSDamountGetter();
 
+  const etaDate: Date | undefined = useMemo(() => {
+    if (eta && txTimestamp) {
+      return new Date(txTimestamp + eta);
+    } else {
+      return undefined;
+    }
+  }, [eta]);
+
+  // Initialize the countdown with 0, 0 as we might not have eta or txTimestamp yet
+  const { seconds, minutes, isRunning, restart } = useTimer({
+    expiryTimestamp: new Date(),
+    autoStart: false,
+    onExpire: () => setEtaExpired(true),
+  });
+
+  // Side-effect to start the ETA timer when we have the ETA and tx timestamp
+  useEffect(() => {
+    // Only start when we have the required values and if the timer hasn't been started yet
+    if (!txTimestamp || !eta || isRunning) {
+      return;
+    }
+
+    restart(new Date(txTimestamp + eta), true);
+  }, [eta, isRunning, restart, txTimestamp]);
+
   // Start tracking changes in the transaction
   const txTrackingResult = useTrackTransfer({
     receipt,
     route: routeName,
+    eta: etaDate,
   });
 
   // We need check the initial receipt state and tracking result together
@@ -334,23 +360,6 @@ const Redeem = () => {
   const receivingWallet = useSelector(
     (state: RootState) => state.wallet.receiving,
   );
-
-  // Initialize the countdown with 0, 0 as we might not have eta or txTimestamp yet
-  const { seconds, minutes, isRunning, restart } = useTimer({
-    expiryTimestamp: new Date(),
-    autoStart: false,
-    onExpire: () => setEtaExpired(true),
-  });
-
-  // Side-effect to start the ETA timer when we have the ETA and tx timestamp
-  useEffect(() => {
-    // Only start when we have the required values and if the timer hasn't been started yet
-    if (!txTimestamp || !eta || isRunning) {
-      return;
-    }
-
-    restart(new Date(txTimestamp + eta), true);
-  }, [eta, isRunning, restart, txTimestamp]);
 
   // Time remaining to reach the estimated completion of the transaction
   const remainingEta = useMemo(() => {

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -196,7 +196,7 @@ const Redeem = () => {
     } else {
       return undefined;
     }
-  }, [eta]);
+  }, [eta, txTimestamp]);
 
   // Initialize the countdown with 0, 0 as we might not have eta or txTimestamp yet
   const { seconds, minutes, isRunning, restart } = useTimer({

--- a/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
@@ -117,7 +117,7 @@ const WidgetItem = (props: Props) => {
     isReadyToClaim,
     receipt: trackingReceipt,
   } = useTrackTransfer({
-    eta,
+    eta: eta ? new Date(timestamp + eta) : undefined,
     receipt: initialReceipt,
     route,
   });


### PR DESCRIPTION
This makes `useTrackTransfer` wait until 1 minute before the transfer is estimated to complete, before trying to fetch updates using `track`.

I also removed `stateChanged` since it's always identical to `isCompleted`. ([It wasn't originally](https://github.com/wormhole-foundation/wormhole-connect/commit/1fe5b35ff08ada3629942e5cd6b15b8da69a1e3e#diff-9adedeb8d27e2b358795bdf604404e6ece65d46fe961681eca1d9520a616e1edR52), but after some code changes it's now redundant)

The `sleepTime` variable is not actually that important - the retries are generally handled downstream in the SDK code. Here we only hit the `sleepTime` code if `track` throws an error.