### PR TITLE
Don't try to switch chains if it's already correct

### DIFF
--- a/wormhole-connect/src/AppRouter.tsx
+++ b/wormhole-connect/src/AppRouter.tsx
@@ -48,10 +48,10 @@ function AppRouter(props: Props) {
   const dispatch = useDispatch();
   const routeContext = useContext(RouteContext);
   const route = useSelector((state: RootState) => state.router.route);
-  
+
   const hasSetSsgConfig = useRef(false);
   const isInitialLoad = useRef(true);
-  
+
   // We update the global config once when WormholeConnect is first mounted, if a custom
   // config was provided.
   //
@@ -72,7 +72,7 @@ function AppRouter(props: Props) {
   if (!hasSetSsgConfig.current) {
     // This runs once in SSG step (server-side pre-rendering)
     if (props.config) {
-        loadConfig(props.config);
+      loadConfig(props.config);
     }
     if (route !== 'bridge') {
       // The route may not be bridge on initial load if the component was re-rendered after client side navigation

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -94,7 +94,9 @@ export async function signAndSendTransaction(
   w: Wallet,
   chainName: string,
 ): Promise<string> {
-  const signer = await (w as any).getSigner();
+  const evmWallet = w as EVMWallet;
+
+  const signer = await evmWallet.getSigner();
   if (!signer) throw new Error('No signer found for chain' + chainName);
 
   const expectedChainId = request.transaction.chainId
@@ -105,7 +107,7 @@ export async function signAndSendTransaction(
     throw new Error(`EVM transaction has no chainId`);
   }
 
-  const signerChainId = (await (w as any).provider?.getNetwork())?.chainId;
+  const signerChainId = (await signer.provider?.getNetwork())?.chainId;
 
   if (signerChainId === undefined) {
     throw new Error(`Signer has no chainId`);
@@ -114,13 +116,13 @@ export async function signAndSendTransaction(
   // Ensure the signer is connected to the correct chain
   if (signerChainId !== expectedChainId) {
     try {
-      await (w as EVMWallet).switchChain(Number(expectedChainId));
+      await evmWallet.switchChain(Number(expectedChainId));
 
       let signerChainIdAfterSwitch: bigint | undefined = undefined;
 
       // Wait up to five seconds until wallet's chainId matches the expected chainId
       for (let i = 0; i < 50; i++) {
-        signerChainIdAfterSwitch = (await (w as any).provider?.getNetwork())
+        signerChainIdAfterSwitch = (await signer.provider?.getNetwork())
           ?.chainId;
         if (signerChainIdAfterSwitch === expectedChainId) {
           break;
@@ -146,6 +148,8 @@ export async function signAndSendTransaction(
 
   const tx = await signer.sendTransaction(request.transaction);
   const result = await tx.wait();
+
+  if (result === null) throw new Error('Failed to wait for transaction');
 
   return result.hash;
 }

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -17,6 +17,7 @@ import { Network } from '@wormhole-foundation/sdk';
 
 import config from 'config';
 import * as ethers from 'ethers';
+import { sleep } from 'utils';
 
 type ChainRpcUrls = (typeof DEFAULT_CHAINS)[0]['rpcUrls']['default'];
 
@@ -111,6 +112,24 @@ export async function signAndSendTransaction(
     if (signerChainId !== expectedChainId) {
       try {
         await (w as EVMWallet).switchChain(Number(expectedChainId));
+
+        let signerChainIdAfterSwitch: bigint | undefined = undefined;
+
+        // Wait up to five seconds until wallet's chainId matches the expected chainId
+        for (let i = 0; i < 50; i++) {
+          signerChainIdAfterSwitch = (await (w as any).provider?.getNetwork())
+            ?.chainId;
+          if (signerChainIdAfterSwitch === expectedChainId) {
+            break;
+          }
+          await sleep(100);
+        }
+
+        if (signerChainIdAfterSwitch !== expectedChainId) {
+          throw new Error(
+            `Failed to switch signer to the correct EVM chain - they still don't match`,
+          );
+        }
       } catch (e) {
         if (e instanceof NotSupported) {
           throw new Error(

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -102,48 +102,46 @@ export async function signAndSendTransaction(
     : undefined;
 
   if (expectedChainId === undefined) {
-    console.warn(`EVM transaction has no chainId`, request.transaction);
+    throw new Error(`EVM transaction has no chainId`);
   }
 
   const signerChainId = (await (w as any).provider?.getNetwork())?.chainId;
 
-  if (signerChainId !== undefined) {
-    // Ensure the signer is connected to the correct chain
-    if (signerChainId !== expectedChainId) {
-      try {
-        await (w as EVMWallet).switchChain(Number(expectedChainId));
+  if (signerChainId === undefined) {
+    throw new Error(`Signer has no chainId`);
+  }
 
-        let signerChainIdAfterSwitch: bigint | undefined = undefined;
+  // Ensure the signer is connected to the correct chain
+  if (signerChainId !== expectedChainId) {
+    try {
+      await (w as EVMWallet).switchChain(Number(expectedChainId));
 
-        // Wait up to five seconds until wallet's chainId matches the expected chainId
-        for (let i = 0; i < 50; i++) {
-          signerChainIdAfterSwitch = (await (w as any).provider?.getNetwork())
-            ?.chainId;
-          if (signerChainIdAfterSwitch === expectedChainId) {
-            break;
-          }
-          await sleep(100);
-        }
+      let signerChainIdAfterSwitch: bigint | undefined = undefined;
 
-        if (signerChainIdAfterSwitch !== expectedChainId) {
-          throw new Error(
-            `Failed to switch signer to the correct EVM chain - they still don't match`,
-          );
+      // Wait up to five seconds until wallet's chainId matches the expected chainId
+      for (let i = 0; i < 50; i++) {
+        signerChainIdAfterSwitch = (await (w as any).provider?.getNetwork())
+          ?.chainId;
+        if (signerChainIdAfterSwitch === expectedChainId) {
+          break;
         }
-      } catch (e) {
-        if (e instanceof NotSupported) {
-          throw new Error(
-            `Selected EVM wallet does not support switching chains but has the wrong chain selected`,
-          );
-        } else {
-          throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
-        }
+        await sleep(100);
+      }
+
+      if (signerChainIdAfterSwitch !== expectedChainId) {
+        throw new Error(
+          `Failed to switch signer to the correct EVM chain - they still don't match`,
+        );
+      }
+    } catch (e) {
+      if (e instanceof NotSupported) {
+        throw new Error(
+          `Selected EVM wallet does not support switching chains but has the wrong chain selected`,
+        );
+      } else {
+        throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
       }
     }
-  } else {
-    console.warn(
-      `EVM signer has no chainId; cannot verify that it matches transaction`,
-    );
   }
 
   const tx = await signer.sendTransaction(request.transaction);

--- a/wormhole-connect/src/utils/wallet/evm.ts
+++ b/wormhole-connect/src/utils/wallet/evm.ts
@@ -96,29 +96,39 @@ export async function signAndSendTransaction(
   const signer = await (w as any).getSigner();
   if (!signer) throw new Error('No signer found for chain' + chainName);
 
-  // Ensure the signer is connected to the correct chain
   const expectedChainId = request.transaction.chainId
     ? ethers.getBigInt(request.transaction.chainId)
     : undefined;
 
-  if (expectedChainId) {
-    try {
-      await (w as EVMWallet).switchChain(Number(expectedChainId));
-    } catch (e) {
-      if (e instanceof NotSupported) {
-        console.warn(`Selected EVM wallet cannot switch chains`);
-      } else {
-        throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
+  if (expectedChainId === undefined) {
+    console.warn(`EVM transaction has no chainId`, request.transaction);
+  }
+
+  const signerChainId = (await (w as any).provider?.getNetwork())?.chainId;
+
+  if (signerChainId !== undefined) {
+    // Ensure the signer is connected to the correct chain
+    if (signerChainId !== expectedChainId) {
+      try {
+        await (w as EVMWallet).switchChain(Number(expectedChainId));
+      } catch (e) {
+        if (e instanceof NotSupported) {
+          throw new Error(
+            `Selected EVM wallet does not support switching chains but has the wrong chain selected`,
+          );
+        } else {
+          throw new Error(`Error switching to chain ${expectedChainId}: ${e}`);
+        }
       }
     }
   } else {
-    console.warn(`EVM transaction has no chainId`, request.transaction);
+    console.warn(
+      `EVM signer has no chainId; cannot verify that it matches transaction`,
+    );
   }
 
   const tx = await signer.sendTransaction(request.transaction);
   const result = await tx.wait();
 
-  // TODO move all this to ethers 6
-  /* @ts-ignore */
   return result.hash;
 }


### PR DESCRIPTION
This fixes an issue where the wallet aggregator library hangs forever on the `switchChains` call if the wallet is already on that chain.