### PR TITLE
Fix TxHistory render for Eth Bridge transactions

### DIFF
--- a/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistoryWHScan.ts
@@ -271,7 +271,7 @@ const useTransactionHistoryWHScan = (
       } = payload;
 
       const nativeToken = config.tokens.get(
-        txData.fromChain,
+        chainIdToChain(tx.content.standarizedProperties.tokenChain) as Chain,
         tx.content.standarizedProperties.tokenAddress,
       );
       if (!nativeToken) return;


### PR DESCRIPTION
The fix is to use `tx.content.standarizedProperties.tokenChain` along with `tx.content.standarizedProperties.tokenAddress` to get the native token.
Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/3211


<img width="526" alt="Screenshot 2025-02-03 at 9 10 03 PM" src="https://github.com/user-attachments/assets/709062ff-7c53-4989-bb7a-b555f6519314" />
