### PR TITLE
Quotes: display seconds when ETA < 2 minutes, otherwise minutes

### DIFF
--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -348,7 +348,7 @@ export const isStableCoin = (token: Token) => {
 };
 
 export const millisToHumanString = (ts: number): string => {
-  if (ts > 60000) {
+  if (ts >= 2 * 60000) {
     const minutes = Math.ceil(ts / 60000);
     return `~${minutes} min`;
   } else {


### PR DESCRIPTION
Mayan changed Shuttle ETA to 90 seconds but was being shown as 2 minutes. 2 minutes should be the rough upper limit for fast transfers going forward. NOTE: this applies to all routes, but is probably fine.