### PR TITLE
Fix track request pile up in useTrackTransfer

### DIFF
--- a/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Widget/Item.tsx
@@ -117,12 +117,20 @@ const WidgetItem = (props: Props) => {
     onExpire: () => setEtaExpired(true),
   });
 
+  const etaDate: Date | undefined = useMemo(() => {
+    if (eta && timestamp) {
+      return new Date(timestamp + eta);
+    } else {
+      return undefined;
+    }
+  }, [eta, timestamp]);
+
   const {
     isCompleted,
     isReadyToClaim,
     receipt: trackingReceipt,
   } = useTrackTransfer({
-    eta: eta ? new Date(timestamp + eta) : undefined,
+    eta: etaDate,
     receipt: initialReceipt,
     route,
   });


### PR DESCRIPTION
We need to memoize the eta date not to create a new Date object each time, which re-triggers the side-effect in useTrackTransfer hook, then piles up track requests. These are all called at once when the timer hits 1 minute mark.

https://www.loom.com/share/91a4dc35bd044f0c95bb7af375926fc1?sid=09460a2f-bf38-4309-8125-5f94f55c1fc2