### PR TITLE
Improvements to quote refreshing

### DIFF
--- a/wormhole-connect/package-lock.json
+++ b/wormhole-connect/package-lock.json
@@ -30,8 +30,8 @@
         "@solana/spl-token": "0.4.0",
         "@solana/wallet-adapter-wallets": "0.19.32",
         "@solana/web3.js": "1.98.0",
-        "@wormhole-foundation/sdk": "1.15.3",
-        "@wormhole-foundation/sdk-definitions": "1.15.3",
+        "@wormhole-foundation/sdk": "1.16.0",
+        "@wormhole-foundation/sdk-definitions": "1.16.0",
         "@wormhole-foundation/sdk-definitions-ntt": "^0.7.1",
         "@wormhole-foundation/sdk-evm-ntt": "^0.7.1",
         "@wormhole-foundation/sdk-icons": "^1.0.0",
@@ -4032,9 +4032,9 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.14.47",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.47.tgz",
-      "integrity": "sha512-ULYeE4oBnR57GIsN7+fX097IlW4Ck94bUv3RwgTlkHazVfBxSN56f1eEXnHcBNYG1A96shPMeLmgh3U8XLH/mg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.15.1.tgz",
+      "integrity": "sha512-dUL6ks9G8I5VJYw7hXehf9OOYaN8bcB5/WCaseKfdzeBwe+yn/Dz/wXQ76NG+Rtknx85eqEkLZHX3LZMVU48cw==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-status-codes": "^2.3.0"
@@ -4113,12 +4113,12 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.14.47",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.47.tgz",
-      "integrity": "sha512-th0QIf3Av4fV8zVmyYEsd1UG8UHVDVkZ9yFpHvnqJq4hF27Ev0M8V7KJWtk391GV1u1HaaaD8BlnSQlXdZmf1Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.15.2.tgz",
+      "integrity": "sha512-b1fvxzUdgrvw2aFgWjf7tIMDnqhIImmAMnkLBdOP1f4/eZKEk3NgoBJxdoixhGWW/v9XFfR66X5PVB0mNz85TA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@injectivelabs/ts-types": "^1.14.47"
+        "@injectivelabs/ts-types": "^1.15.2"
       }
     },
     "node_modules/@injectivelabs/olp-proto-ts": {
@@ -4143,9 +4143,9 @@
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.14.58",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.14.58.tgz",
-      "integrity": "sha512-L5icSt5q0stB9haCTFCaOU3U06Y+HhOQOKr1HACxv6KKqwchcPqfjg0pjSE7S298kTU5t6QqLBHpD2f6G3oq2w==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.15.2.tgz",
+      "integrity": "sha512-a8fPn2xG+ARPfWrIv0Zkf5nOoy8tR7xKGGXrddWQinWHMBJrakujcBxXr8jwCMauX/8T5iKonBapY1i4qGkN1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "^3.13.1",
@@ -4155,17 +4155,17 @@
         "@ethersproject/bytes": "^5.8.0",
         "@injectivelabs/abacus-proto-ts": "1.14.0",
         "@injectivelabs/core-proto-ts": "1.14.3",
-        "@injectivelabs/exceptions": "^1.14.47",
+        "@injectivelabs/exceptions": "^1.15.1",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
         "@injectivelabs/indexer-proto-ts": "1.13.9",
         "@injectivelabs/mito-proto-ts": "1.13.2",
-        "@injectivelabs/networks": "^1.14.47",
+        "@injectivelabs/networks": "^1.15.2",
         "@injectivelabs/olp-proto-ts": "1.13.4",
-        "@injectivelabs/ts-types": "^1.14.47",
-        "@injectivelabs/utils": "^1.14.48",
-        "@metamask/eth-sig-util": "^4.0.0",
+        "@injectivelabs/ts-types": "^1.15.2",
+        "@injectivelabs/utils": "^1.15.2",
+        "@metamask/eth-sig-util": "^8.2.0",
         "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.7.1",
         "axios": "^1.8.1",
@@ -4344,21 +4344,21 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.14.47",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.47.tgz",
-      "integrity": "sha512-c1BQg72eDGaNd2JizJw34wFoiDtHX3Xgc9BJ7zEVRP14xQGdmE3ddCDV8Yc5hKYrpiOZtPevCRgeF5OsFXTeVA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.15.2.tgz",
+      "integrity": "sha512-NE0yYKP/HIP1+V1gDH6ooAf/kq5UpY14BXHb1a4DOljudSv0znj5WSqeDLPcSoUkzdycrCj+MuxtDBAogi55nw==",
       "license": "Apache-2.0"
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.14.48",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.48.tgz",
-      "integrity": "sha512-ypqSVpEWrBKp2GB7UBbymhwShPT5x94NsvA7XZl7EW/5uQ9qyFevrd7vsOo81yiHsYscup3F7aTDQ7/C0+W0aQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.15.2.tgz",
+      "integrity": "sha512-Fs1FuNhkTijrzUEDjBH6N3xuqdOaAWob/l+6IonUuGFcmLdmiFFFgUnepnkKgn2vgQDlqu2vc+JpfWSE4BSNoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bangjelkoski/store2": "^2.14.3",
-        "@injectivelabs/exceptions": "^1.14.47",
-        "@injectivelabs/networks": "^1.14.47",
-        "@injectivelabs/ts-types": "^1.14.47",
+        "@injectivelabs/exceptions": "^1.15.1",
+        "@injectivelabs/networks": "^1.15.2",
+        "@injectivelabs/ts-types": "^1.15.2",
         "axios": "^1.8.1",
         "bignumber.js": "^9.1.2",
         "http-status-codes": "^2.3.0"
@@ -4837,6 +4837,76 @@
         "ethers": "^6"
       }
     },
+    "node_modules/@metamask/abi-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@metamask/abi-utils/-/abi-utils-3.0.0.tgz",
+      "integrity": "sha512-a/l0DiSIr7+CBYVpHygUa3ztSlYLFCQMsklLna+t6qmNY9+eIO5TedNxhyIyvaJ+4cN7TLy0NQFbp9FV3X2ktg==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@metamask/superstruct": "^3.1.0",
+        "@metamask/utils": "^11.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/abi-utils/node_modules/@ethereumjs/common": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethereumjs/util": "^8.1.0",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "node_modules/@metamask/abi-utils/node_modules/@ethereumjs/tx": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@ethereumjs/common": "^3.2.0",
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@metamask/abi-utils/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.4.0.tgz",
+      "integrity": "sha512-dqsi65DAyprs91wo/D0yTST2Sry9h2krf1NADBJb9L3NTJn1py0w+C8K4jVVSh0XTrrj0/MF/t6XldGsidfypA==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/abi-utils/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@metamask/detect-provider": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-2.0.0.tgz",
@@ -4924,72 +4994,87 @@
       }
     },
     "node_modules/@metamask/eth-sig-util": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
-      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-8.2.0.tgz",
+      "integrity": "sha512-LZDglIh4gYGw9Myp+2aIwKrj6lIJpMC4e0m7wKJU+BxLLBFcrTgKrjdjstXGVWvuYG3kutlh9J+uNBRPJqffWQ==",
       "license": "ISC",
       "dependencies": {
-        "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^6.2.1",
-        "ethjs-util": "^0.1.6",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "@metamask/abi-utils": "^3.0.0",
+        "@metamask/utils": "^11.0.1",
+        "@scure/base": "~1.1.3",
+        "ethereum-cryptography": "^2.1.2",
+        "tweetnacl": "^1.0.3"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^18.18 || ^20.14 || >=22"
       }
     },
-    "node_modules/@metamask/eth-sig-util/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+    "node_modules/@metamask/eth-sig-util/node_modules/@ethereumjs/common": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-3.2.0.tgz",
+      "integrity": "sha512-pksvzI0VyLgmuEF2FA/JR/4/y6hcPq8OUail3/AvycBaW1d5VSauOZzqGvJ3RTmR4MU35lWE8KseKOsEhrFRBA==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*"
+        "@ethereumjs/util": "^8.1.0",
+        "crc-32": "^1.2.0"
       }
     },
-    "node_modules/@metamask/eth-sig-util/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "license": "MIT"
-    },
-    "node_modules/@metamask/eth-sig-util/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/@metamask/eth-sig-util/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
+    "node_modules/@metamask/eth-sig-util/node_modules/@ethereumjs/tx": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-4.2.0.tgz",
+      "integrity": "sha512-1nc6VO4jtFd172BbSnTnDQVr9IYBFl1y4xPzZdtkrkKIncBCkdbgfdRV+MiTkJYAtTxvV12GRZLqBFT1PNK6Yw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
+        "@ethereumjs/common": "^3.2.0",
+        "@ethereumjs/rlp": "^4.0.1",
+        "@ethereumjs/util": "^8.1.0",
+        "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/@metamask/utils": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/utils/-/utils-11.4.0.tgz",
+      "integrity": "sha512-dqsi65DAyprs91wo/D0yTST2Sry9h2krf1NADBJb9L3NTJn1py0w+C8K4jVVSh0XTrrj0/MF/t6XldGsidfypA==",
+      "license": "ISC",
+      "dependencies": {
+        "@ethereumjs/tx": "^4.2.0",
+        "@metamask/superstruct": "^3.1.0",
+        "@noble/hashes": "^1.3.1",
+        "@scure/base": "^1.1.3",
+        "@types/debug": "^4.1.7",
+        "debug": "^4.3.4",
+        "pony-cause": "^2.1.10",
+        "semver": "^7.5.4",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": "^18.18 || ^20.14 || >=22"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/@scure/base": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@metamask/eth-sig-util/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@metamask/json-rpc-engine": {
@@ -13856,52 +13941,52 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.15.3.tgz",
-      "integrity": "sha512-+NehAROcTFfoVVo4IuKeg83F09MVg8OZb4HZ53I3TQvVXFQoUT1HxEDcA+CvFHmqnp+eSGTIfq5BydHurL+8iw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-1.16.0.tgz",
+      "integrity": "sha512-H583unQpc/E3moPnJzYVtM+1q4rTxToUUP5C4PYN++/7u+8L3+RtF8rx4CxS+Zz1s768KGazq/uga7YFnNzyqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.15.3",
-        "@wormhole-foundation/sdk-algorand-core": "1.15.3",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.15.3",
-        "@wormhole-foundation/sdk-aptos": "1.15.3",
-        "@wormhole-foundation/sdk-aptos-cctp": "1.15.3",
-        "@wormhole-foundation/sdk-aptos-core": "1.15.3",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.15.3",
-        "@wormhole-foundation/sdk-base": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.15.3",
-        "@wormhole-foundation/sdk-definitions": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
-        "@wormhole-foundation/sdk-evm-cctp": "1.15.3",
-        "@wormhole-foundation/sdk-evm-core": "1.15.3",
-        "@wormhole-foundation/sdk-evm-portico": "1.15.3",
-        "@wormhole-foundation/sdk-evm-tbtc": "1.15.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.15.3",
-        "@wormhole-foundation/sdk-solana": "1.15.3",
-        "@wormhole-foundation/sdk-solana-cctp": "1.15.3",
-        "@wormhole-foundation/sdk-solana-core": "1.15.3",
-        "@wormhole-foundation/sdk-solana-tbtc": "1.15.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.15.3",
-        "@wormhole-foundation/sdk-sui": "1.15.3",
-        "@wormhole-foundation/sdk-sui-cctp": "1.15.3",
-        "@wormhole-foundation/sdk-sui-core": "1.15.3",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "1.15.3"
+        "@wormhole-foundation/sdk-algorand": "1.16.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.16.0",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "1.16.0",
+        "@wormhole-foundation/sdk-aptos": "1.16.0",
+        "@wormhole-foundation/sdk-aptos-cctp": "1.16.0",
+        "@wormhole-foundation/sdk-aptos-core": "1.16.0",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "1.16.0",
+        "@wormhole-foundation/sdk-base": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "1.16.0",
+        "@wormhole-foundation/sdk-definitions": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
+        "@wormhole-foundation/sdk-evm-cctp": "1.16.0",
+        "@wormhole-foundation/sdk-evm-core": "1.16.0",
+        "@wormhole-foundation/sdk-evm-portico": "1.16.0",
+        "@wormhole-foundation/sdk-evm-tbtc": "1.16.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.16.0",
+        "@wormhole-foundation/sdk-solana": "1.16.0",
+        "@wormhole-foundation/sdk-solana-cctp": "1.16.0",
+        "@wormhole-foundation/sdk-solana-core": "1.16.0",
+        "@wormhole-foundation/sdk-solana-tbtc": "1.16.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.16.0",
+        "@wormhole-foundation/sdk-sui": "1.16.0",
+        "@wormhole-foundation/sdk-sui-cctp": "1.16.0",
+        "@wormhole-foundation/sdk-sui-core": "1.16.0",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.15.3.tgz",
-      "integrity": "sha512-tkY34qa7+B29/9a9rEiVxPBbDyEA5bcROufRkVP+RIXHf0zcYh8CxPWqVtrf7leFdmo9uZOXjVV2b8Z0Z0u1iw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-1.16.0.tgz",
+      "integrity": "sha512-Xv+Gn/agTPLFTJubBO1CQLn3BUZO5RotH1MXygkYNjZzvJOIMDyv+V0l8ARmBI6uRER9w+GPUYeFubJ89gNZrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -13909,89 +13994,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.15.3.tgz",
-      "integrity": "sha512-/5NhE3cAs2Vi1zaCZTd918HEosKjlKDB3dPtowjB/KD8KwwClPmNPMjLXNzbJVGnD7y6/yuqt7Jf/kzUNYNnZQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-1.16.0.tgz",
+      "integrity": "sha512-CYLncNWULI6ajN1qHy1ab79LfVxDQSk033UEMDEJILG2+AYc9piMVYieSCAJ08ApbFH9XMfaD1P0XttJT5p5Mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-algorand": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-dOblpaI2pCQz9ShFDSAWwXSVanHFHlRuE3/N6uwmiFD7rYlqAWNZgauj+J2tqaHtrCqzYtuH3kRMXEuYBwL6CA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-UcMRPiwh2L3+6GJRS2hBv3HoHv7zEAESWnvM+9scsimk3qXwYuYZ4z3EnW+fSjeEbIFc9bmpHPHIXCCSLX761w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "1.15.3",
-        "@wormhole-foundation/sdk-algorand-core": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-algorand": "1.16.0",
+        "@wormhole-foundation/sdk-algorand-core": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.15.3.tgz",
-      "integrity": "sha512-berir5y8OLGkSLGBhrxSvfj0EiPttYrdXtq+SXxgoDlAafRrRgbLoHNEJUR8mUWocb1pP5wsbtG2Aolbug6wRQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-1.16.0.tgz",
+      "integrity": "sha512-yQ304s4QNWz/TaT1/3bXwYM3S5iQ5AQR5ZOqYCqk2av9M6VptOkRgLk9/yBwU1P6srx/pxORqJ65D1tBIqiw/w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-1.15.3.tgz",
-      "integrity": "sha512-L4ii6vNy3yeD1oTibOR+Tg7Ov4Rf6RMeZJqTo3fbfg2514r/UvzcYT0Cw7Mj/1oZJ8J+7QNtBYU3FBr4mJd/ew==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-1.16.0.tgz",
+      "integrity": "sha512-SdreNHaKWSbYucjcT7Nxt2fYxn8iiAlTxOjvoa33Wb4yD2lbxjONV5Poca2Mok2CXHvZwOblzqhdRVutm3uDzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^1.33.1",
-        "@wormhole-foundation/sdk-aptos": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-aptos": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.15.3.tgz",
-      "integrity": "sha512-q5xnf+YR+8m1Stdn7ng5tKunqMiKBJyy7OUOBwQKcJ57XP8MzSyQho1pVZ10Ft/KGTHNYphYOKC3FJn/EwThQQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-1.16.0.tgz",
+      "integrity": "sha512-evVLKitf89GYJXti2NsqRae+smalRHhUow0PCNFQuOaylTezBF4bMP7hV0LLTSwIxwxuPHLlaJQrVSXaAkj9bQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-aptos": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-NFA/XxiyOZ7zBnXOeWBO3loEzYTCTtOxoP5RuDTOHQYB+Y+VxyV7XUeQqu2ZnOLNUrauldPJHOhP/uEPshk6PA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-2eXYiW8cHSy+vj0gb9b2x7XS7DVY87EmFa5iiA2w1qc6UgnrDnA6xfE5cqQNVh3wlGx0hCEIxTGfj40K3UML6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "1.15.3",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-aptos": "1.16.0",
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.15.3.tgz",
-      "integrity": "sha512-okgbohZ9hlh/dsdDASEtGJMi1a6BqCuSpBDAiHRf/wlu9kiUfdUaorDIst5lIjPzynNZ2RVDEzVCuvY9qOdT4w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-1.16.0.tgz",
+      "integrity": "sha512-51E+NP8VNe+w99l5PqZijbQtwJtLcd9kg2kV+ehmHP8p+yGdyTQXaq0202+5vM+GmItJ5OrX7jdhfGjx1S5o1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -13999,13 +14084,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.15.3.tgz",
-      "integrity": "sha512-zwKNXXYr73myTKHnBpTChB5xmb8DoV4Oeb49k9oItZiLBmHQWln69Uz4TzSTcPpeu0bi6Pez8/Fo3C0mdHBLPw==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-1.16.0.tgz",
+      "integrity": "sha512-+Hg1mMWrljRwYWiDRVgDv2nb8rykPI5lcdNXQodnC2TFqcievjsned9GsUkl8T4Z8RT/H9Zo2ScS3mgYuurDzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "1.15.3",
-        "@wormhole-foundation/sdk-definitions": "1.15.3",
+        "@wormhole-foundation/sdk-base": "1.16.0",
+        "@wormhole-foundation/sdk-definitions": "1.16.0",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -14013,16 +14098,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.15.3.tgz",
-      "integrity": "sha512-eWuK+aIp00+PlF6iOO0UAMoPMidXXxDX8xD9n+bjfVeBF9kavnM40JXIcCLLFqcTulNYQRqmNmMjMqgBW1Ta+A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-1.16.0.tgz",
+      "integrity": "sha512-vmGGZtEXieKNJ/fEa2vUowS08/DRNEiWQDqOX0qNlrGgKeOIjDkTo/emzrV10EpG7cBSVCZ7WuLfcIhTTzQ8Zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -14030,33 +14115,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.15.3.tgz",
-      "integrity": "sha512-YwN1IWGOXx2NdGsA+WFPQss8VOYzMp1fS7bv2UOT4ArHANOgY167dUdLyhL+N1z79LSBAMcTA/hQKM0cpj96AA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-1.16.0.tgz",
+      "integrity": "sha512-0X5WbEXTvlRl8WhdezpboCkgI/L0SLBlzm7kzyISSkNHjRR5i9f+l1MSJG+GznRIju8ls2mb7tzOO17B1lZ7sQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.15.3.tgz",
-      "integrity": "sha512-HZI8KpLJxgFi1YEx3c9nlD5t3xJVTk4qlFl2poK542QPtZZHeX5wuuKPLpGSm1lsEqpldGRy1pAkoHaOs80Bvg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-1.16.0.tgz",
+      "integrity": "sha512-no82MJjeQc9ECrjeDIVnQbKbPo5xhYE9K1PrlrGY9klZMwQd0pfdLsJ4RNQlbc53GnatjXB7Ox+ebkVuaiBD3w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm-core": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm-core": "1.16.0",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -14064,28 +14149,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-yA/OLfuT1yoaTuChTjSgLPcOad6e8WIMyKFtF90CAbRyxxHKp7pvyM33gfC0QI9oNfj256XoB979I6/awAbl3Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-rtg7pXodF/TmfQyc47d0dJEuKjh80LyUEkDbDqcKRgdN9f/v2ok/d0YFmLDfNMkpIEy+rlbQOQ3+ZuI63yRnkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-cosmwasm": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-cosmwasm": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.15.3.tgz",
-      "integrity": "sha512-7wiAve70oxqcVJ/mzXYs4Zwxql0UHAHqRrgAIouV1yXCTmJiowLlfuuO6sYPWvOV8ZwHRxiCSjMaDvkep7X65w==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-1.16.0.tgz",
+      "integrity": "sha512-GozRC/9OOr69S9Qou0DvxgpkL3LVLFZ79iY0MoviBol3F/zE7WJSkA9DF8zAbMX8Ry2k8Gacq090iso7EjumyA==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "1.15.3"
+        "@wormhole-foundation/sdk-base": "1.16.0"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -14098,12 +14183,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.15.3.tgz",
-      "integrity": "sha512-QmDsQjMtDJ/1whRvAAj5DUVr1CmjQJEL4HL9jzswGsPGIff0Dssbpe4v35pfvKsfGj8qChmfjDWK/1vRnEd0kg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-1.16.0.tgz",
+      "integrity": "sha512-1mX5z6QQxzHriBE7VyjE2IkofYVd2PpPWDIxXAAQkfjDEpshUWNQab2eGgwADOgwl2Fk5JfoSP6zXl/wrcpZaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14111,14 +14196,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.15.3.tgz",
-      "integrity": "sha512-L/lhLMtnuSeCXtlNcnHSshOmCmP8okP5JXm24RgjM1qqXRFEY7FuqV95jFFAA5jxHpDqZQXesHrEpmUZ3+GT7g==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-1.16.0.tgz",
+      "integrity": "sha512-4ty4WYAejyYCQ98K6HOQ2IZKxaNY3wq8ah0CxNbvRbhV7gylqICvsrDjpdlA3iTLyRJzDxK1TLFDbY0DvKlxYw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
-        "@wormhole-foundation/sdk-evm-core": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
+        "@wormhole-foundation/sdk-evm-core": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14126,13 +14211,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.15.3.tgz",
-      "integrity": "sha512-tCjVfpw/62NLO+sTjWiXe5AilvDa0xYAMd4w+QPmGNKpvR3YDz7GB2PD8ShjT+IkqvhyPxD/xUhCnQKHDi6mwQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-1.16.0.tgz",
+      "integrity": "sha512-rmo0EgGNyjsFVhzu518i/sKWqmUifMaZKseRQ1yh+Jl4oBTo11QWSOPMw8vNBvZhT39nuPIYXFIJMV7I+FrGDg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14159,15 +14244,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.15.3.tgz",
-      "integrity": "sha512-rH315JP80GA+HH5H+R7LxcTNspk+M0fN+PjZEcXSyG8e4jUcJo66fLGNrj8AcjeYBMELuBCYxYNkggnBTA8wLg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-1.16.0.tgz",
+      "integrity": "sha512-GBcd01Az+peer7bicLyzxZQQoH0Th/5oSYwfWBzq7sE5s8VQaFFBbafu0OKSNXdO01EvuPdAI6HCiynNt0zQOg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
-        "@wormhole-foundation/sdk-evm-core": "1.15.3",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
+        "@wormhole-foundation/sdk-evm-core": "1.16.0",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14175,14 +14260,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-1.15.3.tgz",
-      "integrity": "sha512-RKCgNcc6gpZHDtbywlwjt9APO+aQshPDEIGYFT5bNc+42V7M52Sd+YmMfhmGCiN3tR1/BEJO8VFx3hpTax4woA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-1.16.0.tgz",
+      "integrity": "sha512-vRyvTJBgj7axQmbRIQn1hvo4BPzXu+K92lzVu7lVoMHdGga/TCXCgz+fk/0CUguc72Lm9azSocpBs3oZJU987Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
-        "@wormhole-foundation/sdk-evm-core": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
+        "@wormhole-foundation/sdk-evm-core": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14190,14 +14275,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-TSF5hGUk/IgDXSpzGIotcYbhuJ7AFAD3c7Z906zQFGUGgMkeBILc/Pg3PDoT/SJkU5lQwGemRmNgkENd/xqGtg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-YkVqqERipqSLr+Y4SOvU5O+6WWK1ofkG3gWqLZD4OT2pN8rxDw+7VL/2LWCP2/2671AOepiCfUdwrfY5d/7xhA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-evm": "1.15.3",
-        "@wormhole-foundation/sdk-evm-core": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-evm": "1.16.0",
+        "@wormhole-foundation/sdk-evm-core": "1.16.0",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -14239,16 +14324,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.15.3.tgz",
-      "integrity": "sha512-sAah3gyvAh1Zb5C59RnCMbt6Eg3p210Am+Lf5SwING67IWxIPTdf0pcNLyWb0h62p4B05jKf29JHruLLCD+OqA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-1.16.0.tgz",
+      "integrity": "sha512-omhdLg56lWbup/UOftPsNUI8DGoUry1zMBtCA4oSesg7F2qoGfA/CcFs4CjsQSfvzx4Ar7gW9mjrY3zRWC4/gQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
+        "@wormhole-foundation/sdk-connect": "1.16.0",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -14256,16 +14341,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.15.3.tgz",
-      "integrity": "sha512-UG+p8iHZOcsQU+Z6ID5ZelJnhu+G2dOHH5zREoYqXBINYdsExH/sPxvpu1ke3F+JAiSz7uerW6ZOxq+jypvJaQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-1.16.0.tgz",
+      "integrity": "sha512-xRysBNvBclBA5oSWn9I/6VaAoCkemJp0jPth8Tr3glrH+zNvmQjLGNLbzd2ZPeOz2cHkyIAzxI1OVnDzRQotkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-solana": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-solana": "1.16.0"
       },
       "engines": {
         "node": ">=16"
@@ -14289,16 +14374,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.15.3.tgz",
-      "integrity": "sha512-51XqQ1L/FV48WUSsGibi7YSjx4CjLdm6kwbwE/JwdUILtC1W46uOG3bdvqTbEsYp+KD67cdXqzQmaj1Phhs/YQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-1.16.0.tgz",
+      "integrity": "sha512-lUEr4Ox/r14Jglea1nVWjY9KQ3+c4OyADpgBDcaR2QwXW0x2ihfzRvg6XFUXhotTb3IXSV4yWNmI5F7ceXcECQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-solana": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-solana": "1.16.0"
       },
       "engines": {
         "node": ">=16"
@@ -14328,18 +14413,18 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-1.15.3.tgz",
-      "integrity": "sha512-6A2YeWRQCYq8Z/cUXloFE7pJ7gSIiLJqYaWQITsaVwt3rXyApzPkkqTfggw30Hbiysuz8QRmW8sEC4UKJBDeSg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-1.16.0.tgz",
+      "integrity": "sha512-6OgTunQi6qXyQUcfA5oIjvFdH/x4KJL2baJmtj/fw5FWc43xaC+9yXIfJhIOtrxQg51FVwKJYUYzTiRm1yb2Sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-solana": "1.15.3",
-        "@wormhole-foundation/sdk-solana-core": "1.15.3",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-solana": "1.16.0",
+        "@wormhole-foundation/sdk-solana-core": "1.16.0",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "1.16.0"
       },
       "engines": {
         "node": ">=16"
@@ -14363,17 +14448,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-pr6WTTM+QbHvhNRmL8IT4Ss6LrFeg7LPwodiytcYU2j8PXnZRdKk41VtCESy/AOc9uueOuYPMQUirpqk4nH1kA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-OTuidwDAkTKbeI+wXLKnEGAkmGRBuIvoB7fkgLqbLN4FHe++IrTi7ZXY6iydYlkhxUx9bCwLLnSKy4Bx+XUyiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-solana": "1.15.3",
-        "@wormhole-foundation/sdk-solana-core": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-solana": "1.16.0",
+        "@wormhole-foundation/sdk-solana-core": "1.16.0"
       },
       "engines": {
         "node": ">=16"
@@ -14414,56 +14499,56 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.15.3.tgz",
-      "integrity": "sha512-/ka45AWouKLyG6O5v8VyToDN1crTsWhj/hYYuf0n+pOAm+Qf3glXEBQVBxqT10nitHMJvSjutW/TOqT4Jk+D7Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-1.16.0.tgz",
+      "integrity": "sha512-JarE3f9j5de0zTI7Y9RVpTzfCuGYbcrdJzzP2SLuYH8awnzqfFZEiKvNh5y6aNECdUsj8Gc11aj8T10RJlvkfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.15.3.tgz",
-      "integrity": "sha512-tNmGZ0upB/sGnVsocMCyildcmaskUEg/OyipXDY+xvADAEbL0YlfG5coW9l2SNZV3Hfg4lowaPyBuifyj/FAhA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-1.16.0.tgz",
+      "integrity": "sha512-kLb+JzRGy80VDDiuw0Yt6NSD4UHVUf5Xng3tmTExZKTxfj19/5H7KkZjTKRos8jeXxtBWE7IBH0tFyfiknvgmA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-sui": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-sui": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.15.3.tgz",
-      "integrity": "sha512-7rXz9GErAQQnQGyOxVRB/lqEoPTTXg8VWHwwSauW6aw+E2qEIUyeKbsar+6iKO3ZviAIyPUZNlUqiuBTpez7gQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-1.16.0.tgz",
+      "integrity": "sha512-2cpEY/cWxHd5iYr+B6RKcbqO+OSs7FsYCvB4GOO507dWLzDaN9bSRYDJGEbt9oRiNcEeRlb5c0TMoNyX/td12w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-sui": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-sui": "1.16.0"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.15.3.tgz",
-      "integrity": "sha512-VSDC/rVL7x2L1Bxcjj5H0S5M/7LnABlxN3UFRJAGairQtILufALDITwqegwTsn4Z0d6PbL6LwZtSxlnFK8n4Ig==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-1.16.0.tgz",
+      "integrity": "sha512-1hf5Zzsh8R/ZO3BT9rRl0nB+pXCNiI7CDFkSPOoz1hcn+eDLK8Z1PnIx6XqZeqBPZerRbUB9usslYGxGlAPQXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "1.15.3",
-        "@wormhole-foundation/sdk-sui": "1.15.3",
-        "@wormhole-foundation/sdk-sui-core": "1.15.3"
+        "@wormhole-foundation/sdk-connect": "1.16.0",
+        "@wormhole-foundation/sdk-sui": "1.16.0",
+        "@wormhole-foundation/sdk-sui-core": "1.16.0"
       },
       "engines": {
         "node": ">=16"
@@ -17287,70 +17372,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ethereumjs-abi": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz",
-      "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
-      "deprecated": "This library has been deprecated and usage is discouraged.",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "node_modules/ethereumjs-abi/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ethereumjs-abi/node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==",
-      "license": "MIT"
-    },
-    "node_modules/ethereumjs-abi/node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
-      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
     "node_modules/ethereumjs-util": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
@@ -17470,20 +17491,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ethjs-util": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
-      "integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
-      "license": "MIT",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0",
-        "strip-hex-prefix": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
       }
     },
     "node_modules/ev-emitter": {
@@ -18661,16 +18668,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-hex-prefixed": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
-      "integrity": "sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
       }
     },
     "node_modules/is-nan": {
@@ -22709,19 +22706,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strip-hex-prefix": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
-      "integrity": "sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==",
-      "license": "MIT",
-      "dependencies": {
-        "is-hex-prefixed": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.5.0",
-        "npm": ">=3"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -23165,7 +23149,8 @@
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
-      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw=="
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/wormhole-connect/package.json
+++ b/wormhole-connect/package.json
@@ -39,8 +39,8 @@
     "@solana/spl-token": "0.4.0",
     "@solana/wallet-adapter-wallets": "0.19.32",
     "@solana/web3.js": "1.98.0",
-    "@wormhole-foundation/sdk": "1.15.3",
-    "@wormhole-foundation/sdk-definitions": "1.15.3",
+    "@wormhole-foundation/sdk": "1.16.0",
+    "@wormhole-foundation/sdk-definitions": "1.16.0",
     "@wormhole-foundation/sdk-definitions-ntt": "^0.7.1",
     "@wormhole-foundation/sdk-evm-ntt": "^0.7.1",
     "@wormhole-foundation/sdk-icons": "^1.0.0",
@@ -169,28 +169,28 @@
       "axios": "1.4.0"
     },
     "@mayanfinance/wormhole-sdk-route": {
-      "@wormhole-foundation/sdk-connect": "1.15.3",
-      "@wormhole-foundation/sdk-evm": "1.15.3",
-      "@wormhole-foundation/sdk-solana": "1.15.3"
+      "@wormhole-foundation/sdk-connect": "1.16.0",
+      "@wormhole-foundation/sdk-evm": "1.16.0",
+      "@wormhole-foundation/sdk-solana": "1.16.0"
     },
     "@wormhole-foundation/sdk-definitions-ntt": {
-      "@wormhole-foundation/sdk-base": "1.15.3",
-      "@wormhole-foundation/sdk-definitions": "1.15.3"
+      "@wormhole-foundation/sdk-base": "1.16.0",
+      "@wormhole-foundation/sdk-definitions": "1.16.0"
     },
     "@wormhole-foundation/sdk-evm-ntt": {
-      "@wormhole-foundation/sdk-base": "1.15.3",
-      "@wormhole-foundation/sdk-definitions": "1.15.3",
-      "@wormhole-foundation/sdk-evm": "1.15.3",
-      "@wormhole-foundation/sdk-evm-core": "1.15.3"
+      "@wormhole-foundation/sdk-base": "1.16.0",
+      "@wormhole-foundation/sdk-definitions": "1.16.0",
+      "@wormhole-foundation/sdk-evm": "1.16.0",
+      "@wormhole-foundation/sdk-evm-core": "1.16.0"
     },
     "@wormhole-foundation/sdk-route-ntt": {
-      "@wormhole-foundation/sdk-connect": "1.15.3"
+      "@wormhole-foundation/sdk-connect": "1.16.0"
     },
     "@wormhole-foundation/sdk-solana-ntt": {
-      "@wormhole-foundation/sdk-base": "1.15.3",
-      "@wormhole-foundation/sdk-definitions": "1.15.3",
-      "@wormhole-foundation/sdk-solana": "1.15.3",
-      "@wormhole-foundation/sdk-solana-core": "1.15.3"
+      "@wormhole-foundation/sdk-base": "1.16.0",
+      "@wormhole-foundation/sdk-definitions": "1.16.0",
+      "@wormhole-foundation/sdk-solana": "1.16.0",
+      "@wormhole-foundation/sdk-solana-core": "1.16.0"
     },
     "@wormhole-foundation/wormhole-connect": {
       "aptos": "1.5.2"

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -24,6 +24,7 @@ type Params = {
   destToken: Token | undefined;
   amount?: sdkAmount.Amount;
   nativeGas: number;
+  recipient?: string;
 };
 
 type HookReturn = {
@@ -196,7 +197,14 @@ export default (routes: string[], params: Params): HookReturn => {
     // Important: Do not the token or chain params to the dependency array. This causes the hook
     // to fire prematurely; we need to figure out supported routes before fetching quotes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routes, nonce, params.amount, params.nativeGas, isVisible]);
+  }, [
+    routes,
+    nonce,
+    params.amount,
+    params.nativeGas,
+    params.recipient,
+    isVisible,
+  ]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -112,53 +112,59 @@ export default (routes: string[], params: Params): HookReturn => {
   }, [quotes, routes, params]);
 
   useEffect(() => {
-    if (!routes.length) {
-      setQuotes([]);
-      setIsFetchingInitialQuotes(false);
-      return;
-    }
     let unmounted = false;
+    const cleanup = () => {
+      unmounted = true;
+    };
+
     if (
+      routes.length === 0 ||
       !params.sourceChain ||
       !params.sourceToken ||
       !params.destChain ||
       !params.destToken ||
-      !params.amount ||
-      !isVisible
+      !params.amount
     ) {
-      return;
+      // Clear quotes if we are missing any inputs or if the inputs support 0 routes
+      setQuotes([]);
+      setIsFetchingInitialQuotes(false);
+      return cleanup;
+    }
+
+    if (isTransactionInProgress || !isVisible) {
+      // Leave quotes alone if the user initiated a transfer,
+      // or if the tab is not visible.
+      return cleanup;
     }
 
     // Forcing TS to infer that fields are non-optional
     const rParams = params as Required<QuoteParams>;
 
-    if (isTransactionInProgress) {
-      // Don't fetch new quotes if the user has committed to one and has initiated a transaction
-    } else {
-      const quotesValues = quotes.filter((q) => q.success);
-      // Immediately invalidate quotes if token inputs changed
-      if (quotesValues.length > 0) {
-        const { sourceToken, destinationToken } = quotesValues[0];
-        if (
-          !isSameToken(sourceToken.token, rParams.sourceToken) ||
-          !isSameToken(destinationToken.token, rParams.destToken)
-        ) {
-          setIsFetchingInitialQuotes(true);
-          setQuotes([]);
-        }
+    // Don't fetch new quotes if the user has committed to one and has initiated a transaction
+    const quotesValues = quotes.filter((q) => q.success);
+    // Immediately invalidate quotes if token inputs changed
+    if (quotesValues.length > 0) {
+      const { sourceToken, destinationToken } = quotesValues[0];
+      if (
+        !isSameToken(sourceToken.token, rParams.sourceToken) ||
+        !isSameToken(destinationToken.token, rParams.destToken)
+      ) {
+        setQuotes([]);
       }
-
-      config.routes.getQuotes(routes, rParams).then((quoteResults) => {
-        if (!unmounted) {
-          setQuotes(quoteResults);
-          setIsFetchingInitialQuotes(false);
-        }
-      });
     }
 
-    return () => {
-      unmounted = true;
-    };
+    if (quotes.length === 0 && routes.length !== 0) {
+      setIsFetchingInitialQuotes(true);
+    }
+
+    config.routes.getQuotes(routes, rParams).then((quoteResults) => {
+      if (!unmounted) {
+        setQuotes(quoteResults);
+        setIsFetchingInitialQuotes(false);
+      }
+    });
+
+    return cleanup;
     // Important: We should not include routes property in deps. See routes.join() below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routes, params, nonce, isVisible]);

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -1,5 +1,5 @@
 import { isSameToken, amount as sdkAmount } from '@wormhole-foundation/sdk';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import type { RootState } from 'store';
 import {
@@ -38,10 +38,9 @@ const MAYAN_BETA_PROTOCOL_LIMITS = {
 
 export default (routes: string[], params: Params): HookReturn => {
   const [nonce, setNonce] = useState(new Date().valueOf());
-  const [refreshTimeout, setRefreshTimeout] = useState<null | ReturnType<
-    typeof setTimeout
-  >>(null);
-
+  const refreshTimeout = useRef<undefined | ReturnType<typeof setTimeout>>(
+    undefined,
+  );
   const [isFetchingInitialQuotes, setIsFetchingInitialQuotes] = useState(false);
   const [quotes, setQuotes] = useState<QuoteResult[]>([]);
   const [isVisible, setIsVisible] = useState(true);
@@ -92,7 +91,7 @@ export default (routes: string[], params: Params): HookReturn => {
     }
 
     if (refreshTimeout) {
-      clearTimeout(refreshTimeout);
+      clearTimeout(refreshTimeout.current);
     }
 
     console.debug(
@@ -101,18 +100,17 @@ export default (routes: string[], params: Params): HookReturn => {
       params,
     );
 
-    const _refreshTimeout = setTimeout(
+    refreshTimeout.current = setTimeout(
       () => setNonce(Date.now()),
       timeTilNextFetch,
     );
-    setRefreshTimeout(_refreshTimeout);
 
     return () => {
       if (refreshTimeout) {
-        clearTimeout(refreshTimeout);
+        clearTimeout(refreshTimeout.current);
       }
     };
-  }, [quotes]);
+  }, [quotes, routes, params]);
 
   useEffect(() => {
     let unmounted = false;

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -36,7 +36,7 @@ const MAYAN_BETA_PROTOCOL_LIMITS = {
   SHUTTLE: 5000,
 };
 
-const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
+export default (routes: string[], params: Params): HookReturn => {
   const [nonce, setNonce] = useState(new Date().valueOf());
   const [refreshTimeout, setRefreshTimeout] = useState<null | ReturnType<
     typeof setTimeout
@@ -102,7 +102,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     );
 
     const _refreshTimeout = setTimeout(
-      () => setNonce(new Date().valueOf()),
+      () => setNonce(Date.now()),
       timeTilNextFetch,
     );
     setRefreshTimeout(_refreshTimeout);
@@ -282,5 +282,3 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     isFetchingInitialQuotes,
   };
 };
-
-export default useRoutesQuotesBulk;

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -112,6 +112,11 @@ export default (routes: string[], params: Params): HookReturn => {
   }, [quotes, routes, params]);
 
   useEffect(() => {
+    if (!routes.length) {
+      setQuotes([]);
+      setIsFetchingInitialQuotes(false);
+      return;
+    }
     let unmounted = false;
     if (
       !params.sourceChain ||
@@ -119,7 +124,6 @@ export default (routes: string[], params: Params): HookReturn => {
       !params.destChain ||
       !params.destToken ||
       !params.amount ||
-      routes.length === 0 ||
       !isVisible
     ) {
       return;
@@ -157,21 +161,7 @@ export default (routes: string[], params: Params): HookReturn => {
     };
     // Important: We should not include routes property in deps. See routes.join() below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    routes.join(), // .join() is necessary to prevent unnecessary updates when routes array's ref changed but its content did not
-    params.sourceChain,
-    params.sourceToken,
-    params.destChain,
-    params.destToken,
-    params.amount,
-    params.nativeGas,
-    nonce,
-    isTransactionInProgress,
-    params,
-    isFetchingInitialQuotes,
-    isVisible,
-  ]);
+  }, [routes, params, isVisible, isTransactionInProgress]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -165,9 +165,10 @@ export default (routes: string[], params: Params): HookReturn => {
     });
 
     return cleanup;
-    // Important: We should not include routes property in deps. See routes.join() below.
+    // Important: Do not the token or chain params to the dependency array. This causes the hook
+    // to fire prematurely; we need to figure out supported routes before fetching quotes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routes, params, nonce, isVisible]);
+  }, [routes, nonce, params.amount, isVisible]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -32,8 +32,7 @@ type HookReturn = {
 };
 
 const MAYAN_BETA_PROTOCOL_LIMITS = {
-  MCTP: 10_000,
-  SHUTTLE: 5000,
+  SHUTTLE: 10_000,
 };
 
 export default (routes: string[], params: Params): HookReturn => {

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -161,7 +161,7 @@ export default (routes: string[], params: Params): HookReturn => {
     };
     // Important: We should not include routes property in deps. See routes.join() below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routes, params, isVisible, isTransactionInProgress]);
+  }, [nonce, isVisible]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -161,7 +161,7 @@ export default (routes: string[], params: Params): HookReturn => {
     };
     // Important: We should not include routes property in deps. See routes.join() below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nonce, isVisible]);
+  }, [routes, params, nonce, isVisible]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -111,6 +111,29 @@ export default (routes: string[], params: Params): HookReturn => {
     };
   }, [quotes, routes, params]);
 
+  // IMPORTANT
+  //
+  // This is the hook where the quotes are actually fetched. This should only be invoked by
+  // very specific events:
+  //
+  // 1. supported routes being recomputed (this is the "routes" dep)
+  // 2. the expiry watching hook above has fired because one of our quotes expired (this is the "nonce" dep)
+  // 3. the user changed the amount input (this is the "params.amount" dep)
+  // 3. the user changed the gas dropoff input (this is the "params.nativeGas" dep)
+  // 4. the tab became visible again after being not visible (this is the "isVisible" dep)
+  //
+  // Notably we are NOT putting all of "params" into the deps, or any of its other properties, which
+  // are the tokens or chains. We do not want to immediately fetch quotes when the user changes the
+  // chain or token because we don't have a new list of supported routes for those inputs yet.
+  // This is why "routes" is a dependency here. This input is recomputed by useFetchSupportedRoutes inside of
+  // useSortedRoutesWithQuotes, which is also the parent hook which invokes this fetchQuotes hook.
+  //
+  // In other words it is a pipeline; we need to first figure out which routes are supported before
+  // we fetch quotes.
+  //
+  // So please don't add deps to this hook just because the linter told you to, or if you don't understand
+  // how all of this is supposed to flow. React hooks are an inelegant tool for building pipelines and lead
+  // you to writing confusing spaghetti, but this is what we have to work with.
   useEffect(() => {
     let unmounted = false;
     const cleanup = () => {
@@ -140,7 +163,6 @@ export default (routes: string[], params: Params): HookReturn => {
     // Forcing TS to infer that fields are non-optional
     const rParams = params as Required<QuoteParams>;
 
-    // Don't fetch new quotes if the user has committed to one and has initiated a transaction
     const quotesValues = quotes.filter((q) => q.success);
     // Immediately invalidate quotes if token inputs changed
     if (quotesValues.length > 0) {
@@ -153,6 +175,12 @@ export default (routes: string[], params: Params): HookReturn => {
       }
     }
 
+    // Let the hook caller know when we are fetching for the first time
+    // so it can show an in-progress state.
+    //
+    // However, when fetching updates afterwards, we do not need to show
+    // this in-progress state because there are already existing quotes
+    // to show - this is less jarring.
     if (quotes.length === 0 && routes.length !== 0) {
       setIsFetchingInitialQuotes(true);
     }
@@ -168,7 +196,7 @@ export default (routes: string[], params: Params): HookReturn => {
     // Important: Do not the token or chain params to the dependency array. This causes the hook
     // to fire prematurely; we need to figure out supported routes before fetching quotes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [routes, nonce, params.amount, isVisible]);
+  }, [routes, nonce, params.amount, params.nativeGas, isVisible]);
 
   const quotesMap = useMemo(
     () =>

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -1,33 +1,38 @@
 import { useEffect, useState } from 'react';
-import { useSelector } from 'react-redux';
-
-import type { RootState } from 'store';
 import config from 'config';
 import { getTokenDetails } from 'telemetry';
-import { useGetTokens } from './useGetTokens';
 import { maybeLogSdkError } from 'utils/errors';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
+import type { Chain, amount } from '@wormhole-foundation/sdk';
+import type { Token } from 'config/tokens';
+import type { WalletData } from 'utils/wallet';
 
 type HookReturn = {
   supportedRoutes: string[];
   isFetching: boolean;
 };
 
-const useFetchSupportedRoutes = (): HookReturn => {
+interface UseFetchSupportedRoutesArgs {
+  fromChain: Chain | undefined;
+  toChain: Chain | undefined;
+  amount: amount.Amount | undefined;
+  sourceToken: Token | undefined;
+  destToken: Token | undefined;
+  toNativeToken: number;
+  receivingWallet: WalletData | undefined;
+}
+
+const useFetchSupportedRoutes = ({
+  fromChain,
+  toChain,
+  amount,
+  sourceToken,
+  destToken,
+  toNativeToken,
+  receivingWallet,
+}: UseFetchSupportedRoutesArgs): HookReturn => {
   const [routes, setRoutes] = useState<string[]>([]);
   const [isFetching, setIsFetching] = useState<boolean>(false);
-
-  const { fromChain, toChain, amount } = useSelector(
-    (state: RootState) => state.transferInput,
-  );
-
-  const { sourceToken, destToken } = useGetTokens();
-
-  const { toNativeToken } = useSelector((state: RootState) => state.relay);
-
-  const receivingWallet = useSelector(
-    (state: RootState) => state.wallet.receiving,
-  );
 
   useEffect(() => {
     if (!fromChain || !toChain || !sourceToken || !destToken) {
@@ -46,7 +51,7 @@ const useFetchSupportedRoutes = (): HookReturn => {
         // because the receiving wallet can't sign/complete the transaction
         if (
           !route.AUTOMATIC_DEPOSIT &&
-          receivingWallet.name === ReadOnlyWallet.NAME
+          receivingWallet?.name === ReadOnlyWallet.NAME
         ) {
           return;
         }

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -3,7 +3,7 @@ import config from 'config';
 import { getTokenDetails } from 'telemetry';
 import { maybeLogSdkError } from 'utils/errors';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
-import type { Chain, amount } from '@wormhole-foundation/sdk';
+import type { Chain } from '@wormhole-foundation/sdk';
 import type { Token } from 'config/tokens';
 import type { WalletData } from 'store/wallet';
 
@@ -15,7 +15,6 @@ type HookReturn = {
 interface UseFetchSupportedRoutesArgs {
   fromChain: Chain | undefined;
   toChain: Chain | undefined;
-  amount: amount.Amount | undefined;
   sourceToken: Token | undefined;
   destToken: Token | undefined;
   toNativeToken: number;
@@ -25,7 +24,6 @@ interface UseFetchSupportedRoutesArgs {
 const useFetchSupportedRoutes = ({
   fromChain,
   toChain,
-  amount,
   sourceToken,
   destToken,
   toNativeToken,
@@ -119,7 +117,6 @@ const useFetchSupportedRoutes = ({
   }, [
     sourceToken,
     destToken,
-    amount,
     fromChain,
     toChain,
     toNativeToken,

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -5,7 +5,7 @@ import { maybeLogSdkError } from 'utils/errors';
 import { ReadOnlyWallet } from 'utils/wallet/ReadOnlyWallet';
 import type { Chain, amount } from '@wormhole-foundation/sdk';
 import type { Token } from 'config/tokens';
-import type { WalletData } from 'utils/wallet';
+import type { WalletData } from 'store/wallet';
 
 type HookReturn = {
   supportedRoutes: string[];

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -49,6 +49,18 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
 
   const [isFetchingInitialQuotes, setIsFetchingInitialQuotes] = useState(false);
   const [quotes, setQuotes] = useState<QuoteResult[]>([]);
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    let visibilityHandler = () => {
+      setIsVisible(!document.hidden);
+    };
+    document.addEventListener('visibilitychange', visibilityHandler);
+
+    return () => {
+      document.removeEventListener('visibilitychange', visibilityHandler);
+    };
+  }, []);
 
   // TODO temporary
   // Calculate USD amount for temporary $10,000 Mayan limit
@@ -84,14 +96,12 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       return;
     }
 
-    // Refresh quotes in 20 seconds
     if (refreshTimeout) {
       clearTimeout(refreshTimeout);
     }
 
-    console.log(
-      'waiting until next quote fetch',
-      timeTilNextFetch / 1000,
+    console.debug(
+      `Waiting ${timeTilNextFetch / 1000}s until next quote fetch`,
       routes,
       params,
     );
@@ -117,7 +127,8 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       !params.destChain ||
       !params.destToken ||
       !params.amount ||
-      routes.length === 0
+      routes.length === 0 ||
+      !isVisible
     ) {
       return;
     }
@@ -167,6 +178,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     isTransactionInProgress,
     params,
     isFetchingInitialQuotes,
+    isVisible,
   ]);
 
   const quotesMap = useMemo(

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -26,12 +26,16 @@ type Params = {
   nativeGas: number;
 };
 
-type HookReturn = {
-  quotesMap: Record<string, QuoteResult | undefined>;
-  isFetching: boolean;
+export type QuoteAndStatus = {
+  quote: QuoteResult;
+  isRefreshing: boolean;
 };
 
-const QUOTE_REFRESH_INTERVAL = 20_000;
+type HookReturn = {
+  quotesMap: Record<string, QuoteResult | undefined>;
+  isFetchingInitialQuotes: boolean;
+};
+
 const MAYAN_BETA_PROTOCOL_LIMITS = {
   MCTP: 10_000,
   SHUTTLE: 5000,
@@ -43,7 +47,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     typeof setTimeout
   >>(null);
 
-  const [isFetching, setIsFetching] = useState(false);
+  const [isFetchingInitialQuotes, setIsFetchingInitialQuotes] = useState(false);
   const [quotes, setQuotes] = useState<QuoteResult[]>([]);
 
   // TODO temporary
@@ -57,6 +61,53 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     params.amount,
     params.sourceToken,
   );
+
+  useEffect(() => {
+    if (routes.length === 0) return;
+
+    // Determine when the next quote expires, and set a timer
+    // to refetch quotes at that point.
+    let timeTilNextFetch = 0;
+
+    if (quotes.length > 0) {
+      const rParams = params as Required<QuoteParams>;
+      const nextExpiry = config.routes.quoteCache.nextExpiry(routes, rParams);
+
+      if (!nextExpiry) {
+        return;
+      }
+      // Fetch again 5 seconds before the next expiry
+      timeTilNextFetch = nextExpiry.valueOf() - Date.now() - 5_000;
+    }
+
+    if (!timeTilNextFetch) {
+      return;
+    }
+
+    // Refresh quotes in 20 seconds
+    if (refreshTimeout) {
+      clearTimeout(refreshTimeout);
+    }
+
+    console.log(
+      'waiting until next quote fetch',
+      timeTilNextFetch / 1000,
+      routes,
+      params,
+    );
+
+    const _refreshTimeout = setTimeout(
+      () => setNonce(new Date().valueOf()),
+      timeTilNextFetch,
+    );
+    setRefreshTimeout(_refreshTimeout);
+
+    return () => {
+      if (refreshTimeout) {
+        clearTimeout(refreshTimeout);
+      }
+    };
+  }, [quotes]);
 
   useEffect(() => {
     let unmounted = false;
@@ -74,21 +125,9 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     // Forcing TS to infer that fields are non-optional
     const rParams = params as Required<QuoteParams>;
 
-    const onComplete = () => {
-      // Refresh quotes in 20 seconds
-      const refreshTimeout = setTimeout(
-        () => setNonce(new Date().valueOf()),
-        QUOTE_REFRESH_INTERVAL,
-      );
-      setRefreshTimeout(refreshTimeout);
-    };
-
     if (isTransactionInProgress) {
       // Don't fetch new quotes if the user has committed to one and has initiated a transaction
-      onComplete();
     } else {
-      setIsFetching(true);
-
       const quotesValues = quotes.filter((q) => q.success);
       // Immediately invalidate quotes if token inputs changed
       if (quotesValues.length > 0) {
@@ -97,6 +136,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
           !isSameToken(sourceToken.token, rParams.sourceToken) ||
           !isSameToken(destinationToken.token, rParams.destToken)
         ) {
+          setIsFetchingInitialQuotes(true);
           setQuotes([]);
         }
       }
@@ -104,17 +144,13 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
       config.routes.getQuotes(routes, rParams).then((quoteResults) => {
         if (!unmounted) {
           setQuotes(quoteResults);
-          setIsFetching(false);
-          onComplete();
+          setIsFetchingInitialQuotes(false);
         }
       });
     }
 
     return () => {
       unmounted = true;
-      if (refreshTimeout) {
-        clearTimeout(refreshTimeout);
-      }
     };
     // Important: We should not include routes property in deps. See routes.join() below.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -130,6 +166,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
     nonce,
     isTransactionInProgress,
     params,
+    isFetchingInitialQuotes,
   ]);
 
   const quotesMap = useMemo(
@@ -235,7 +272,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
 
   return {
     quotesMap,
-    isFetching,
+    isFetchingInitialQuotes,
   };
 };
 

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -26,11 +26,6 @@ type Params = {
   nativeGas: number;
 };
 
-export type QuoteAndStatus = {
-  quote: QuoteResult;
-  isRefreshing: boolean;
-};
-
 type HookReturn = {
   quotesMap: Record<string, QuoteResult | undefined>;
   isFetchingInitialQuotes: boolean;

--- a/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
+++ b/wormhole-connect/src/hooks/useRoutesQuotesBulk.ts
@@ -52,7 +52,7 @@ const useRoutesQuotesBulk = (routes: string[], params: Params): HookReturn => {
   const [isVisible, setIsVisible] = useState(true);
 
   useEffect(() => {
-    let visibilityHandler = () => {
+    const visibilityHandler = () => {
       setIsVisible(!document.hidden);
     };
     document.addEventListener('visibilitychange', visibilityHandler);

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -63,8 +63,17 @@ export const useSortedRoutesWithQuotes = ({
       destChain: toChain,
       destToken,
       nativeGas: toNativeToken,
+      recipient: receivingWallet?.address,
     }),
-    [amount, fromChain, sourceToken, destToken, toChain, toNativeToken],
+    [
+      amount,
+      fromChain,
+      sourceToken,
+      destToken,
+      toChain,
+      toNativeToken,
+      receivingWallet?.address,
+    ],
   );
 
   const { quotesMap, isFetchingInitialQuotes: isFetchingQuotes } =

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import type { RootState } from 'store';
 import { routes } from '@wormhole-foundation/sdk';
-import useRoutesQuotesBulk from 'hooks/useRoutesQuotesBulk';
+import useFetchQuotes from 'hooks/useFetchQuotes';
 import config from 'config';
 import useFetchSupportedRoutes from './useFetchSupportedRoutes';
 import { useGetTokens } from './useGetTokens';
@@ -21,7 +21,7 @@ type HookReturn = {
   allSupportedRoutes: string[];
   sortedRoutes: string[];
   sortedRoutesWithQuotes: RouteWithQuote[];
-  quotesMap: ReturnType<typeof useRoutesQuotesBulk>['quotesMap'];
+  quotesMap: ReturnType<typeof useFetchQuotes>['quotesMap'];
   isFetching: boolean;
 };
 
@@ -37,7 +37,7 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
   const { supportedRoutes, isFetching: isFetchingSupportedRoutes } =
     useFetchSupportedRoutes();
 
-  const useQuotesBulkParams = useMemo(
+  const quoteParams = useMemo(
     () => ({
       amount,
       sourceChain: fromChain,
@@ -50,7 +50,7 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
   );
 
   const { quotesMap, isFetchingInitialQuotes: isFetchingQuotes } =
-    useRoutesQuotesBulk(supportedRoutes, useQuotesBulkParams);
+    useFetchQuotes(supportedRoutes, quoteParams);
 
   const routesWithQuotes = useMemo(() => {
     return supportedRoutes

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -1,11 +1,8 @@
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import type { RootState } from 'store';
 import { routes } from '@wormhole-foundation/sdk';
 import useFetchQuotes from 'hooks/useFetchQuotes';
 import config from 'config';
 import useFetchSupportedRoutes from './useFetchSupportedRoutes';
-import { useGetTokens } from './useGetTokens';
 
 type Quote = routes.Quote<
   routes.Options,
@@ -25,17 +22,37 @@ type HookReturn = {
   isFetching: boolean;
 };
 
-export const useSortedRoutesWithQuotes = (): HookReturn => {
-  const { amount, fromChain, toChain, preferredRouteName } = useSelector(
-    (state: RootState) => state.transferInput,
-  );
+interface UseSortedRoutesWithQuotesArgs {
+  amount: any;
+  fromChain: any;
+  toChain: any;
+  preferredRouteName: string | undefined;
+  toNativeToken: any;
+  sourceToken: any;
+  destToken: any;
+  receivingWallet: any;
+}
 
-  const { toNativeToken } = useSelector((state: RootState) => state.relay);
-
-  const { sourceToken, destToken } = useGetTokens();
-
+export const useSortedRoutesWithQuotes = ({
+  amount,
+  fromChain,
+  toChain,
+  preferredRouteName,
+  toNativeToken,
+  sourceToken,
+  destToken,
+  receivingWallet,
+}: UseSortedRoutesWithQuotesArgs): HookReturn => {
   const { supportedRoutes, isFetching: isFetchingSupportedRoutes } =
-    useFetchSupportedRoutes();
+    useFetchSupportedRoutes({
+      fromChain,
+      toChain,
+      amount,
+      sourceToken,
+      destToken,
+      toNativeToken,
+      receivingWallet,
+    });
 
   const quoteParams = useMemo(
     () => ({

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -49,10 +49,8 @@ export const useSortedRoutesWithQuotes = (): HookReturn => {
     [amount, fromChain, sourceToken, destToken, toChain, toNativeToken],
   );
 
-  const { quotesMap, isFetching: isFetchingQuotes } = useRoutesQuotesBulk(
-    supportedRoutes,
-    useQuotesBulkParams,
-  );
+  const { quotesMap, isFetchingInitialQuotes: isFetchingQuotes } =
+    useRoutesQuotesBulk(supportedRoutes, useQuotesBulkParams);
 
   const routesWithQuotes = useMemo(() => {
     return supportedRoutes

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -1,8 +1,10 @@
 import { useMemo } from 'react';
-import { routes } from '@wormhole-foundation/sdk';
+import { amount, Chain, routes } from '@wormhole-foundation/sdk';
 import useFetchQuotes from 'hooks/useFetchQuotes';
 import config from 'config';
 import useFetchSupportedRoutes from './useFetchSupportedRoutes';
+import { Token } from 'config/tokens';
+import { WalletData } from 'store/wallet';
 
 type Quote = routes.Quote<
   routes.Options,
@@ -23,14 +25,14 @@ type HookReturn = {
 };
 
 interface UseSortedRoutesWithQuotesArgs {
-  amount: any;
-  fromChain: any;
-  toChain: any;
-  preferredRouteName: string | undefined;
-  toNativeToken: any;
-  sourceToken: any;
-  destToken: any;
-  receivingWallet: any;
+  amount?: amount.Amount;
+  fromChain?: Chain;
+  toChain?: Chain;
+  preferredRouteName?: string;
+  toNativeToken: number;
+  sourceToken?: Token;
+  destToken?: Token;
+  receivingWallet: WalletData;
 }
 
 export const useSortedRoutesWithQuotes = ({

--- a/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
+++ b/wormhole-connect/src/hooks/useSortedRoutesWithQuotes.ts
@@ -49,7 +49,6 @@ export const useSortedRoutesWithQuotes = ({
     useFetchSupportedRoutes({
       fromChain,
       toChain,
-      amount,
       sourceToken,
       destToken,
       toNativeToken,

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -302,6 +302,8 @@ class QuoteCache {
             result.expires = new Date(Date.now() + 60_000);
           }
 
+          console.debug(`Fetched quote`, routeName, result);
+
           this.cache[key] = new QuoteCacheEntry(result);
         })
         .catch((err: any) => {

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -47,6 +47,7 @@ export interface QuoteParams {
   destToken: Token;
   amount: sdkAmount.Amount;
   nativeGas: number;
+  recipient?: string; // wallet may be undefined when not connected
 }
 
 export default class RouteOperator {
@@ -240,7 +241,7 @@ class QuoteCache {
       params.destChain
     }:${params.destToken.address.toString()}:${sdkAmount.units(
       params.amount,
-    )}:${params.nativeGas}`;
+    )}:${params.nativeGas}:${params.recipient}`;
   }
 
   get(routeName: string, params: QuoteParams): QuoteResult | null {
@@ -289,6 +290,7 @@ class QuoteCache {
           params.sourceChain,
           params.destChain,
           { nativeGas: params.nativeGas },
+          params.recipient,
         )
         .then((result: QuoteResult) => {
           const pending = this.pending[key];

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -69,7 +69,7 @@ export default class RouteOperator {
     }
     this.routes = routes;
     this.preference = preference;
-    this.quoteCache = new QuoteCache(15_000 /* 15 seconds */);
+    this.quoteCache = new QuoteCache();
   }
 
   get(name: string): SDKv2Route {
@@ -225,12 +225,10 @@ export default class RouteOperator {
 // quote request is resolved. This just prevents us from making redundant API calls when
 // multiple components or hooks are interested in a quote.
 class QuoteCache {
-  ttl: number;
   cache: Record<string, QuoteCacheEntry>;
   pending: Record<string, QuotePromiseHandlers[]>;
 
-  constructor(ttl: number) {
-    this.ttl = ttl;
+  constructor() {
     this.cache = {};
     this.pending = {};
   }
@@ -249,7 +247,7 @@ class QuoteCache {
     const key = this.quoteParamsKey(routeName, params);
     const cachedVal = this.cache[key];
     if (cachedVal) {
-      if (cachedVal.age() < this.ttl) {
+      if (cachedVal.ttl() > 5) {
         return cachedVal.result;
       } else {
         delete this.cache[key];
@@ -264,6 +262,7 @@ class QuoteCache {
     params: QuoteParams,
     route: SDKv2Route,
   ): Promise<QuoteResult> {
+    console.log('fetch quote', routeName, params);
     const key = this.quoteParamsKey(routeName, params);
     const pending = this.pending[key];
     if (pending) {
@@ -297,7 +296,11 @@ class QuoteCache {
           }
           delete this.pending[key];
 
-          // Cache result
+          if (result.success && result.expires === undefined) {
+            // Default to 60 seconds expiry
+            result.expires = new Date(Date.now() + 60_000);
+          }
+
           this.cache[key] = new QuoteCacheEntry(result);
         })
         .catch((err: any) => {
@@ -310,6 +313,24 @@ class QuoteCache {
 
       return returnPromise;
     }
+  }
+
+  nextExpiry(routes: string[], params: QuoteParams): Date | undefined {
+    const expirations: Date[] = routes
+      .map((r) => {
+        const key = this.quoteParamsKey(r, params);
+        if (this.cache[key]) {
+          return this.cache[key].expires();
+        }
+      })
+      .filter((e: Date | undefined) => e !== undefined)
+      .sort((a, b) => a.valueOf() - b.valueOf());
+
+    if (expirations.length > 0) {
+      return expirations[0];
+    }
+
+    return undefined;
   }
 }
 
@@ -329,8 +350,21 @@ class QuoteCacheEntry {
     this.timestamp = new Date();
   }
 
-  age(): number {
-    return new Date().valueOf() - this.timestamp.valueOf();
+  // Number of seconds this quote is still valid for before we should fetch a new one
+  expires(): Date {
+    if (this.result.success) {
+      // For a successful quote, if it specifies an expiry we return that
+      // otherwise we default to a TTL 1 minute
+      return this.result.expires ?? new Date(this.timestamp.valueOf() + 60_000);
+    } else {
+      // We cache errors for 10 seconds
+      return new Date(this.timestamp.valueOf() + 120_000);
+    }
+  }
+
+  // TTL in seconds before quote expires
+  ttl(): number {
+    return (this.expires().valueOf() - Date.now().valueOf()) / 1000;
   }
 }
 

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -262,7 +262,8 @@ class QuoteCache {
     params: QuoteParams,
     route: SDKv2Route,
   ): Promise<QuoteResult> {
-    console.log('fetch quote', routeName, params);
+    console.debug('Fetching quote', routeName, params);
+
     const key = this.quoteParamsKey(routeName, params);
     const pending = this.pending[key];
     if (pending) {
@@ -309,6 +310,12 @@ class QuoteCache {
             reject(err);
           }
           delete this.pending[key];
+
+          // Cache uncaught error
+          this.cache[key] = new QuoteCacheEntry({
+            success: false,
+            error: err,
+          });
         });
 
       return returnPromise;

--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -124,6 +124,7 @@ export class SDKv2Route {
     sourceChain: Chain,
     destChain: Chain,
     options?: routes.AutomaticTokenBridgeRoute.Options,
+    recipient?: string,
   ): Promise<
     [
       routes.Route<Network>,
@@ -136,6 +137,7 @@ export class SDKv2Route {
       destToken,
       sourceChain,
       destChain,
+      recipient,
     );
     const wh = await getWormholeContextV2();
     const route = new this.rc(wh);
@@ -158,6 +160,7 @@ export class SDKv2Route {
     destToken: Token,
     sourceChain: Chain,
     destChain: Chain,
+    recipient?: string,
   ): Promise<routes.RouteTransferRequest<Network>> {
     const sourceContext = (await this.getV2ChainContext(sourceChain)).context;
     const destContext = (await this.getV2ChainContext(destChain)).context;
@@ -169,38 +172,14 @@ export class SDKv2Route {
       {
         source: sourceToken.tokenId,
         destination: destToken.tokenId,
+        recipient: recipient
+          ? Wormhole.chainAddress(destChain, recipient)
+          : undefined,
       },
       sourceContext,
       destContext,
     );
     return req;
-  }
-
-  async computeReceiveAmount(
-    amountIn: Amount,
-    sourceToken: Token,
-    destToken: Token,
-    fromChain: Chain | undefined,
-    toChain: Chain | undefined,
-    options?: routes.AutomaticTokenBridgeRoute.Options,
-  ): Promise<Amount> {
-    if (!fromChain || !toChain)
-      throw new Error('Need both chains to get a quote from SDKv2');
-
-    const [, quote] = await this.getQuote(
-      amountIn,
-      sourceToken,
-      destToken,
-      fromChain,
-      toChain,
-      options,
-    );
-
-    if (quote.success) {
-      return quote.destinationToken.amount;
-    } else {
-      throw quote.error;
-    }
   }
 
   async computeQuote(
@@ -210,6 +189,7 @@ export class SDKv2Route {
     fromChain: Chain,
     toChain: Chain,
     options?: routes.AutomaticTokenBridgeRoute.Options,
+    recipient?: string,
   ): Promise<routes.QuoteResult<routes.Options>> {
     if (!fromChain || !toChain)
       throw new Error('Need both chains to get a quote from SDKv2');
@@ -221,6 +201,7 @@ export class SDKv2Route {
       fromChain,
       toChain,
       options,
+      recipient,
     );
 
     if (!quote.success) {
@@ -247,6 +228,7 @@ export class SDKv2Route {
       fromChain,
       toChain,
       options,
+      recipientAddress,
     );
 
     if (!quote.success) {

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -19,7 +19,6 @@ import PageHeader from 'components/PageHeader';
 import AlertBannerV2 from 'components/v2/AlertBanner';
 import Button from 'components/v2/Button';
 import config from 'config';
-//import useFetchSupportedRoutes from 'hooks/useFetchSupportedRoutes';
 import useComputeDestinationTokens from 'hooks/useComputeDestinationTokens';
 import { useSortedRoutesWithQuotes } from 'hooks/useSortedRoutesWithQuotes';
 import { useAmountValidation } from 'hooks/useAmountValidation';
@@ -207,7 +206,6 @@ const Bridge = () => {
   }, [preferredRouteName, route, sortedRoutesWithQuotes]);
 
   // Pre-fetch available routes
-  //useFetchSupportedRoutes();
 
   // Connect to any previously used wallets for the selected networks
   useConnectToLastUsedWallet();

--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -19,7 +19,7 @@ import PageHeader from 'components/PageHeader';
 import AlertBannerV2 from 'components/v2/AlertBanner';
 import Button from 'components/v2/Button';
 import config from 'config';
-import useFetchSupportedRoutes from 'hooks/useFetchSupportedRoutes';
+//import useFetchSupportedRoutes from 'hooks/useFetchSupportedRoutes';
 import useComputeDestinationTokens from 'hooks/useComputeDestinationTokens';
 import { useSortedRoutesWithQuotes } from 'hooks/useSortedRoutesWithQuotes';
 import { useAmountValidation } from 'hooks/useAmountValidation';
@@ -118,6 +118,7 @@ const Bridge = () => {
 
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
 
+  // --- pipeline state gathering ---
   // Connected wallets, if any
   const { sending: sendingWallet, receiving: receivingWallet } = useSelector(
     (state: RootState) => state.wallet,
@@ -129,21 +130,34 @@ const Bridge = () => {
     route,
     preferredRouteName,
     amount,
-    validations,
+    toNativeToken,
     isTransactionInProgress,
-  } = useSelector((state: RootState) => state.transferInput);
+    validations,
+  } = useSelector((state: RootState) => ({
+    ...state.transferInput,
+    ...state.relay,
+  }));
 
   const { sourceToken, destToken } = useGetTokens();
 
+  // --- pipeline usage ---
   const {
     allSupportedRoutes,
     sortedRoutes,
     sortedRoutesWithQuotes,
     quotesMap,
     isFetching: isFetchingQuotes,
-  } = useSortedRoutesWithQuotes();
+  } = useSortedRoutesWithQuotes({
+    amount,
+    fromChain: sourceChain,
+    toChain: destChain,
+    preferredRouteName,
+    sourceToken,
+    destToken,
+    toNativeToken,
+    receivingWallet,
+  });
 
-  // Compute and set destination tokens
   const { isFetching: isFetchingSupportedDestTokens, supportedDestTokens } =
     useComputeDestinationTokens({
       sourceChain,
@@ -193,7 +207,7 @@ const Bridge = () => {
   }, [preferredRouteName, route, sortedRoutesWithQuotes]);
 
   // Pre-fetch available routes
-  useFetchSupportedRoutes();
+  //useFetchSupportedRoutes();
 
   // Connect to any previously used wallets for the selected networks
   useConnectToLastUsedWallet();


### PR DESCRIPTION
- Refactor the hooks `useSortedRoutesWithQuotes`, `useFetchSupportedRoutes`, `useFetchQuotes` to be a proper pipeline where we fetch support routes first, before trying to fetch quotes.
  - *Only `Bridge/index.ts` should be reading from Redux, and passing these values in to the hooks as arguments. Downstream hooks should not be reading directly from Redux because this makes them fire too soon.* 
  - This fixes a subtle bug where we would immediately start fetching quotes after changing tokens, before even figuring out which routes we should be using first. This was wasteful and always being thrown away
- Use the new `expires` property in an SDK `Route` quote and cache quote values until then
- Pause all quote refreshing when the tab is hidden, and immediately refresh the ones that have expired when tab becomes visible again