### PR TITLE
try/catch creation of pendingRequest in AsyncCache

### DIFF
--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -299,6 +299,7 @@ class QuoteCache {
           this.cache[key] = new QuoteCacheEntry(result);
         })
         .catch((err: any) => {
+          console.debug(`Error fetching quote`, routeName, err);
           const pending = this.pending[key];
           for (const { reject } of pending) {
             reject(err);

--- a/wormhole-connect/src/routes/sdkv2/route.ts
+++ b/wormhole-connect/src/routes/sdkv2/route.ts
@@ -80,9 +80,9 @@ export class SDKv2Route {
 
     try {
       const supportedDestinationTokens = await this.supportedDestTokens(
-          sourceToken,
-          fromChain,
-          toChain,
+        sourceToken,
+        fromChain,
+        toChain,
       );
 
       return !!supportedDestinationTokens.find((tokenId) => {
@@ -116,13 +116,12 @@ export class SDKv2Route {
     if (isIlliquid) return [];
 
     const cacheKey = `supportedDestTokens-${sourceToken.address}-${fromChain}-${toChain}`;
-    return await this.tokenCache.requestWithCache(
-      cacheKey,
-      () => this.rc.supportedDestinationTokens(
+    return await this.tokenCache.requestWithCache(cacheKey, () =>
+      this.rc.supportedDestinationTokens(
         sourceToken.tokenId,
         fromContext.context,
         toContext.context,
-      )
+      ),
     );
   }
 

--- a/wormhole-connect/src/utils/AsyncCache.ts
+++ b/wormhole-connect/src/utils/AsyncCache.ts
@@ -29,27 +29,39 @@ export class AsyncCache<T> {
     let pendingRequest = this.pendingRequests.get(cacheKey);
     if (!pendingRequest) {
       console.debug('[Cache Debug] Cache MISS - initiating new request');
-      pendingRequest = fetchFn()
-        .then((result) => {
-          this.cache.set(cacheKey, { 
-            value: result, 
-            timestamp: Date.now(),
-            isError: false
+      try {
+        pendingRequest = fetchFn()
+          .then((result) => {
+            this.cache.set(cacheKey, {
+              value: result,
+              timestamp: Date.now(),
+              isError: false,
+            });
+            this.pendingRequests.delete(cacheKey);
+            return result;
+          })
+          .catch((error) => {
+            console.debug('[Cache Debug] Cache ERROR - storing error');
+            this.cache.set(cacheKey, {
+              value: error,
+              timestamp: Date.now(),
+              isError: true,
+            });
+            this.pendingRequests.delete(cacheKey);
+            throw error;
           });
-          this.pendingRequests.delete(cacheKey);
-          return result;
-        })
-        .catch((error) => {
-          console.debug('[Cache Debug] Cache ERROR - storing error');
-          this.cache.set(cacheKey, { 
-            value: error, 
-            timestamp: Date.now(),
-            isError: true
-          });
-          this.pendingRequests.delete(cacheKey);
-          throw error;
+
+        this.pendingRequests.set(cacheKey, pendingRequest);
+      } catch (error: any) {
+        console.debug('[Cache Debug] Cache UNCAUGHT ERROR - storing error');
+        this.cache.set(cacheKey, {
+          value: error,
+          timestamp: Date.now(),
+          isError: true,
         });
-      this.pendingRequests.set(cacheKey, pendingRequest);
+        this.pendingRequests.delete(cacheKey);
+        throw error;
+      }
     } else {
       console.debug('[Cache Debug] Cache MISS - using pending request');
     }


### PR DESCRIPTION
If `fetchFn` throws an uncaught error, this code vomits all over the stack trace. This is causing issues with resolving routes:

<img width="692" alt="image" src="https://github.com/user-attachments/assets/f0ec3193-ffdc-4189-9559-6a8c6ec2dc4d" />
