### PR TITLE
Executor route relay failure handling

### DIFF
--- a/wormhole-connect/src/hooks/useExternalSearch.ts
+++ b/wormhole-connect/src/hooks/useExternalSearch.ts
@@ -3,7 +3,7 @@ import config from 'config';
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { RootState } from 'store';
-import { clearExternalSearch, setExternalSearch } from 'store/search';
+import { clearSearch, setSearch } from 'store/search';
 
 type ExternalSearch = {
   hasExternalSearch?: boolean;
@@ -25,7 +25,7 @@ export function useExternalSearch(): ExternalSearch {
 
       if (cfg) {
         dispatch(
-          setExternalSearch({
+          setSearch({
             txHash: config.ui.searchTx.txHash,
             chain: cfg.sdkName,
           }),
@@ -39,7 +39,7 @@ export function useExternalSearch(): ExternalSearch {
     txHash,
     chain,
     clear: () => {
-      dispatch(clearExternalSearch());
+      dispatch(clearSearch());
       if (config.ui.searchTx) {
         config.ui.searchTx.chainName = undefined;
         config.ui.searchTx.txHash = undefined;

--- a/wormhole-connect/src/hooks/useExternalSearch.ts
+++ b/wormhole-connect/src/hooks/useExternalSearch.ts
@@ -32,7 +32,7 @@ export function useExternalSearch(): ExternalSearch {
         );
       }
     }
-  }, []);
+  }, [dispatch]);
 
   return {
     hasExternalSearch: !!(txHash && chain),

--- a/wormhole-connect/src/hooks/useExternalSearch.ts
+++ b/wormhole-connect/src/hooks/useExternalSearch.ts
@@ -18,16 +18,16 @@ export function useExternalSearch(): ExternalSearch {
 
   useEffect(() => {
     if (config.ui.searchTx?.chainName && config.ui.searchTx?.txHash) {
-      const chain = config.ui.searchTx.chainName.toLowerCase() as Chain;
-      const isConfigured = config.chainsArr.some(
-        (cfg) => cfg.sdkName === chain,
+      const chainName = config.ui.searchTx.chainName.toLowerCase();
+      const cfg = config.chainsArr.find(
+        (cfg) => cfg.sdkName.toLowerCase() === chainName,
       );
 
-      if (isConfigured) {
+      if (cfg) {
         dispatch(
           setExternalSearch({
             txHash: config.ui.searchTx.txHash,
-            chain,
+            chain: cfg.sdkName,
           }),
         );
       }

--- a/wormhole-connect/src/hooks/useExternalSearch.ts
+++ b/wormhole-connect/src/hooks/useExternalSearch.ts
@@ -1,43 +1,45 @@
 import { Chain } from '@wormhole-foundation/sdk';
 import config from 'config';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { RootState } from 'store';
+import { clearExternalSearch, setExternalSearch } from 'store/search';
 
 type ExternalSearch = {
-  hasExternalSearch: boolean;
+  hasExternalSearch?: boolean;
   txHash?: string;
-  chainName?: Chain;
+  chain?: Chain;
   clear: () => void;
 };
 
 export function useExternalSearch(): ExternalSearch {
-  const [hasExternalSearch, setHasExternalSearchtate] =
-    useState<boolean>(false);
-  const [txHash, setTxHash] = useState<string>();
-  const [chainName, setChainName] = useState<Chain>();
+  const dispatch = useDispatch();
+  const { txHash, chain } = useSelector((state: RootState) => state.search);
+
   useEffect(() => {
     if (config.ui.searchTx?.chainName && config.ui.searchTx?.txHash) {
-      const chainName = config.ui.searchTx.chainName.toLowerCase() as Chain;
+      const chain = config.ui.searchTx.chainName.toLowerCase() as Chain;
+      const isConfigured = config.chainsArr.some(
+        (cfg) => cfg.sdkName === chain,
+      );
 
-      const validChains = config.chainsArr
-        .filter((chain) => chain.key !== 'Wormchain')
-        .map((chain) => chain.key);
-
-      if (validChains.includes(chainName)) {
-        setHasExternalSearchtate(true);
-        setTxHash(config.ui.searchTx.txHash);
-        setChainName(chainName);
+      if (isConfigured) {
+        dispatch(
+          setExternalSearch({
+            txHash: config.ui.searchTx.txHash,
+            chain,
+          }),
+        );
       }
     }
   }, []);
 
   return {
-    hasExternalSearch,
+    hasExternalSearch: !!(txHash && chain),
     txHash,
-    chainName,
+    chain,
     clear: () => {
-      setHasExternalSearchtate(false);
-      setTxHash(undefined);
-      setChainName(undefined);
+      dispatch(clearExternalSearch());
       if (config.ui.searchTx) {
         config.ui.searchTx.chainName = undefined;
         config.ui.searchTx.txHash = undefined;

--- a/wormhole-connect/src/store/index.ts
+++ b/wormhole-connect/src/store/index.ts
@@ -4,6 +4,7 @@ import transferInputReducer from './transferInput';
 import relayReducer from './relay';
 import routerReducer from './router';
 import walletReducer from './wallet';
+import searchReducer from './search';
 
 export const store = configureStore({
   reducer: {
@@ -12,6 +13,7 @@ export const store = configureStore({
     router: routerReducer,
     wallet: walletReducer,
     relay: relayReducer,
+    search: searchReducer,
   },
 });
 

--- a/wormhole-connect/src/store/search.ts
+++ b/wormhole-connect/src/store/search.ts
@@ -1,21 +1,21 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { Chain } from '@wormhole-foundation/sdk';
 
-type ExternalSearchState = {
+type SearchState = {
   txHash?: string;
   chain?: Chain;
 };
 
-const initialState: ExternalSearchState = {
+const initialState: SearchState = {
   txHash: undefined,
   chain: undefined,
 };
 
-const externalSearchSlice = createSlice({
-  name: 'externalSearch',
+const searchSlice = createSlice({
+  name: 'search',
   initialState,
   reducers: {
-    setExternalSearch(
+    setSearch(
       state,
       action: PayloadAction<{
         txHash: string;
@@ -25,13 +25,12 @@ const externalSearchSlice = createSlice({
       state.txHash = action.payload.txHash;
       state.chain = action.payload.chain;
     },
-    clearExternalSearch(state) {
+    clearSearch(state) {
       state.txHash = undefined;
       state.chain = undefined;
     },
   },
 });
 
-export const { setExternalSearch, clearExternalSearch } =
-  externalSearchSlice.actions;
-export default externalSearchSlice.reducer;
+export const { setSearch, clearSearch } = searchSlice.actions;
+export default searchSlice.reducer;

--- a/wormhole-connect/src/store/search.ts
+++ b/wormhole-connect/src/store/search.ts
@@ -1,0 +1,37 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Chain } from '@wormhole-foundation/sdk';
+
+type ExternalSearchState = {
+  txHash?: string;
+  chain?: Chain;
+};
+
+const initialState: ExternalSearchState = {
+  txHash: undefined,
+  chain: undefined,
+};
+
+const externalSearchSlice = createSlice({
+  name: 'externalSearch',
+  initialState,
+  reducers: {
+    setExternalSearch(
+      state,
+      action: PayloadAction<{
+        txHash: string;
+        chain: Chain;
+      }>,
+    ) {
+      state.txHash = action.payload.txHash;
+      state.chain = action.payload.chain;
+    },
+    clearExternalSearch(state) {
+      state.txHash = undefined;
+      state.chain = undefined;
+    },
+  },
+});
+
+export const { setExternalSearch, clearExternalSearch } =
+  externalSearchSlice.actions;
+export default externalSearchSlice.reducer;

--- a/wormhole-connect/src/telemetry/types.ts
+++ b/wormhole-connect/src/telemetry/types.ts
@@ -71,6 +71,7 @@ export const ERR_AMOUNT_TOO_SMALL = 'amount_too_small';
 export const ERR_USER_REJECTED = 'user_rejected';
 export const ERR_TIMEOUT = 'user_timeout';
 export const ERR_UNKNOWN = 'unknown';
+export const ERR_RELAY_FAILED = 'relay_failed';
 
 export type TransferErrorType =
   | typeof ERR_INSUFFICIENT_ALLOWANCE
@@ -83,6 +84,7 @@ export type TransferErrorType =
   | typeof ERR_AMOUNT_TOO_SMALL
   | typeof ERR_USER_REJECTED
   | typeof ERR_TIMEOUT
+  | typeof ERR_RELAY_FAILED
   | typeof ERR_UNKNOWN;
 
 export interface ConnectWalletEvent {

--- a/wormhole-connect/src/utils/errors.ts
+++ b/wormhole-connect/src/utils/errors.ts
@@ -11,9 +11,10 @@ import {
   ERR_USER_REJECTED,
   ERR_AMOUNT_TOO_LARGE,
   ERR_AMOUNT_TOO_SMALL,
+  ERR_RELAY_FAILED,
 } from 'telemetry/types';
 import { InsufficientFundsForGasError } from 'sdklegacy';
-import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import { routes, amount as sdkAmount } from '@wormhole-foundation/sdk';
 
 // TODO SDKV2
 // attempt to capture errors using regex
@@ -33,7 +34,10 @@ export function interpretTransferError(
   let internalErrorCode: TransferErrorType = ERR_UNKNOWN;
 
   if (e.message) {
-    if (INSUFFICIENT_ALLOWANCE_REGEX.test(e?.message)) {
+    if (e instanceof routes.RelayFailedError) {
+      uiErrorMessage = e.message;
+      internalErrorCode = ERR_RELAY_FAILED;
+    } else if (INSUFFICIENT_ALLOWANCE_REGEX.test(e?.message)) {
       uiErrorMessage = 'Error with transfer, please try again';
       internalErrorCode = ERR_INSUFFICIENT_ALLOWANCE;
     } else if (

--- a/wormhole-connect/src/views/TxSearch.tsx
+++ b/wormhole-connect/src/views/TxSearch.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { makeStyles } from 'tss-react/mui';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Select,
   MenuItem,
@@ -30,7 +30,6 @@ import Spacer from 'components/Spacer';
 import AlertBanner from 'components/AlertBanner';
 import { setToChain } from 'store/transferInput';
 import FooterNavBar from 'components/FooterNavBar';
-import { useExternalSearch } from 'hooks/useExternalSearch';
 import { RouteContext } from 'contexts/RouteContext';
 
 import { parseReceipt } from 'utils/sdkv2';
@@ -40,6 +39,8 @@ import {
   Chain,
 } from '@wormhole-foundation/sdk';
 import ChainIconComponent from 'icons/ChainIcons';
+import { RootState } from 'store';
+import { clearSearch } from 'store/search';
 
 const useStyles = makeStyles()((theme) => ({
   container: {
@@ -84,6 +85,8 @@ function TxSearch() {
   });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const externalSearch = useSelector((state: RootState) => state.search);
 
   const theme = useTheme();
 
@@ -157,16 +160,16 @@ function TxSearch() {
     setLoading(false);
   }
 
-  const { hasExternalSearch, txHash, chain, clear } = useExternalSearch();
-
-  // set the txHash and chainName from configs and reset it to undefined
   useEffect(() => {
-    const autoSearch = !!(hasExternalSearch && txHash && chain);
-    if (autoSearch) {
-      setState({ chain, tx: txHash, autoSearch });
-      clear();
+    if (externalSearch.chain && externalSearch.txHash) {
+      setState({
+        chain: externalSearch.chain,
+        tx: externalSearch.txHash,
+        autoSearch: true,
+      });
+      dispatch(clearSearch());
     }
-  }, [hasExternalSearch, txHash, chain, clear]);
+  }, [externalSearch]);
 
   const doSearch = useCallback(() => search(), [state]);
 

--- a/wormhole-connect/src/views/TxSearch.tsx
+++ b/wormhole-connect/src/views/TxSearch.tsx
@@ -157,16 +157,16 @@ function TxSearch() {
     setLoading(false);
   }
 
-  const { hasExternalSearch, txHash, chainName, clear } = useExternalSearch();
+  const { hasExternalSearch, txHash, chain, clear } = useExternalSearch();
 
   // set the txHash and chainName from configs and reset it to undefined
   useEffect(() => {
-    const autoSearch = !!(hasExternalSearch && txHash && chainName);
+    const autoSearch = !!(hasExternalSearch && txHash && chain);
     if (autoSearch) {
-      setState({ chain: chainName, tx: txHash, autoSearch });
+      setState({ chain, tx: txHash, autoSearch });
       clear();
     }
-  }, [hasExternalSearch, txHash, chainName, clear]);
+  }, [hasExternalSearch, txHash, chain, clear]);
 
   const doSearch = useCallback(() => search(), [state]);
 

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -63,7 +63,7 @@ import TxReadyForClaim from 'icons/TxReadyForClaim';
 import { useGetRedeemTokens } from 'hooks/useGetTokens';
 import { tokenIdFromTuple } from 'config/tokens';
 import { clearRedeem } from 'store/redeem';
-import { setExternalSearch } from 'store/search';
+import { setSearch } from 'store/search';
 
 const useStyles = makeStyles()((theme: any) => ({
   spacer: {
@@ -854,7 +854,7 @@ const Redeem = () => {
             dispatch(clearRedeem());
             dispatch(setRoute('search'));
             dispatch(
-              setExternalSearch({
+              setSearch({
                 txHash: sendTx,
                 chain: fromChain,
               }),

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -62,6 +62,8 @@ import { PublicKey } from '@solana/web3.js';
 import TxReadyForClaim from 'icons/TxReadyForClaim';
 import { useGetRedeemTokens } from 'hooks/useGetTokens';
 import { tokenIdFromTuple } from 'config/tokens';
+import { clearRedeem } from 'store/redeem';
+import { setExternalSearch } from 'store/search';
 
 const useStyles = makeStyles()((theme: any) => ({
   spacer: {
@@ -170,7 +172,13 @@ const Redeem = () => {
   const isTxRefunded = receipt && isRefunded(receipt);
   const isTxFailed =
     (receipt && isFailed(receipt)) || !!unhandledManualClaimError;
+  const isRelayFailed =
+    receipt &&
+    isFailed(receipt) &&
+    receipt.error instanceof routes.RelayFailedError;
   const isTxDestQueued = receipt && isDestinationQueued(receipt);
+
+  const isExecutorRoute = routeName?.endsWith('ExecutorRoute');
 
   const {
     recipient,
@@ -180,6 +188,7 @@ const Redeem = () => {
     receivedToken,
     amount,
     eta = 0,
+    sendTx,
   } = txData!;
 
   const getUSDAmount = useUSDamountGetter();
@@ -392,6 +401,8 @@ const Redeem = () => {
       statusText = 'Transaction completed';
     } else if (isTxRefunded) {
       statusText = 'Transaction was refunded';
+    } else if (isRelayFailed && isExecutorRoute) {
+      statusText = `Ready to claim on ${toChain}`;
     } else if (isTxFailed) {
       statusText = 'Transaction failed';
     } else if (isTxDestQueued) {
@@ -411,6 +422,7 @@ const Redeem = () => {
     isTxCompleted,
     isTxRefunded,
     isTxFailed,
+    isRelayFailed,
     isTxDestQueued,
     isTxAttested,
     isAutomaticRoute,
@@ -563,6 +575,13 @@ const Redeem = () => {
           sx={{ color: theme.palette.warning.main }}
         />
       );
+    } else if (isRelayFailed && isExecutorRoute) {
+      return (
+        <TxReadyForClaim
+          className={classes.txStatusIcon}
+          sx={{ color: theme.palette.warning.light }}
+        />
+      );
     } else if (isTxFailed) {
       return (
         <TxFailedIcon
@@ -590,6 +609,7 @@ const Redeem = () => {
     isTxRefunded,
     isTxDestQueued,
     isTxFailed,
+    isRelayFailed,
     isTxAttested,
     theme.palette.primary.light,
     theme.palette.warning.main,
@@ -821,6 +841,33 @@ const Redeem = () => {
       }
     }
 
+    // Checking if relay has failed
+    // TODO: The AutomaticRoute interface doesn't provide a way to manually claim failed relays.
+    // Until that is added, we will use the "resume transaction" flow to handle this case.
+    // This works as long as there is a manual route that can be used to claim the tokens.
+    if (isRelayFailed && isExecutorRoute && sendTx) {
+      return (
+        <Button
+          variant="primary"
+          className={classes.actionButton}
+          onClick={() => {
+            dispatch(clearRedeem());
+            dispatch(setRoute('search'));
+            dispatch(
+              setExternalSearch({
+                txHash: sendTx,
+                chain: fromChain,
+              }),
+            );
+          }}
+        >
+          <Typography textTransform="none">
+            Claim tokens to complete transfer
+          </Typography>
+        </Button>
+      );
+    }
+
     return (
       <>
         <Button
@@ -848,10 +895,12 @@ const Redeem = () => {
     isAutomaticRoute,
     isClaimInProgress,
     isConnectedToReceivingWallet,
+    isRelayFailed,
     isTxAttested,
     isTxCompleted,
     isTxDestQueued,
     theme.palette.primary.contrastText,
+    sendTx,
   ]);
 
   const txDelayedText = useMemo(() => {


### PR DESCRIPTION
Refactored the `useExternalSearch` hook to use redux store instead of local state. The purpose of this is for the Redeem page to navigate the user to the resume transaction flow when a relay fails for an executor route. Automatic routes don't support manual claim yet, so this is a "hack" until we figure out a more robust solution.