### PR TITLE
Add try/catch when checking whether a token is supported by ntt

### DIFF
--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -357,13 +357,17 @@ const isNttSupportedToken = async (
     const route: SDKv2Route | undefined = config.routes.get(routeName);
     if (!route) return false;
 
-    const destTokens = await route.rc.supportedDestinationTokens(
-      token,
-      fromContext,
-      toContext,
-    );
+    try {
+      const destTokens = await route.rc.supportedDestinationTokens(
+        token,
+        fromContext,
+        toContext,
+      );
 
-    return destTokens.length > 0;
+      return destTokens.length > 0;
+    } catch (e) {
+      return false;
+    }
   };
 
   const [isManualSupported, isAutomaticSupported, isM0Supported] =


### PR DESCRIPTION
The M0 route might throw an error when checking and thus cause the `Promise.all` to fail. Adding a try/catch will cover other routes as well.

[1] https://github.com/m0-foundation/ntt-sdk-route/blob/main/src/m0AutomaticRoute.ts#L131
[2] https://github.com/m0-foundation/ntt-sdk-route/blob/main/src/m0AutomaticRoute.ts#L107