### PR TITLE
Silence 'No protocols registered for' error message

### DIFF
--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -20,6 +20,7 @@ import {
 import '@wormhole-foundation/sdk-definitions-ntt';
 import '@wormhole-foundation/sdk-evm-ntt';
 import '@wormhole-foundation/sdk-solana-ntt';
+import { maybeLogSdkError } from 'utils/errors';
 
 export interface TxInfo {
   route: string;
@@ -180,7 +181,7 @@ export default class RouteOperator {
           }
         }
       } catch (e) {
-        console.error(e);
+        maybeLogSdkError(e);
       }
     });
 

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -1,5 +1,6 @@
 import config from 'config';
 import { parseTokenKey, Token, tokenKey } from 'config/tokens';
+import { maybeLogSdkError } from 'utils/errors';
 
 import {
   Chain,
@@ -20,7 +21,6 @@ import {
 import '@wormhole-foundation/sdk-definitions-ntt';
 import '@wormhole-foundation/sdk-evm-ntt';
 import '@wormhole-foundation/sdk-solana-ntt';
-import { maybeLogSdkError } from 'utils/errors';
 
 export interface TxInfo {
   route: string;


### PR DESCRIPTION
This is not a "real" error. It just means the chain doesn't support the protocol. Prevent this error from being logged to the console.