### PR TITLE
Don't run `connectLastUsedWallet` twice concurrently

### DIFF
--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -173,10 +173,28 @@ export const useConnectToLastUsedWallet = (): void => {
   );
 
   useEffect(() => {
-    if (fromChain)
-      connectLastUsedWallet(TransferWallet.SENDING, fromChain, dispatch);
-    if (toChain)
-      connectLastUsedWallet(TransferWallet.RECEIVING, toChain, dispatch);
+    let canceled = false;
+
+    const connect = async () => {
+      if (fromChain && !canceled)
+        await connectLastUsedWallet(
+          TransferWallet.SENDING,
+          fromChain,
+          dispatch,
+        );
+      if (toChain && !canceled)
+        await connectLastUsedWallet(
+          TransferWallet.RECEIVING,
+          toChain,
+          dispatch,
+        );
+    };
+
+    connect();
+
+    return () => {
+      canceled = true;
+    };
   }, [fromChain, toChain]);
 };
 


### PR DESCRIPTION
I think this is causing some race condition issues :-)