### PR TITLE
Optimizes token address handling with lazy loading cache

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -23,9 +23,48 @@ const TOKEN_CACHE_VERSION = 1;
 
 const HAS_LOCALSTORAGE = typeof localStorage !== 'undefined';
 
+class TokenAddressCache<C extends Chain> {
+  private _nativeAddress: TokenAddress<C> | undefined;
+  private readonly _originalAddress: string;
+  private readonly _chain: C;
+  private readonly _address: TokenAddress<C>;
+
+  constructor(chain: C, address: string) {
+    this._originalAddress = address;
+    this._chain = chain;
+
+    // Create a proxy that handles all property access
+    this._address = isNative(address)? address : new Proxy(
+      {
+        toString: () => {
+          return this._originalAddress},
+      },
+      {
+        get: (target, prop) => {
+          if (prop === 'toString' || prop === Symbol.toPrimitive || prop === 'valueOf') {
+            return target[prop];
+          }
+
+          // Lazily load the native address for all other property access
+          if (!this._nativeAddress) {
+            this._nativeAddress = toNative(this._chain, this._originalAddress);
+          }
+
+          const value = this._nativeAddress[prop as keyof TokenAddress<C>];
+          return typeof value === 'function' ? value.bind(this._nativeAddress) : value;
+        }
+      }
+    ) as TokenAddress<C>;
+  }
+
+  getProxy(): TokenAddress<C> {
+    return this._address;
+  }
+}
+
 export class Token {
   chain: Chain;
-  address: TokenAddress<Chain>;
+  private _addressCache: TokenAddressCache<Chain>;
   decimals: number;
   symbol: string;
   name?: string;
@@ -47,12 +86,16 @@ export class Token {
     tokenBridgeOriginalTokenId?: TokenId,
   ) {
     this.chain = chain;
-    this.address = isNative(address) ? address : toNative(chain, address);
+    this._addressCache = new TokenAddressCache(chain, address);
     this.decimals = decimals;
     this.symbol = symbol;
     this.name = name;
     this.icon = icon;
     this.tokenBridgeOriginalTokenId = tokenBridgeOriginalTokenId;
+  }
+
+  get address(): TokenAddress<Chain> {
+    return this._addressCache.getProxy();
   }
 
   get display(): string {

--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -42,13 +42,18 @@ class TokenAddressCache<C extends Chain> {
       {
         get: (target, prop) => {
           if (prop === 'toString' || prop === Symbol.toPrimitive || prop === 'valueOf') {
+            console.log("Saved some ms")
             return target[prop];
           }
 
           // Lazily load the native address for all other property access
+          console.log("Heavy work")
           if (!this._nativeAddress) {
             this._nativeAddress = toNative(this._chain, this._originalAddress);
           }
+
+          if(prop === 'toNative')
+            return this._nativeAddress;
 
           const value = this._nativeAddress[prop as keyof TokenAddress<C>];
           return typeof value === 'function' ? value.bind(this._nativeAddress) : value;

--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -42,12 +42,10 @@ class TokenAddressCache<C extends Chain> {
       {
         get: (target, prop) => {
           if (prop === 'toString' || prop === Symbol.toPrimitive || prop === 'valueOf') {
-            console.log("Saved some ms")
             return target[prop];
           }
 
           // Lazily load the native address for all other property access
-          console.log("Heavy work")
           if (!this._nativeAddress) {
             this._nativeAddress = toNative(this._chain, this._originalAddress);
           }

--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -231,7 +231,7 @@ export class TokenMapping<T> {
     if (isTokenTuple(firstArg)) {
       return this._mapping.get(firstArg[0])?.get(firstArg[1]);
     } else if (isTokenId(firstArg)) {
-      return this._mapping.get(firstArg.chain)?.get(canonicalAddress(firstArg));
+      return this._mapping.get(firstArg.chain)?.get(firstArg.address.toString());
     } else if (isChain(firstArg) && address !== undefined) {
       return this._mapping.get(firstArg)?.get(address);
     } else {
@@ -309,7 +309,7 @@ export class TokenMapping<T> {
   forEach(callback: (tokenId: TokenId, val: T) => void) {
     this._mapping.forEach((nextLevel, chain) => {
       nextLevel.forEach((val, addr) => {
-        const tokenId = Wormhole.tokenId(chain, addr);
+        const tokenId = { chain, address: addr } as TokenId;
         callback(tokenId, val);
       });
     });
@@ -523,34 +523,32 @@ export function buildTokenCache(
   // Temporary hack... use wrappedTokens to populate the cache with all of the known
   // token bridge foreign assets. When we are able to fetch full token balances for every chain
   // this will become unnecessary.
-  for (const chain in wrappedTokens) {
-    for (const addr in wrappedTokens[chain]) {
-      const wts = wrappedTokens[chain][addr];
-      for (const otherChain in wts) {
-        const originalToken = cache.get(chain as Chain, addr);
-        if (originalToken) {
-          const wrappedAddr = wts[otherChain];
+  Object.entries(wrappedTokens).forEach(([chain, addrMap]) => {
+    Object.entries(addrMap).forEach(([addr, wrappedAddrs]) => {
+      const originalToken = cache.get(chain as Chain, addr);
+      if (!originalToken) return;
 
-          let decimals =
-            chainToPlatform(otherChain as Chain) === 'Evm' ? 18 : 8;
+      Object.entries(wrappedAddrs).forEach(([otherChain, wrappedAddr]) => {
+        const platform = chainToPlatform(otherChain as Chain);
+        const decimals = Math.min(
+          platform === 'Evm' ? 18 : 8,
+          originalToken.decimals
+        );
 
-          decimals = Math.min(decimals, originalToken.decimals);
+        const wrappedToken = new Token(
+          otherChain as Chain,
+          wrappedAddr,
+          decimals,
+          originalToken.symbol,
+          originalToken.name,
+          originalToken.icon,
+          originalToken,
+        );
 
-          const wrappedToken = new Token(
-            otherChain as Chain,
-            wrappedAddr,
-            decimals,
-            originalToken.symbol,
-            originalToken.name,
-            originalToken.icon,
-            originalToken,
-          );
-
-          cache.add(wrappedToken);
-        }
-      }
-    }
-  }
+        cache.add(wrappedToken);
+      });
+    });
+  });
 
   cache.persist();
   return cache;
@@ -570,9 +568,7 @@ export function tokenIdToTuple(tokenId: TokenId): TokenTuple {
 
 export function tokenIdFromTuple(tokenTuple: TokenTuple): TokenId {
   const chain = tokenTuple[0] as Chain;
-  const address = isNative(tokenTuple[1])
-    ? tokenTuple[1]
-    : toNative(chain, tokenTuple[1]);
+  const address = new TokenAddressCache(chain, tokenTuple[1]).getProxy();
   return {
     chain,
     address,


### PR DESCRIPTION
Introduces TokenAddressCache class for efficient token address handling using a proxy pattern to defer native address conversion until needed. This improves performance by avoiding unnecessary address conversions at initialization time.

The change replaces direct address conversion with a lazy-loading mechanism that only performs the conversion when address properties are actually accessed.

Before:
![image](https://github.com/user-attachments/assets/9a4b7565-da05-4740-b72a-f536bec1514a)

After:
![image](https://github.com/user-attachments/assets/9e123ed4-3eaa-407c-97d0-6b2791fb97d7)

After 2nd commit:
![image](https://github.com/user-attachments/assets/71dde497-75c6-4f97-8bcc-9b4ab23b83f9)


Savings will be more pronounced with custom configs that include more tokens.