### PR TITLE
Should not get cached quote when no amount is entered

### DIFF
--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -77,6 +77,12 @@ export default (routes: string[], params: Params): HookReturn => {
 
     if (quotes.length > 0) {
       const rParams = params as Required<QuoteParams>;
+
+      if (!rParams.amount) {
+        // Stop fetching if no amount entered
+        return;
+      }
+
       const nextExpiry = config.routes.quoteCache.nextExpiry(routes, rParams);
 
       if (!nextExpiry) {


### PR DESCRIPTION
Otherwise we get an error trying to get a cached quote for amount undefined.