### PR TITLE
Load utils/tokens async

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -18,7 +18,6 @@ import { getWormholeContextV2 } from './index';
 import { isValidSuiType } from '@wormhole-foundation/sdk-sui';
 
 import { fetchTokenMetadata } from 'utils/coingecko';
-import { getTokenMetadataFromRpc } from 'utils/tokens';
 
 const TOKEN_CACHE_VERSION = 1;
 
@@ -359,6 +358,7 @@ export class TokenCache extends TokenMapping<Token> {
 
     if (!symbol) {
       // Attempt to get the symbol from on-chain
+      const { getTokenMetadataFromRpc } = await import('utils/tokens');
       const metadataRpc = await getTokenMetadataFromRpc(tokenId);
       if (metadataRpc) {
         console.info('Got metadata from RPC', metadataRpc);


### PR DESCRIPTION
This one-liner shaves a significant amount off the main chunk by asynchronously loading `metaplex` code (for Solana SPL token metadata).

|         | ESM     | CJS     |
|---------|---------|---------|
| Before  | 1.60 MB | 1.36 MB |
| After   | 1.35 MB | 1.14 MB |
| Savings | **15%**     | **16%**     |

That should make Connect load noticeably faster!


## Before:

```
...
ib/solanaEmbed.esm-CI-Nv0O6.mjs        635.86 kB │ gzip:   168.59 kB
lib/aptos-CR3NOL7r.mjs                  671.63 kB │ gzip:   206.30 kB
lib/index-BlddB8Y5.mjs                1,285.62 kB │ gzip:   345.10 kB
lib/chunk-IMTC3J2M-subaby0-.mjs       5,936.72 kB │ gzip: 1,176.57 kB
lib/index-D7BMLqtH.mjs                7,553.43 kB │ gzip: 1,607.90 kB <--- Main chunk
...
lib/evm-9FpIIRdl.js                    448.16 kB │ gzip:   143.78 kB
lib/aptos-Ci_2T2JF.js                  476.13 kB │ gzip:   177.95 kB
lib/index-B_QI_TVP.js                  889.78 kB │ gzip:   306.73 kB
lib/chunk-IMTC3J2M-BLflawC7.js       4,538.02 kB │ gzip: 1,118.06 kB
lib/index-BrlxjTG_.js                5,225.72 kB │ gzip: 1,367.53 kB <--- Main chunk
✓ built in 51.80s
```

## After:

```
...
lib/aptos-C2jMnC_N.mjs                  671.62 kB │ gzip:   206.29 kB
lib/index-BinKPek4.mjs                1,285.58 kB │ gzip:   345.09 kB
lib/tokens-2dDriw_5.mjs               1,342.45 kB │ gzip:   168.99 kB
lib/index-DEZC3eUV.mjs                5,756.74 kB │ gzip: 1,354.29 kB <--- Main chunk
lib/chunk-IMTC3J2M-DfbkQAl2.mjs       5,936.72 kB │ gzip: 1,176.58 kB
...
lib/aptos-CUtF1318.js                  476.13 kB │ gzip:   177.96 kB
lib/tokens-9ihGSj-6.js                 797.15 kB │ gzip:   149.82 kB
lib/index-B7zEXi1C.js                  889.74 kB │ gzip:   306.69 kB
lib/index-B3mED5BZ.js                4,060.20 kB │ gzip: 1,142.65 kB <--- Main chunk
lib/chunk-IMTC3J2M-4i4wVf4c.js       4,538.02 kB │ gzip: 1,118.06 kB
✓ built in 51.86s
```
