### PR TITLE
2.5.0 fixes

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -317,7 +317,7 @@ export class TokenCache extends TokenMapping<Token> {
   // Excludes wrapped tokens
   findBySymbol(chain: Chain, symbol: string): Token | undefined {
     let matching = this.getAllForChain(chain).filter(
-      (t) => t.symbol === symbol,
+      (t) => t.symbol.toLowerCase() === symbol.toLowerCase(),
     );
 
     if (matching.length > 1) {

--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -76,13 +76,14 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
         return;
       }
 
+      if (!active) {
+        return;
+      }
       setSupportedDestTokens(supported);
 
       // Auto-select if there's only one option
       if (destChain && supported.length === 1) {
-        if (active) {
-          dispatch(setDestToken(supported[0].tuple));
-        }
+        dispatch(setDestToken(supported[0].tuple));
       }
     };
 

--- a/wormhole-connect/src/routes/operator.ts
+++ b/wormhole-connect/src/routes/operator.ts
@@ -168,9 +168,7 @@ export default class RouteOperator {
       try {
         // TODO remove once the SDK has a special return value that represents infinite supported tokens
         if (name.includes('Mayan')) {
-          config.tokens.getAllForChain(destChain).map((t) => {
-            supported.add(t.key);
-          });
+          // Ignore for now
         } else {
           const destTokenIds = await route.supportedDestTokens(
             sourceToken,
@@ -316,6 +314,7 @@ class QuoteCache {
           this.cache[key] = new QuoteCacheEntry(result);
         })
         .catch((err: any) => {
+          console.debug(`Error fetching quote`, routeName, err);
           const pending = this.pending[key];
           for (const { reject } of pending) {
             reject(err);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -136,6 +136,7 @@ const TokenList = (props: Props) => {
       tokens.push(nativeToken);
     }
 
+    // Third, USDC
     const usdcAddr = circle.usdcContract.get(
       config.network,
       props.selectedChainConfig.sdkName,
@@ -151,7 +152,7 @@ const TokenList = (props: Props) => {
       }
     }
 
-    // Third: Add tokens with a balances in the connected wallet
+    // Finally: Add tokens with a balances in the connected wallet
     Object.entries(balances).forEach(([key, val]) => {
       if (val?.balance && sdkAmount.units(val.balance) > 0n) {
         const tokenConfig = props.tokenList?.find((t) => t.key === key);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -112,42 +112,16 @@ const TokenList = (props: Props) => {
 
     // Check if any token's address is an exact match on the search query
     // If so, add that one next
-    const searchResult = props.tokenList?.find(
-      (t) => t.address.toString().toLowerCase() === searchQuery.toLowerCase(),
+    const searchResult = config.tokens.findByAddressOrSymbol(
+      props.selectedChainConfig.sdkName,
+      searchQuery,
     );
     if (searchResult && !tokenSet.has(searchResult.address.toString())) {
       tokenSet.add(searchResult.address.toString());
       tokens.push(searchResult);
     }
 
-    // Second: add any tokens with a matching symbol to the source token, ignoring leading Ws (for wrapped),
-    // but NOT if they are wrapped and there's a non-wrapped (native) token with the same symbol also in the list
-    //
-    // This basically prioritizes token bridge outputs in a somewhat hacky way.
-    if (props.sourceToken) {
-      props.tokenList?.forEach((t) => {
-        const symbolMatch =
-          t.symbol.replace(/^W?/, '') ===
-          props.sourceToken!.symbol.replace(/^W?/, '');
-        const originatesFromSourceChain =
-          t.isTokenBridgeWrappedToken &&
-          t.tokenBridgeOriginalTokenId!.chain === props.sourceToken!.chain;
-
-        if (
-          symbolMatch &&
-          originatesFromSourceChain &&
-          !props.tokenList!.find(
-            (ot) => !ot.isTokenBridgeWrappedToken && ot.symbol === t.symbol,
-          ) &&
-          !tokenSet.has(t.address.toString())
-        ) {
-          tokenSet.add(t.address.toString());
-          tokens.push(t);
-        }
-      });
-    }
-
-    // Third: Add the native gas token
+    // Second: Add the native gas token
     if (
       nativeToken &&
       nativeToken.address.toString() !==
@@ -158,7 +132,7 @@ const TokenList = (props: Props) => {
       tokens.push(nativeToken);
     }
 
-    // Fourth: Add tokens with a balances in the connected wallet
+    // Third: Add tokens with a balances in the connected wallet
     Object.entries(balances).forEach(([key, val]) => {
       if (val?.balance && sdkAmount.units(val.balance) > 0n) {
         const tokenConfig = props.tokenList?.find((t) => t.key === key);

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -4,7 +4,11 @@ import CircularProgress from '@mui/material/CircularProgress';
 import ListItemButton from '@mui/material/ListItemButton';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
-import { amount as sdkAmount, toNative } from '@wormhole-foundation/sdk';
+import {
+  circle,
+  amount as sdkAmount,
+  toNative,
+} from '@wormhole-foundation/sdk';
 
 import useGetTokenBalances from 'hooks/useGetTokenBalances';
 import type { ChainConfig } from 'config/types';
@@ -12,7 +16,7 @@ import { isTokenTuple, Token, tokenIdFromTuple } from 'config/tokens';
 import type { WalletData } from 'store/wallet';
 import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
 import TokenItem from 'views/v2/Bridge/AssetPicker/TokenItem';
-import { calculateUSDPrice, isFrankensteinToken } from 'utils';
+import { calculateUSDPrice } from 'utils';
 import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
 
@@ -132,6 +136,21 @@ const TokenList = (props: Props) => {
       tokens.push(nativeToken);
     }
 
+    const usdcAddr = circle.usdcContract.get(
+      config.network,
+      props.selectedChainConfig.sdkName,
+    );
+    if (usdcAddr) {
+      const usdc = config.tokens.get(
+        props.selectedChainConfig.sdkName,
+        usdcAddr,
+      );
+      if (usdc) {
+        tokenSet.add(usdc.address.toString());
+        tokens.push(usdc);
+      }
+    }
+
     // Third: Add tokens with a balances in the connected wallet
     Object.entries(balances).forEach(([key, val]) => {
       if (val?.balance && sdkAmount.units(val.balance) > 0n) {
@@ -143,25 +162,6 @@ const TokenList = (props: Props) => {
         }
       }
     });
-
-    // Finally: If this is destination token or no wallet is connected,
-    // fill up any remaining space from supported and non-Frankenstein tokens
-    if (!props.isSource || !props.wallet?.address) {
-      props.tokenList?.forEach((t) => {
-        // Check if previously added
-        if (tokenSet.has(t.address.toString())) {
-          return;
-        }
-
-        // Exclude frankenstein tokens
-        if (isFrankensteinToken(t, props.selectedChainConfig.key)) {
-          return;
-        }
-
-        tokenSet.add(t.address.toString());
-        tokens.push(t);
-      });
-    }
 
     if (config.tokenWhitelist && config.tokenWhitelist.length > 0) {
       // If integrator has specified a token whitelist, filter the token list by this whitelist.


### PR DESCRIPTION
This fixes two bugs:

- Token list wasn't properly prioritizing destination tokens. We are now ignoring Mayan in this computation entirely (since they support everything) and only surfacing directly supported tokens by NTT, TB, as well as the native gas token & USDC. You can still paste an arbitrary address to get any token. 44f08b5cdd05719e433b39a97a072e644925e7d9 e7c01b1d2e0df65d9e41172cbe5d38a03f27f656

<img width="703" alt="image" src="https://github.com/user-attachments/assets/987feb44-10ab-47cb-9ff1-6c3820599b70" />
<img width="680" alt="image" src="https://github.com/user-attachments/assets/8a026efb-0452-402a-a325-e06f78f8f3d8" />


- When switching chains, it's possible to get the previous chain's token list after the new one. This was a race condition. Fixed by ea7fe11ec5e14889525642d4883d185c3ff4e0b9
![image](https://github.com/user-attachments/assets/e6d68e3b-7112-4272-830e-bf476fc24a6c)
