### PR TITLE
Prevent error when chain is not defined in built-in config

### DIFF
--- a/wormhole-connect/src/config/utils.ts
+++ b/wormhole-connect/src/config/utils.ts
@@ -53,6 +53,8 @@ export const mergeCustomWrappedTokens = (
 
   for (const chain in custom) {
     for (const addr in custom[chain]) {
+      // Prevent error when chain is not defined in built-in config
+      if (!builtin[chain]) builtin[chain] = {};
       builtin[chain][addr] = {
         ...custom[chain][addr],
         // Prevent overwriting built-in wrapped token addresses


### PR DESCRIPTION
While testing the Connect 2.0.0 beta version, we encountered a problem with configuring wrapped tokens when the chain is not in the built-in config, as in the case of the world chain.

The config that causes the error:

```
wrappedTokens: {
...
        Worldchain: {
          // Worldcoin
          ["0x2cFc85d8E48F8EAB294be644d9E25C3030863003"]: {
            Ethereum: "0x...",
            Solana: "WSgvEfWpAUg...",
            ....
          },
        },
...
}
```

Before:
<img width="1724" alt="Captura de pantalla 2025-01-28 a la(s) 4 21 24 p m" src="https://github.com/user-attachments/assets/c1583f83-319d-465d-a104-e8ac53cf3ea0" />
After:
<img width="554" alt="Captura de pantalla 2025-01-28 a la(s) 5 02 33 p m" src="https://github.com/user-attachments/assets/a049c23c-6904-4eb1-87ff-17ef5f87c092" />
