### PR TITLE
Better handling of errors in `connectLastUsedWallet`

### DIFF
--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -171,10 +171,12 @@ export const connectLastUsedWallet = async (
           // Previously used wallet isn't available anymore.
           // This isn't an error to throw. We simply don't
           // auto-connect to it.
-        } else {
-          throw e;
+          console.error(
+            `Failed to autoconnect to wallet ${lastUsedWallet} for ${chain} (${chainConfig.context})`,
+          );
         }
         localStorage.removeItem(localStorageKey);
+        throw e;
       }
     }
   }

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -158,8 +158,22 @@ export const connectLastUsedWallet = async (
     const options = await getWalletOptions(chainConfig);
     const wallet = options.find((w) => w.name === lastUsedWallet);
     if (wallet) {
-      const connected = await connectWallet(type, chain, wallet, dispatch);
-      if (!connected) {
+      try {
+        const connected = await connectWallet(type, chain, wallet, dispatch);
+        if (!connected) {
+          localStorage.removeItem(localStorageKey);
+        }
+      } catch (e: any) {
+        if (
+          e.message.includes('ConnectorNotFound') ||
+          e.message.toLowerCase().includes('connector not found')
+        ) {
+          // Previously used wallet isn't available anymore.
+          // This isn't an error to throw. We simply don't
+          // auto-connect to it.
+        } else {
+          throw e;
+        }
         localStorage.removeItem(localStorageKey);
       }
     }

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -164,19 +164,10 @@ export const connectLastUsedWallet = async (
           localStorage.removeItem(localStorageKey);
         }
       } catch (e: any) {
-        if (
-          e.message.includes('ConnectorNotFound') ||
-          e.message.toLowerCase().includes('connector not found')
-        ) {
-          // Previously used wallet isn't available anymore.
-          // This isn't an error to throw. We simply don't
-          // auto-connect to it.
-          console.error(
-            `Failed to autoconnect to wallet ${lastUsedWallet} for ${chain} (${chainConfig.context})`,
-          );
-        }
         localStorage.removeItem(localStorageKey);
-        throw e;
+        throw new Error(
+          `Failed to autoconnect to wallet ${lastUsedWallet} for ${chain} (${chainConfig.context}): ${e.message}`,
+        );
       }
     }
   }


### PR DESCRIPTION
Connect spams an error `ConnectorNotFound` in `connectLastUsedWallet` which is an Ethereum wallet error that indicates the last used wallet is no longer available on `window.ethereum`. We should catch the error here and remove the last used wallet localStorage property, so we stop trying to automatically connect to the wallet in the future. I did continue to throw the error however, so we can see how often `connectLastUsedWallet` fails the first time. I am also now logging which wallet the user was using, and for which chain.