### PR TITLE
Theme prop to override transparent bg for asset pickers and amount input

### DIFF
--- a/wormhole-connect/src/components/SampleApp/index.tsx
+++ b/wormhole-connect/src/components/SampleApp/index.tsx
@@ -370,6 +370,10 @@ function SampleApp() {
                       <i>string;</i>
                     </li>
                     <li>
+                      <pre>inputFill</pre>
+                      <i>string;</i>
+                    </li>
+                    <li>
                       <pre>primary</pre>
                       <i>string;</i>
                     </li>

--- a/wormhole-connect/src/components/SampleApp/index.tsx
+++ b/wormhole-connect/src/components/SampleApp/index.tsx
@@ -370,8 +370,8 @@ function SampleApp() {
                       <i>string;</i>
                     </li>
                     <li>
-                      <pre>inputFill</pre>
-                      <i>string;</i>
+                      <pre>inputFillTreatment</pre>
+                      <i>boolean;</i>
                     </li>
                     <li>
                       <pre>primary</pre>

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -9,8 +9,10 @@ export type WormholeConnectTheme = {
   mode: PaletteMode;
   // Background of surrounding application
   background?: PaletteMode;
-  // Color of input fields, like asset picker and dropdowns
+  // Color of input fields, like asset picker and amount input
   input?: string;
+  // Color of input fields when filled
+  inputFilled?: string;
   // Primary brand color
   primary?: string;
   // Secondary brand color
@@ -71,6 +73,7 @@ export type InternalTheme = {
   input: {
     background: string;
     border: string;
+    filled: string;
   };
   font: string;
   logo: string;
@@ -120,6 +123,7 @@ export const light: InternalTheme = {
   input: {
     background: '#f9f9f9',
     border: '#DEE0E3',
+    filled: 'transparent',
   },
   font: '"Inter", sans-serif',
   logo: '#000000',
@@ -176,6 +180,7 @@ export const dark: InternalTheme = {
   input: {
     background: '#1a1928',
     border: '#1e1f35',
+    filled: 'transparent',
   },
   font: '"Inter", sans-serif',
   logo: '#ffffff',
@@ -188,10 +193,22 @@ export const generateTheme = (customTheme: WormholeConnectTheme): Theme => {
 
   // Override built-in theme with whichever custom values we've been provided
   if (customTheme) {
+    if (customTheme.background) {
+      theme.background = {
+        default: customTheme.background,
+      };
+    }
     if (customTheme.input) {
       theme.input = {
         background: customTheme.input,
         border: customTheme.secondary || theme.secondary.main,
+        filled: theme.input.filled,
+      };
+    }
+    if (customTheme.inputFilled) {
+      theme.input = {
+        ...theme.input,
+        filled: customTheme.inputFilled,
       };
     }
     if (customTheme.primary) {

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -12,7 +12,7 @@ export type WormholeConnectTheme = {
   // Color of input fields, like asset picker and amount input
   input?: string;
   // Color of input fields when filled
-  inputFilled?: string;
+  inputFill?: string;
   // Primary brand color
   primary?: string;
   // Secondary brand color
@@ -73,7 +73,7 @@ export type InternalTheme = {
   input: {
     background: string;
     border: string;
-    filled: string;
+    fill: string;
   };
   font: string;
   logo: string;
@@ -123,7 +123,7 @@ export const light: InternalTheme = {
   input: {
     background: '#f9f9f9',
     border: '#DEE0E3',
-    filled: 'transparent',
+    fill: 'transparent',
   },
   font: '"Inter", sans-serif',
   logo: '#000000',
@@ -180,7 +180,7 @@ export const dark: InternalTheme = {
   input: {
     background: '#1a1928',
     border: '#1e1f35',
-    filled: 'transparent',
+    fill: 'transparent',
   },
   font: '"Inter", sans-serif',
   logo: '#ffffff',
@@ -202,13 +202,13 @@ export const generateTheme = (customTheme: WormholeConnectTheme): Theme => {
       theme.input = {
         background: customTheme.input,
         border: customTheme.secondary || theme.secondary.main,
-        filled: theme.input.filled,
+        fill: theme.input.fill,
       };
     }
-    if (customTheme.inputFilled) {
+    if (customTheme.inputFill) {
       theme.input = {
         ...theme.input,
-        filled: customTheme.inputFilled,
+        fill: customTheme.inputFill,
       };
     }
     if (customTheme.primary) {

--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -11,8 +11,8 @@ export type WormholeConnectTheme = {
   background?: PaletteMode;
   // Color of input fields, like asset picker and amount input
   input?: string;
-  // Color of input fields when filled
-  inputFill?: string;
+  // Whether input fields will be transparent
+  inputFillTreatment?: boolean;
   // Primary brand color
   primary?: string;
   // Secondary brand color
@@ -73,7 +73,7 @@ export type InternalTheme = {
   input: {
     background: string;
     border: string;
-    fill: string;
+    fillTreatment: boolean;
   };
   font: string;
   logo: string;
@@ -123,7 +123,7 @@ export const light: InternalTheme = {
   input: {
     background: '#f9f9f9',
     border: '#DEE0E3',
-    fill: 'transparent',
+    fillTreatment: true,
   },
   font: '"Inter", sans-serif',
   logo: '#000000',
@@ -180,7 +180,7 @@ export const dark: InternalTheme = {
   input: {
     background: '#1a1928',
     border: '#1e1f35',
-    fill: 'transparent',
+    fillTreatment: true,
   },
   font: '"Inter", sans-serif',
   logo: '#ffffff',
@@ -200,16 +200,13 @@ export const generateTheme = (customTheme: WormholeConnectTheme): Theme => {
     }
     if (customTheme.input) {
       theme.input = {
+        ...theme.input,
         background: customTheme.input,
         border: customTheme.secondary || theme.secondary.main,
-        fill: theme.input.fill,
       };
     }
-    if (customTheme.inputFill) {
-      theme.input = {
-        ...theme.input,
-        fill: customTheme.inputFill,
-      };
+    if (customTheme.inputFillTreatment !== undefined) {
+      theme.input.fillTreatment = customTheme.inputFillTreatment;
     }
     if (customTheme.primary) {
       theme.primary = {

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -98,13 +98,9 @@ const useStyles = makeStyles()((theme: any) => ({
     maxWidth: '420px',
   },
   amountInput: {
-    borderRadius: '8px',
-    background: 'transparent',
-    border: `1px solid ${theme.palette.input.border}`,
-  },
-  amountInputEmpty: {
     background: theme.palette.input.background,
-    borderColor: theme.palette.input.background,
+    border: `1px solid ${theme.palette.input.background}`,
+    borderRadius: '8px',
   },
   amountCardContent: {
     display: 'flex',
@@ -223,12 +219,9 @@ const AmountInput = (props: Props) => {
     props.tokenBalance,
   ]);
 
-  const handleChange = useCallback(
-    (newValue: string): void => {
-      setAmountInput(newValue);
-    },
-    [dispatch],
-  );
+  const handleChange = useCallback((newValue: string): void => {
+    setAmountInput(newValue);
+  }, []);
 
   const tokenPriceAdornment = useMemo(() => {
     const price = calculateUSDPrice(
@@ -309,11 +302,7 @@ const AmountInput = (props: Props) => {
       <div className={classes.amountTitle}>
         <Typography variant="body2">Amount</Typography>
       </div>
-      <Card
-        className={`${classes.amountInput} ${
-          amountInput === '' ? classes.amountInputEmpty : ''
-        }`}
-      >
+      <Card className={classes.amountInput}>
         <CardContent className={classes.amountCardContent}>
           <DebouncedTextField
             fullWidth

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -99,7 +99,7 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   amountInput: {
     borderRadius: '8px',
-    background: theme.palette.input.filled,
+    background: theme.palette.input.fill,
     border: `1px solid ${theme.palette.input.border}`,
   },
   amountInputEmpty: {

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -99,8 +99,12 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   amountInput: {
     borderRadius: '8px',
-    background: theme.palette.input.fill,
-    border: `1px solid ${theme.palette.input.border}`,
+    background: theme.palette.input.fillTreatment
+      ? 'transparent'
+      : theme.palette.input.background,
+    border: theme.palette.input.fillTreatment
+      ? `1px solid ${theme.palette.input.border}`
+      : 'none',
   },
   amountInputEmpty: {
     background: theme.palette.input.background,

--- a/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AmountInput/index.tsx
@@ -98,9 +98,13 @@ const useStyles = makeStyles()((theme: any) => ({
     maxWidth: '420px',
   },
   amountInput: {
-    background: theme.palette.input.background,
-    border: `1px solid ${theme.palette.input.background}`,
     borderRadius: '8px',
+    background: theme.palette.input.filled,
+    border: `1px solid ${theme.palette.input.border}`,
+  },
+  amountInputEmpty: {
+    background: theme.palette.input.background,
+    borderColor: theme.palette.input.background,
   },
   amountCardContent: {
     display: 'flex',
@@ -302,7 +306,11 @@ const AmountInput = (props: Props) => {
       <div className={classes.amountTitle}>
         <Typography variant="body2">Amount</Typography>
       </div>
-      <Card className={classes.amountInput}>
+      <Card
+        className={`${classes.amountInput} ${
+          amountInput === '' ? classes.amountInputEmpty : ''
+        }`}
+      >
         <CardContent className={classes.amountCardContent}>
           <DebouncedTextField
             fullWidth

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -31,9 +31,13 @@ const useStyles = makeStyles()((theme: any) => ({
     width: '100%',
     cursor: 'pointer',
     maxWidth: '420px',
-    background: theme.palette.input.background,
-    border: `1px solid ${theme.palette.input.background}`,
     borderRadius: '8px',
+    background: theme.palette.input.filled,
+    border: `1px solid ${theme.palette.input.border}`,
+  },
+  inputAreaEmpty: {
+    borderColor: theme.palette.input.background,
+    background: theme.palette.input.background,
   },
   cardContent: {
     display: 'flex',
@@ -185,6 +189,7 @@ const AssetPicker = (props: Props) => {
       <Card
         className={joinClass([
           classes.inputArea,
+          !chainConfig && classes.inputAreaEmpty,
           props.isTransactionInProgress && classes.disabled,
         ])}
         data-testid={props.dataTestId}

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -32,8 +32,12 @@ const useStyles = makeStyles()((theme: any) => ({
     cursor: 'pointer',
     maxWidth: '420px',
     borderRadius: '8px',
-    background: theme.palette.input.fill,
-    border: `1px solid ${theme.palette.input.border}`,
+    background: theme.palette.input.fillTreatment
+      ? 'transparent'
+      : theme.palette.input.background,
+    border: theme.palette.input.fillTreatment
+      ? `1px solid ${theme.palette.input.border}`
+      : 'none',
   },
   inputAreaEmpty: {
     borderColor: theme.palette.input.background,

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles()((theme: any) => ({
     cursor: 'pointer',
     maxWidth: '420px',
     borderRadius: '8px',
-    background: theme.palette.input.filled,
+    background: theme.palette.input.fill,
     border: `1px solid ${theme.palette.input.border}`,
   },
   inputAreaEmpty: {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -31,13 +31,9 @@ const useStyles = makeStyles()((theme: any) => ({
     width: '100%',
     cursor: 'pointer',
     maxWidth: '420px',
-    borderRadius: '8px',
-    background: 'transparent',
-    border: `1px solid ${theme.palette.input.border}`,
-  },
-  inputAreaEmpty: {
-    borderColor: theme.palette.input.background,
     background: theme.palette.input.background,
+    border: `1px solid ${theme.palette.input.background}`,
+    borderRadius: '8px',
   },
   cardContent: {
     display: 'flex',
@@ -189,7 +185,6 @@ const AssetPicker = (props: Props) => {
       <Card
         className={joinClass([
           classes.inputArea,
-          !chainConfig && classes.inputAreaEmpty,
           props.isTransactionInProgress && classes.disabled,
         ])}
         data-testid={props.dataTestId}


### PR DESCRIPTION
Transparent BG was added before to indicate selection of assets or entering the amount value. However it's causing visual issues with noisy BGs. The proposed solution is to add a new theme prop to override the default transparent value when necessary.

**Before:**
<img width="494" alt="Screenshot 2025-04-07 at 8 29 54 PM" src="https://github.com/user-attachments/assets/03a372a6-91a0-461b-b140-15fa2026bdb7" />

**After:**
<img width="485" alt="Screenshot 2025-04-07 at 8 29 46 PM" src="https://github.com/user-attachments/assets/e28a454b-045d-4fa5-a6d8-e85ee0ae20bd" />
