### PR TITLE
Filter out dupes in Tx History at top level

### DIFF
--- a/wormhole-connect/src/hooks/useTransactionHistory.ts
+++ b/wormhole-connect/src/hooks/useTransactionHistory.ts
@@ -178,8 +178,19 @@ const useTransactionHistory = (
     // Update the indexes to the next item in respective data sources
     updateWHScanIndex(whScanLocalIdx);
     updateMayanIndex(mayanLocalIdx);
+
+    // Check duplicates in merged transactions
+    const mergedTxsSet = new Set<string>();
+    const uniqMergedTxs = appendTxs(transactions, mergedTxs).filter((tx) => {
+      if (tx.txHash && mergedTxsSet.has(tx.txHash)) {
+        return false;
+      }
+      mergedTxsSet.add(tx.txHash);
+      return true;
+    });
+
     // Append the merged transactions and exit
-    setTransactions((txs) => appendTxs(txs, mergedTxs));
+    setTransactions((txs) => uniqMergedTxs);
     // We only need to re-run this side-effect when either of the transaction data changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [whScanTxs, mayanTxs]);


### PR DESCRIPTION
This started to happen when Wormholescan API started to support Mayan transactions and it shows a tx entry in API response for each VAA. Some Mayan txs (I believe Shuttle does) have two VAAs emitted. Even though we parse specifically for APP_IDs, which can prevent duplicates, I believe adding on more to check duplicates in merged txs will be helpful.

Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/3146