### PR TITLE
Remove a hacky shortcut for Shuttle and bump its limit

### DIFF
--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -77,6 +77,15 @@ const useFetchSupportedRoutes = (): HookReturn => {
           );
         }
 
+        // HAX - Enable Mayan routes (except SHUTTLE) for all assets
+        // TODO token refactor
+        if (
+          route.rc.name.includes('Mayan') &&
+          route.rc.name !== 'MayanSwapSHUTTLE'
+        ) {
+          supported = true;
+        }
+
         if (supported) {
           _routes.push(name);
         }

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -77,12 +77,6 @@ const useFetchSupportedRoutes = (): HookReturn => {
           );
         }
 
-        // HAX
-        // TODO token refactor
-        if (route.rc.name.includes('Mayan')) {
-          supported = true;
-        }
-
         if (supported) {
           _routes.push(name);
         }

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -34,7 +34,7 @@ type HookReturn = {
 const QUOTE_REFRESH_INTERVAL = 20_000;
 const MAYAN_BETA_PROTOCOL_LIMITS = {
   MCTP: 10_000,
-  SHUTTLE: 500,
+  SHUTTLE: 2000,
 };
 
 const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {


### PR DESCRIPTION
This PR has two different changes.
- We need to remove a previous hack for Shuttle to work properly when invalid assets selected.
- We are also bumping the limit for Shuttle to $2k.