### PR TITLE
Do not fetch quotes when tab is inactive

### DIFF
--- a/wormhole-connect/src/hooks/useDocumentVisibility.ts
+++ b/wormhole-connect/src/hooks/useDocumentVisibility.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/**
+ * Custom hook to track the visibility of the document.
+ * This hook can be used to pause/resume certain actions based on document visibility.
+ * Usage: const isDocumentVisible = useDocumentVisibility();
+ *
+ * @returns {boolean} - Returns true if the document is visible, false otherwise.
+ */
+
+export const useDocumentVisibility = (): boolean => {
+  const [isDocumentVisible, setIsDocumentVisible] = useState(!document.hidden);
+
+  const onVisibilityChange = useCallback(() => {
+    setIsDocumentVisible(!document.hidden);
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [onVisibilityChange]);
+
+  return isDocumentVisible;
+};

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -16,6 +16,7 @@ import { calculateUSDPriceRaw } from 'utils';
 import config from 'config';
 import { Token } from 'config/tokens';
 import { useTokens } from 'contexts/TokensContext';
+import { useDocumentVisibility } from './useDocumentVisibility';
 
 type Params = {
   sourceChain?: Chain;
@@ -46,6 +47,8 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
   const [isFetching, setIsFetching] = useState(false);
   const [quotes, setQuotes] = useState<QuoteResult[]>([]);
 
+  const isDocumentVisible = useDocumentVisibility();
+
   // TODO temporary
   // Calculate USD amount for temporary $10,000 Mayan limit
   const { getTokenPrice } = useTokens();
@@ -75,6 +78,11 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     const rParams = params as Required<QuoteParams>;
 
     const onComplete = () => {
+      if (!isDocumentVisible) {
+        // Don't refresh quotes when the tab is not active
+        return;
+      }
+
       // Refresh quotes in 20 seconds
       const refreshTimeout = setTimeout(
         () => setNonce(new Date().valueOf()),
@@ -128,6 +136,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     params.amount,
     params.nativeGas,
     nonce,
+    isDocumentVisible,
     isTransactionInProgress,
     params,
   ]);


### PR DESCRIPTION
This will prevent the onComplete callback to create another timeout and continue fetching.