### PR TITLE
Add min-height to bridge header

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -71,6 +71,7 @@ const useStyles = makeStyles()((theme: any) => ({
   },
   bridgeHeader: {
     width: '100%',
+    minHeight: '28px',
     display: 'flex',
     alignItems: 'center',
   },


### PR DESCRIPTION
This is to prevent shifting when the page header is set.