### PR TITLE
Use commit hash to reference version of action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@de90cc6
         id: filter
         with:
           filters: |


### PR DESCRIPTION
Locks this action to its [3.0.2 release](https://github.com/dorny/paths-filter/releases/tag/v3.0.2). Issa more secure