### PR TITLE
Remove Content-Type from CoinGecko GET requests

### DIFF
--- a/wormhole-connect/src/utils/coingecko.ts
+++ b/wormhole-connect/src/utils/coingecko.ts
@@ -45,7 +45,6 @@ const coingeckoRequest = async (
   params?: CoingeckoParams,
 ): Promise<any> => {
   const headers = new Headers({
-    'Content-Type': 'application/json',
     ...(config.coingecko?.apiKey
       ? { 'x-cg-pro-api-key': config.coingecko.apiKey }
       : {}),


### PR DESCRIPTION
None of the requests contain a payload