### PR TITLE
Show routes when no wallets are connected

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/index.tsx
@@ -30,7 +30,6 @@ type Props = {
   onRouteChange: (route: string) => void;
   quotes: Record<string, routes.QuoteResult<routes.Options> | undefined>;
   isLoading: boolean;
-  hasError: boolean;
 };
 
 const Routes = ({ ...props }: Props) => {
@@ -88,10 +87,6 @@ const Routes = ({ ...props }: Props) => {
       { name: '', amountOut: 0n },
     );
   }, [routes, props.quotes]);
-
-  if (props.hasError) {
-    return null;
-  }
 
   return (
     <>

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -210,14 +210,6 @@ const Bridge = () => {
     sourceTokenArray,
   );
 
-  const disableValidation =
-    !sendingWallet.address ||
-    !receivingWallet.address ||
-    !sourceChain ||
-    !sourceToken ||
-    !destChain ||
-    !destToken;
-
   // Validate amount
   const amountValidation = useAmountValidation({
     balance: sourceToken ? balances[sourceToken.key]?.balance : null,
@@ -225,7 +217,7 @@ const Bridge = () => {
     quotesMap,
     tokenSymbol: sourceToken?.symbol ?? '',
     isLoading: isFetchingBalances || isFetchingQuotes,
-    disabled: disableValidation,
+    disabled: !sendingWallet.address || !sourceChain || !sourceToken,
   });
 
   //useFetchTokenPrices(sourceToken ? [sourceToken.tokenId] : []);
@@ -490,9 +482,6 @@ const Bridge = () => {
 
   const hasConnectedWallets = sendingWallet.address && receivingWallet.address;
 
-  const showRoutes =
-    hasConnectedWallets && isWalletCompatible && hasEnteredAmount && !hasError;
-
   const confirmTransactionDisabled =
     !sourceChain ||
     !sourceToken ||
@@ -590,7 +579,7 @@ const Bridge = () => {
         error={amountValidation.error}
         warning={amountValidation.warning || walletWarning}
       />
-      {showRoutes && (
+      {hasEnteredAmount && (
         <Routes
           routes={sortedRoutes}
           selectedRoute={route}
@@ -599,7 +588,6 @@ const Bridge = () => {
           }}
           quotes={quotesMap}
           isLoading={isFetchingQuotes || isFetchingBalances}
-          hasError={hasError}
         />
       )}
       {transactionError}


### PR DESCRIPTION
This PR will remove the wallet connection checks to show fetched routes and quotes, so users can see quotes without connecting any wallets.

https://www.loom.com/share/0391f4654b7d4389a83ec6d90ef1fe24?sid=69532f1e-f456-4ec1-ab50-8c4cc4d0e466