### PR TITLE
memoize getOrFetchToken

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -79,7 +79,7 @@ const TokenList = (props: Props) => {
     } catch (_e) {
       // Failed to parse the search query as an address... this is expected to happen a lot
     }
-  }, [searchQuery, props.selectedChainConfig.sdkName]);
+  }, [searchQuery, props.selectedChainConfig.sdkName, getOrFetchToken]);
 
   const sortedTokens = useMemo(() => {
     const nativeToken = config.tokens.getGasToken(


### PR DESCRIPTION
We need to memoize `getOrFetchToken` with `useCallback` to prevent hooks from firing when the function is re-created on each state update in `TokensContext`