### PR TITLE
Fix bugs in token price fetching which cause excessive API calls

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -156,9 +156,12 @@ export class TokenMapping<T> {
   // Mapping of Chain -> token address -> T
   _mapping: Map<Chain, Map<string, T>>;
 
+  size: number;
+
   constructor() {
     this.lastUpdate = new Date();
     this._mapping = new Map();
+    this.size = 0;
   }
 
   add(token: TokenId, value: T) {
@@ -168,6 +171,7 @@ export class TokenMapping<T> {
 
     this._mapping.get(token.chain)!.set(token.address.toString(), value);
     this.lastUpdate = new Date();
+    this.size += 1;
   }
 
   // You can get a token either using its string key, TokenId, or with (chain, address)
@@ -233,6 +237,14 @@ export class TokenMapping<T> {
     );
   }
 
+  getAllTokenIds(): TokenId[] {
+    return Array.from(this._mapping.keys()).flatMap((chain) =>
+      Array.from(this._mapping.get(chain)!.keys()).map((address) =>
+        Wormhole.tokenId(chain, address),
+      ),
+    );
+  }
+
   get chains(): Chain[] {
     return Array.from(this._mapping.keys());
   }
@@ -242,6 +254,13 @@ export class TokenMapping<T> {
     other.forEach(this.add);
   }
 
+  // Removes all records from the TokenMapping
+  clear() {
+    this.lastUpdate = new Date();
+    this._mapping = new Map();
+    this.size = 0;
+  }
+
   forEach(callback: (tokenId: TokenId, val: T) => void) {
     this._mapping.forEach((nextLevel, chain) => {
       nextLevel.forEach((val, addr) => {
@@ -249,6 +268,10 @@ export class TokenMapping<T> {
         callback(tokenId, val);
       });
     });
+  }
+
+  get empty(): boolean {
+    return this.size === 0;
   }
 }
 

--- a/wormhole-connect/src/contexts/TokensContext.tsx
+++ b/wormhole-connect/src/contexts/TokensContext.tsx
@@ -59,6 +59,10 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
   const [tokenPrices, _setTokenPrices] = useState<TokenMapping<TokenPrice>>(
     new TokenMapping(),
   );
+  const [tokenPricesToFetch, _setTokenPricesToFetch] = useState<
+    TokenMapping<boolean>
+  >(new TokenMapping());
+
   const [isFetchingTokenPrices, setIsFetchingPrices] = useState(false);
   const [lastTokenPriceUpdate, setLastPriceUpdate] = useState(new Date());
 
@@ -104,8 +108,6 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
     },
     [],
   );
-
-  const tokenPricesToFetch: TokenMapping<boolean> = new TokenMapping();
 
   const updateTokenPrices = useDebouncedCallback(async () => {
     if (tokenPricesToFetch.empty) return;


### PR DESCRIPTION
There is two bugs in this code I wrote during the arbitrary token refactor. These are causing us to make excessive requests to Coingecko (basically making each call twice 💀)

- `getTokenPrice` can call the `updateTokenPrices` callback multiple times for the same token because it wasn't aware of which tokens in `tokenPricesToFetch` were already being handled in an ongoing request.
- Also, using a `Set` for `tokenPricesToFetch` wasn't the right call; adding `TokenId`s to a `Set` doesn't work because they're just plain objects and jerbascript compares objects by instance and not value. I switched to a `TokenMapping` which is a better way to track a set of unique `TokenId`s.