### PR TITLE
Fix error in toNative method of TokenAddressCache

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -51,7 +51,7 @@ class TokenAddressCache<C extends Chain> {
           }
 
           if(prop === 'toNative')
-            return this._nativeAddress;
+            return () => this._nativeAddress;
 
           const value = this._nativeAddress[prop as keyof TokenAddress<C>];
           return typeof value === 'function' ? value.bind(this._nativeAddress) : value;


### PR DESCRIPTION
Resolve an issue where calling the toNative method on a token address resulted in an error by returning a function instead of a direct value.