### PR TITLE
Use the correct route name

### DIFF
--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -81,7 +81,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
         // TODO token refactor
         if (
           route.rc.name.includes('Mayan') &&
-          route.rc.name !== 'MayanSwapSHUTTLE'
+          route.rc.name !== 'MayanRouteSHUTTLE'
         ) {
           supported = true;
         }


### PR DESCRIPTION
The local name was MayanSwapSHUTTLE but the one from the route object is MayanRouteSHUTTLE, so we need to use that one.