### PR TITLE
Handle token after switching chains

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -33,6 +33,8 @@ import {
   setToken,
   setDestToken,
   setTransferRoute,
+  clearToken,
+  clearDestToken,
 } from 'store/transferInput';
 import { copyTextToClipboard } from 'utils';
 import { joinClass } from 'utils/style';
@@ -306,6 +308,19 @@ const Bridge = () => {
           tokenList={sourceTokens}
           setChain={(value: Chain) => {
             selectFromChain(dispatch, value, sendingWallet);
+            // If there's a token on the new chain with the same symbol, select that
+            // Otherwise, clear the selected token
+            if (sourceToken) {
+              const equivalentToken = config.tokens.findBySymbol(
+                value,
+                sourceToken.symbol,
+              );
+              if (equivalentToken) {
+                dispatch(setToken(equivalentToken.tuple));
+              } else {
+                dispatch(clearToken());
+              }
+            }
           }}
           setToken={(value: Token) => {
             dispatch(setToken(value.tuple));
@@ -350,6 +365,19 @@ const Bridge = () => {
           }
           setChain={(value: Chain) => {
             selectToChain(dispatch, value, receivingWallet);
+            // If there's a token on the new chain with the same symbol, select that
+            // Otherwise, clear the selected token
+            if (destToken) {
+              const equivalentToken = config.tokens.findBySymbol(
+                value,
+                destToken.symbol,
+              );
+              if (equivalentToken) {
+                dispatch(setDestToken(equivalentToken.tuple));
+              } else {
+                dispatch(clearDestToken());
+              }
+            }
           }}
           setToken={(value: Token) => {
             dispatch(setDestToken(value.tuple));


### PR DESCRIPTION
Fixes https://github.com/wormhole-foundation/wormhole-connect/issues/3439

There's a very easily reproduced bug right in the latest stable release which lets Connect get into an invalid state:

<img width="505" alt="image" src="https://github.com/user-attachments/assets/d28d57d9-19bc-4d1c-b9be-02dc2d28f7b5" />

All you have to do is select SOL on Solana, then switch the chain to Ethereum for example. Connect doesn't reconsider the selected token when switching chains. This addresses the issue by clearing the token, unless there's a token with the same symbol on the new chain.