### PR TITLE
Check Solana wallet type when getting ATA

### DIFF
--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -635,6 +635,7 @@ const Redeem = () => {
       isResumeTx &&
       toChain === 'Solana' &&
       receivingWallet.address &&
+      receivingWallet.type === Context.SOLANA &&
       receivingWallet.address !== recipient &&
       routeName &&
       // These routes set the recipient address to the associated token address


### PR DESCRIPTION
There is a racing condition, happens when the connected destination wallet doesn't automatically switch from EVM to Solana after user clicks to a widget with Solana destination. When that happens the code tries to get a ATA (associated token address) from Solana with an EVM address and it throws. The fix is to check the wallet type before calling for ATA.

Fixes https://github.com/wormholelabs-xyz/portal-nextjs/issues/41