### PR TITLE
Update the balance cache in case of an error

### DIFF
--- a/wormhole-connect/src/hooks/useGetTokenBalances.ts
+++ b/wormhole-connect/src/hooks/useGetTokenBalances.ts
@@ -113,10 +113,12 @@ const useGetTokenBalances = (
               };
             }
           }
-
-          updateCache = true;
         } catch (e) {
           console.error('Failed to get token balances', e);
+        } finally {
+          // There can be failures for some tokens,
+          // but we'll still update the cache with latest balances
+          updateCache = true;
         }
       }
       if (isActive) {


### PR DESCRIPTION
There was an issue where an error was thrown by the SDK to get the balance of a token on a chain was stoping Connect to update the balances for all others.