### PR TITLE
call setConfig outside of useEffect

### DIFF
--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -42,6 +42,8 @@ interface Props {
   config?: WormholeConnectConfig;
 }
 
+let _HAS_SET_CONFIG = false;
+
 // since this will be embedded, we'll have to use pseudo routes instead of relying on the url
 function AppRouter(props: Props) {
   const { classes } = useStyles();
@@ -53,7 +55,7 @@ function AppRouter(props: Props) {
   //
   // We don't allow config changes afterwards because they could lead to lots of
   // broken and undesired behavior.
-  React.useEffect(() => {
+  if (!_HAS_SET_CONFIG) {
     if (!isEmptyObject(props.config)) {
       setConfig(props.config);
       dispatch(clearTransfer());
@@ -63,7 +65,9 @@ function AppRouter(props: Props) {
       type: 'load',
       config: props.config,
     });
-  }, []);
+
+    _HAS_SET_CONFIG = true;
+  }
 
   const route = useSelector((state: RootState) => state.router.route);
   const prevRoute = usePrevious(route);

--- a/wormhole-connect/src/config/events.ts
+++ b/wormhole-connect/src/config/events.ts
@@ -9,12 +9,15 @@ import {
 export function wrapEventHandler(
   integrationHandler?: WormholeConnectEventHandler,
 ): TriggerEventHandler {
+  const host =
+    typeof window === 'undefined' ? undefined : window.location?.host;
+
   return function (event: WormholeConnectEventCore) {
     const eventWithMeta: WormholeConnectEvent = {
       meta: {
         version: CONNECT_VERSION,
         hash: CONNECT_GIT_HASH,
-        host: window?.location?.host,
+        host,
       },
       ...event,
     };

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -99,7 +99,7 @@ export interface WormholeConnectEventMeta {
   meta: {
     version: string;
     hash: string;
-    host: string;
+    host?: string;
   };
 }
 


### PR DESCRIPTION
This makes the integrator's provided config get set sooner, so Connect has access to it inside a SSG (server side generated code) step. `useEffect` only runs after the component mounts, which doesn't happen on the server.

Basically, this elminates this flicker:

https://github.com/user-attachments/assets/986d4fb1-fafb-4c86-8012-72618ddf711a

