### PR TITLE
Remove final remnants of MultiProvider (not needed anymore)

### DIFF
--- a/wormhole-connect/src/hooks/useConfirmTransaction.ts
+++ b/wormhole-connect/src/hooks/useConfirmTransaction.ts
@@ -20,11 +20,7 @@ import { toDecimals } from 'utils/balance';
 import { interpretTransferError } from 'utils/errors';
 import { addTxToLocalStorage } from 'utils/inProgressTxCache';
 import { validate, isTransferValid } from 'utils/transferValidation';
-import {
-  registerWalletSigner,
-  switchChain,
-  TransferWallet,
-} from 'utils/wallet';
+import { switchChain, TransferWallet } from 'utils/wallet';
 
 import type { RootState } from 'store';
 import type { RelayerFee } from 'store/relay';
@@ -158,7 +154,6 @@ const useConfirmTransaction = (props: Props): ReturnProps => {
         }
 
         await switchChain(chainId, TransferWallet.SENDING);
-        await registerWalletSigner(sourceChain, TransferWallet.SENDING);
       }
 
       config.triggerEvent({

--- a/wormhole-connect/src/hooks/useConfirmTransaction.ts
+++ b/wormhole-connect/src/hooks/useConfirmTransaction.ts
@@ -1,6 +1,5 @@
 import { useContext, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Context } from 'sdklegacy';
 
 import config from 'config';
 import { RouteContext } from 'contexts/RouteContext';
@@ -20,7 +19,6 @@ import { toDecimals } from 'utils/balance';
 import { interpretTransferError } from 'utils/errors';
 import { addTxToLocalStorage } from 'utils/inProgressTxCache';
 import { validate, isTransferValid } from 'utils/transferValidation';
-import { switchChain, TransferWallet } from 'utils/wallet';
 
 import type { RootState } from 'store';
 import type { RelayerFee } from 'store/relay';
@@ -141,21 +139,6 @@ const useConfirmTransaction = (props: Props): ReturnProps => {
     dispatch(setIsTransactionInProgress(true));
 
     try {
-      const fromConfig = config.chains[sourceChain];
-
-      if (
-        fromConfig?.context === Context.ETH &&
-        !config.ui.testOptions?.enableHeadlessSigner
-      ) {
-        const chainId = fromConfig.chainId;
-
-        if (typeof chainId !== 'number') {
-          throw new Error('Invalid EVM chain ID');
-        }
-
-        await switchChain(chainId, TransferWallet.SENDING);
-      }
-
       config.triggerEvent({
         type: 'transfer.initiate',
         details: transferDetails,

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -1,4 +1,4 @@
-import { Wallet } from '@xlabs-libs/wallet-aggregator-core';
+import { Wallet, NotSupported } from '@xlabs-libs/wallet-aggregator-core';
 import {
   BinanceWallet,
   EVMWallet,
@@ -107,7 +107,11 @@ export async function signAndSendTransaction(
     try {
       await (w as EVMWallet).switchChain(Number(expectedChainId));
     } catch (e) {
-      throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
+      if (e instanceof NotSupported) {
+        console.warn(`Selected EVM wallet cannot switch chains`);
+      } else {
+        throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
+      }
     }
   } else {
     console.warn(`EVM transaction has no chainId`, request.transaction);

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -90,31 +90,21 @@ export interface AssetInfo {
   chainId?: number;
 }
 
-export async function switchChain(w: Wallet, chainId: number | string) {
-  await (w as EVMWallet).switchChain(chainId as number);
-}
-
 export async function signAndSendTransaction(
   request: EvmUnsignedTransaction<Network, EvmChains>,
   w: Wallet,
   chainName: string,
-  options: any, // TODO ?!?!!?!?
 ): Promise<string> {
-  // TODO remove reliance on SDkv1 here (multi-provider)
   const signer = (w as any).getSigner();
   if (!signer) throw new Error('No signer found for chain' + chainName);
 
   // Ensure the signer is connected to the correct chain
-  const provider = await signer.provider?.getNetwork();
   const expectedChainId = request.transaction.chainId
     ? ethers.getBigInt(request.transaction.chainId)
     : undefined;
-  const actualChainId = provider?.chainId;
 
-  if (!actualChainId || !expectedChainId || actualChainId !== expectedChainId) {
-    throw new Error(
-      `Signer is not connected to the right chain. Expected ${expectedChainId}, got ${actualChainId}`,
-    );
+  if (expectedChainId) {
+    await (w as EVMWallet).switchChain(Number(expectedChainId));
   }
 
   const tx = await signer.sendTransaction(request.transaction);

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -101,7 +101,7 @@ export async function signAndSendTransaction(
   options: any, // TODO ?!?!!?!?
 ): Promise<string> {
   // TODO remove reliance on SDkv1 here (multi-provider)
-  const signer = evmSignerCache.getSigner(chainName);
+  const signer = (w as any).getSigner();
   if (!signer) throw new Error('No signer found for chain' + chainName);
 
   // Ensure the signer is connected to the correct chain
@@ -124,66 +124,3 @@ export async function signAndSendTransaction(
   /* @ts-ignore */
   return result.hash;
 }
-
-export class EvmSignerCache {
-  protected signers: Map<string, ethers.Signer>;
-
-  constructor() {
-    this.signers = new Map();
-  }
-
-  registerSigner(name: string, signer: ethers.Signer): void {
-    if (!signer.provider) {
-      throw new Error('Signer does not permit reconnect and has no provider');
-    }
-    this.signers.set(name, signer);
-  }
-
-  unregisterSigner(name: string): void {
-    if (!this.signers.has(name)) {
-      return;
-    }
-    this.signers.delete(name);
-  }
-
-  clearSigners(): void {
-    this.signers.clear();
-  }
-
-  registerWalletSigner(name: string, privkey: string): void {
-    const wallet = new ethers.Wallet(privkey);
-    this.registerSigner(name, wallet);
-  }
-
-  getSigner(name: string): ethers.Signer | undefined {
-    return this.signers.get(name);
-  }
-
-  mustGetSigner(name: string): ethers.Signer {
-    const signer = this.getSigner(name);
-    if (!signer) {
-      throw new Error(`No signer registered for chain: ${name}`);
-    }
-    return signer;
-  }
-
-  getConnection(name: string): ethers.Signer | undefined {
-    return this.getSigner(name);
-  }
-
-  mustGetConnection(name: string): ethers.Signer {
-    const connection = this.getConnection(name);
-    if (!connection) {
-      throw new Error(`No signer registered for chain: ${name}`);
-    }
-    return connection;
-  }
-
-  async getAddress(name: string): Promise<string | undefined> {
-    const signer = this.getSigner(name);
-    return await signer?.getAddress();
-  }
-}
-
-// Singleton
-export const evmSignerCache = new EvmSignerCache();

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -104,7 +104,13 @@ export async function signAndSendTransaction(
     : undefined;
 
   if (expectedChainId) {
-    await (w as EVMWallet).switchChain(Number(expectedChainId));
+    try {
+      await (w as EVMWallet).switchChain(Number(expectedChainId));
+    } catch (e) {
+      throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
+    }
+  } else {
+    console.warn(`EVM transaction has no chainId`, request.transaction);
   }
 
   const tx = await signer.sendTransaction(request.transaction);

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -95,7 +95,7 @@ export async function signAndSendTransaction(
   w: Wallet,
   chainName: string,
 ): Promise<string> {
-  const signer = (w as any).getSigner();
+  const signer = await (w as any).getSigner();
   if (!signer) throw new Error('No signer found for chain' + chainName);
 
   // Ensure the signer is connected to the correct chain

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -34,7 +34,6 @@ import {
 } from '@wormhole-foundation/sdk-aptos';
 import { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
 import { ReadOnlyWallet } from './ReadOnlyWallet';
-import { evmSignerCache } from 'utils/wallet/evm';
 
 export enum TransferWallet {
   SENDING = 'sending',
@@ -214,16 +213,6 @@ export const swapWalletConnections = () => {
   const temp = walletConnection.sending;
   walletConnection.sending = walletConnection.receiving;
   walletConnection.receiving = temp;
-};
-
-export const registerWalletSigner = async (
-  chain: Chain,
-  type: TransferWallet,
-) => {
-  const w = walletConnection[type]! as any;
-  if (!w) throw new Error('must connect wallet');
-  const signer = await w.getSigner();
-  evmSignerCache.registerSigner(chain, signer);
 };
 
 export const switchChain = async (

--- a/wormhole-connect/src/utils/wallet/index.ts
+++ b/wormhole-connect/src/utils/wallet/index.ts
@@ -1,9 +1,5 @@
 import { Context, ChainConfig } from 'sdklegacy';
-import {
-  NotSupported,
-  Wallet,
-  WalletState,
-} from '@xlabs-libs/wallet-aggregator-core';
+import { Wallet, WalletState } from '@xlabs-libs/wallet-aggregator-core';
 import {
   connectWallet as connectSourceWallet,
   clearWallet,
@@ -11,7 +7,6 @@ import {
 } from 'store/wallet';
 
 import config from 'config';
-import { getChainByChainId } from 'utils';
 
 import { RootState } from 'store';
 import { Dispatch } from 'redux';
@@ -215,29 +210,6 @@ export const swapWalletConnections = () => {
   walletConnection.receiving = temp;
 };
 
-export const switchChain = async (
-  chainId: number | string,
-  type: TransferWallet,
-): Promise<string | undefined> => {
-  const w: Wallet = walletConnection[type]! as any;
-  if (!w) throw new Error('must connect wallet');
-
-  const config = getChainByChainId(chainId)!;
-  const currentChain = w.getNetworkInfo().chainId;
-  if (currentChain === chainId) return;
-  if (config.context === Context.ETH) {
-    try {
-      // some wallets may not support chain switching
-      const evm = await import('utils/wallet/evm');
-      await evm.switchChain(w, chainId as number);
-    } catch (e) {
-      if (e instanceof NotSupported) return;
-      throw e;
-    }
-  }
-  return w.getAddress();
-};
-
 export const disconnect = async (type: TransferWallet) => {
   const w = walletConnection[type]! as any;
   if (!w) return;
@@ -263,7 +235,6 @@ export const signAndSendTransaction = async (
       request as EvmUnsignedTransaction<Network, EvmChains>,
       wallet,
       chain,
-      options,
     );
     return tx;
   } else if (chainConfig.context === Context.SOLANA) {

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -48,11 +48,7 @@ import {
   millisToMinutesAndSeconds,
   minutesAndSecondsWithPadding,
 } from 'utils/transferValidation';
-import {
-  TransferWallet,
-  registerWalletSigner,
-  switchChain,
-} from 'utils/wallet';
+import { TransferWallet, switchChain } from 'utils/wallet';
 import TransactionDetails from 'views/v2/Redeem/TransactionDetails';
 import WalletSidebar from 'views/v2/Bridge/WalletConnector/Sidebar';
 import { useConnectToLastUsedWallet } from 'utils/wallet';
@@ -727,7 +723,6 @@ const Redeem = () => {
         typeof chainConfig.chainId === 'number'
       ) {
         await switchChain(chainConfig.chainId, TransferWallet.RECEIVING);
-        await registerWalletSigner(toChain, TransferWallet.RECEIVING);
       }
 
       if (!routes.isManual(route) && !routes.isFinalizable(route)) {

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -48,7 +48,7 @@ import {
   millisToMinutesAndSeconds,
   minutesAndSecondsWithPadding,
 } from 'utils/transferValidation';
-import { TransferWallet, switchChain } from 'utils/wallet';
+import { TransferWallet } from 'utils/wallet';
 import TransactionDetails from 'views/v2/Redeem/TransactionDetails';
 import WalletSidebar from 'views/v2/Bridge/WalletConnector/Sidebar';
 import { useConnectToLastUsedWallet } from 'utils/wallet';
@@ -718,13 +718,6 @@ const Redeem = () => {
     const route = routeContext.route!;
 
     try {
-      if (
-        chainConfig!.context === Context.ETH &&
-        typeof chainConfig.chainId === 'number'
-      ) {
-        await switchChain(chainConfig.chainId, TransferWallet.RECEIVING);
-      }
-
       if (!routes.isManual(route) && !routes.isFinalizable(route)) {
         throw new Error('Route is not manual or finalizable');
       }


### PR DESCRIPTION
All we need to do is call `w.getSigner()` inside of `signAndSendTransaction` directly. This signer cache thing has no purpose anymore - it was an unnecessary middleman which I've cut out in this PR.