### PR TITLE
Remove legacy logic from TokenList filter function

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -305,22 +305,6 @@ const TokenList = (props: Props) => {
       filterFn={(token, query) => {
         if (query.length === 0) return true;
 
-        const chain = props.selectedChainConfig.key;
-
-        // Exclude frankenstein tokens with no balance
-        const balance = balances?.[token.key]?.balance;
-        const hasBalance = balance && sdkAmount.units(balance) > 0n;
-
-        if (isFrankensteinToken(token, chain) && !hasBalance) {
-          return false;
-        }
-
-        // Exclude wormhole-wrapped tokens with no balance
-        // unless it's canonical
-        if (props.isSource && token.isTokenBridgeWrappedToken && !hasBalance) {
-          return false;
-        }
-
         const queryLC = query.toLowerCase();
 
         const symbolMatch = [token.symbol, token.name].some((criteria) =>


### PR DESCRIPTION
The purpose of this change is to make the TokenList show the token when the search query matches the token exactly. There was some additional filtering logic that is no longer needed. If the token has 0 balance it will be grayed out.