### PR TITLE
Log with console.debug by default

### DIFF
--- a/wormhole-connect/src/config/events.ts
+++ b/wormhole-connect/src/config/events.ts
@@ -22,7 +22,7 @@ export function wrapEventHandler(
       ...event,
     };
 
-    console.info('Wormhole Connect event:', eventWithMeta);
+    console.debug('Wormhole Connect event:', eventWithMeta);
     if (integrationHandler) {
       try {
         integrationHandler(eventWithMeta);


### PR DESCRIPTION
This will make it so Connect's built-in event handler logs at the `verbose` level, so we're not spamming the console for the default settings, which exclude `verbose`:

<img width="109" alt="image" src="https://github.com/user-attachments/assets/abbca79f-ff94-4a70-b603-69757f530a1b" />
