### PR TITLE
Speed up token cache initalization by order of magnitude

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -7,7 +7,6 @@ import {
   TokenAddress,
   toNative,
   isNative,
-  isSameToken,
   Network,
   chainToPlatform,
   UniversalAddress,
@@ -124,7 +123,7 @@ export class Token extends TokenIdLazy {
   }
 
   equals(other: Token): boolean {
-    return isSameToken(this.tokenId, other.tokenId);
+    return isSameToken(this, other);
   }
 
   toJson(): TokenJson {
@@ -600,4 +599,8 @@ function addressString(tokenId: TokenId): string {
   } else {
     return tokenId.address.toString();
   }
+}
+
+export function isSameToken(a: Token, b: Token): boolean {
+  return a.chain === b.chain && a.addressString === b.addressString;
 }

--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -1,7 +1,6 @@
 import {
   Chain,
   TokenId,
-  Wormhole,
   canonicalAddress,
   isTokenId,
   isChain,
@@ -23,9 +22,36 @@ const TOKEN_CACHE_VERSION = 1;
 
 const HAS_LOCALSTORAGE = typeof localStorage !== 'undefined';
 
-export class Token {
-  chain: Chain;
-  address: TokenAddress<Chain>;
+// A TokenId initialized from a string address, which only parses the address to a NativeAddress when it's needed
+// This is just a speed optimization
+class TokenIdLazy<C extends Chain = Chain> implements TokenId<C> {
+  chain: C;
+  addressString: string;
+  _address?: TokenAddress<Chain>;
+
+  constructor(chain: C, addr: string) {
+    this.chain = chain;
+    this.addressString = addr;
+  }
+
+  get address(): TokenAddress<C> {
+    if (isNative(this.addressString)) return this.addressString;
+
+    if (!this._address) {
+      this._address = toNative(
+        this.chain,
+        this.addressString,
+      ) as TokenAddress<C>;
+    }
+    return this._address as TokenAddress<C>;
+  }
+
+  static fromTokenTuple(tuple: TokenTuple): TokenIdLazy {
+    return new TokenIdLazy(tuple[0], tuple[1]);
+  }
+}
+
+export class Token extends TokenIdLazy {
   decimals: number;
   symbol: string;
   name?: string;
@@ -46,8 +72,7 @@ export class Token {
     icon?: TokenIcon | string,
     tokenBridgeOriginalTokenId?: TokenId,
   ) {
-    this.chain = chain;
-    this.address = isNative(address) ? address : toNative(chain, address);
+    super(chain, address);
     this.decimals = decimals;
     this.symbol = symbol;
     this.name = name;
@@ -66,12 +91,12 @@ export class Token {
   }
 
   get shortAddress(): string {
-    const addr = this.address.toString();
+    const addr = this.addressString;
     return `${addr.substring(0, 5)}...${addr.substring(addr.length - 6)}`;
   }
 
   get tuple(): TokenTuple {
-    return [this.chain, this.address.toString()];
+    return [this.chain, this.addressString];
   }
 
   get key(): string {
@@ -105,7 +130,7 @@ export class Token {
   toJson(): TokenJson {
     return {
       chain: this.chain,
-      address: this.address.toString(),
+      address: this.addressString,
       decimals: this.decimals,
       symbol: this.symbol,
       name: this.name ?? '',
@@ -171,7 +196,7 @@ export class TokenMapping<T> {
       this._mapping.set(token.chain, new Map());
     }
 
-    this._mapping.get(token.chain)!.set(token.address.toString(), value);
+    this._mapping.get(token.chain)!.set(addressString(token), value);
     this.lastUpdate = new Date();
     this.size += 1;
   }
@@ -185,15 +210,32 @@ export class TokenMapping<T> {
     firstArg: Chain | string | TokenId | TokenTuple,
     address?: string,
   ): T | undefined {
-    if (isTokenTuple(firstArg)) {
-      return this._mapping.get(firstArg[0])?.get(firstArg[1]);
-    } else if (isTokenId(firstArg)) {
-      return this._mapping.get(firstArg.chain)?.get(canonicalAddress(firstArg));
-    } else if (isChain(firstArg) && address !== undefined) {
+    if (
+      typeof firstArg === 'string' &&
+      typeof address === 'string' &&
+      isChain(firstArg)
+    ) {
       return this._mapping.get(firstArg)?.get(address);
+    } else if (firstArg instanceof TokenIdLazy) {
+      // Doing the instanceof TokenIdLazy check before isTokenId() is important here for perf reasons.
+      // All we need is the stringified address. TokenIdLazy is optimized for that.
+      // The Wormhole SDK's TokenId is not.
+      //
+      // Both a TokenIdLazy and vanilla TokenId will pass the isTokenId check. So we catch the lazy version
+      // first, otherwise we will isTokenId will parse the TokenIdLazy's addressString and then we will
+      // immediately re-stringifiy it.
+      //
+      // It's weird but it speeds up token cache operations a lot.
+      return this._mapping.get(firstArg.chain)?.get(firstArg.addressString);
+    } else if (isTokenId(firstArg)) {
+      return this._mapping
+        .get(firstArg.chain)
+        ?.get(firstArg.address.toString());
+    } else if (isTokenTuple(firstArg)) {
+      return this._mapping.get(firstArg[0])?.get(firstArg[1]);
     } else {
-      const { chain, address } = parseTokenKey(firstArg);
-      return this._mapping.get(chain)?.get(address.toString());
+      const tokenId = parseTokenKey(firstArg);
+      return this._mapping.get(tokenId.chain)?.get(addressString(tokenId));
     }
   }
 
@@ -241,8 +283,8 @@ export class TokenMapping<T> {
 
   getAllTokenIds(): TokenId[] {
     return Array.from(this._mapping.keys()).flatMap((chain) =>
-      Array.from(this._mapping.get(chain)!.keys()).map((address) =>
-        Wormhole.tokenId(chain, address),
+      Array.from(this._mapping.get(chain)!.keys()).map(
+        (address) => new TokenIdLazy(chain, address),
       ),
     );
   }
@@ -266,7 +308,7 @@ export class TokenMapping<T> {
   forEach(callback: (tokenId: TokenId, val: T) => void) {
     this._mapping.forEach((nextLevel, chain) => {
       nextLevel.forEach((val, addr) => {
-        const tokenId = Wormhole.tokenId(chain, addr);
+        const tokenId = new TokenIdLazy(chain, addr);
         callback(tokenId, val);
       });
     });
@@ -532,18 +574,11 @@ export function isTokenTuple(thing: any): thing is TokenTuple {
 }
 
 export function tokenIdToTuple(tokenId: TokenId): TokenTuple {
-  return [tokenId.chain, tokenId.address.toString()];
+  return [tokenId.chain, addressString(tokenId)];
 }
 
 export function tokenIdFromTuple(tokenTuple: TokenTuple): TokenId {
-  const chain = tokenTuple[0] as Chain;
-  const address = isNative(tokenTuple[1])
-    ? tokenTuple[1]
-    : toNative(chain, tokenTuple[1]);
-  return {
-    chain,
-    address,
-  };
+  return TokenIdLazy.fromTokenTuple(tokenTuple);
 }
 
 export function tokenKey(tokenId: TokenId): string {
@@ -556,5 +591,13 @@ export function parseTokenKey(key: string): TokenId {
     return tokenIdFromTuple(tuple);
   } else {
     throw new Error(`Invalid token key "${key}"; couldn't parse`);
+  }
+}
+
+function addressString(tokenId: TokenId): string {
+  if (tokenId instanceof TokenIdLazy) {
+    return tokenId.addressString;
+  } else {
+    return tokenId.address.toString();
   }
 }

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -5,19 +5,21 @@ import ListItemButton from '@mui/material/ListItemButton';
 import Typography from '@mui/material/Typography';
 import { makeStyles } from 'tss-react/mui';
 import {
-  Chain,
   circle,
   isNative,
-  isSameToken,
   amount as sdkAmount,
   toNative,
-  Wormhole,
-  TokenId,
 } from '@wormhole-foundation/sdk';
 
 import useGetTokenBalances from 'hooks/useGetTokenBalances';
 import type { ChainConfig } from 'config/types';
-import { isTokenTuple, Token, tokenIdFromTuple, tokenKey } from 'config/tokens';
+import {
+  isTokenTuple,
+  isSameToken,
+  Token,
+  tokenIdFromTuple,
+  tokenKey,
+} from 'config/tokens';
 import type { WalletData } from 'store/wallet';
 import SearchableList from 'views/v2/Bridge/AssetPicker/SearchableList';
 import TokenItem from 'views/v2/Bridge/AssetPicker/TokenItem';
@@ -28,12 +30,6 @@ import {
 } from 'utils';
 import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
-
-export function getUsdc(chain: Chain): TokenId | undefined {
-  const addr = circle.usdcContract.get(config.network, chain);
-  if (addr) return Wormhole.tokenId(chain, addr);
-  return undefined;
-}
 
 const useStyles = makeStyles()((theme: any) => ({
   card: {
@@ -121,8 +117,8 @@ const TokenList = (props: Props) => {
       return 3;
     }
     // USDC preferred next
-    const usdc = getUsdc(props.selectedChainConfig.sdkName);
-    if (usdc && isSameToken(usdc, token)) {
+    const usdc = circle.usdcContract.get(config.network, token.chain);
+    if (usdc && token.addressString === usdc) {
       return 2;
     }
     // Finally, prefer native non-wrapped tokens over wrapped ones


### PR DESCRIPTION
The token cache is very inefficient. It makes lots of wasteful calls to crypto libraries like `keccak256` because it parses & re-stringifies token addresses a ton (since it stores things as strings in localStorage). This adds a new class `TokenIdLazy` which stores the string version of a token (which is always how they originate) and only parses it when needed. We never actually need the parsed address until we start making SDK calls to initiate transfers - until then we can use this cached `addressString` property of `TokenIdLazy` instead.

Yes, this makes the code more convoluted, but it speeds up the cache initialization a lot and removes a huge chunk of the initial blocking time when Connect first loads and is given its config.

Currently it takes up ~70-80ms total of the "total blocking time" on Portal bridge because we run it multiple times (each time we update the config):

![image](https://github.com/user-attachments/assets/5db0c1ae-f63f-40ae-87ef-fef105b67f30)

<img width="327" alt="image" src="https://github.com/user-attachments/assets/1e3e1adb-269c-4866-8e3c-a0a631ec551c" />

This means loading the token cache takes up about 25% of the total blocking time, which is the worst part of Portal's performance score right now. (Just using Portal as an example of a Connect integration).

After these changes, each invocation takes 0.5-2ms, so even if we run it 2-3 times this is only adding up to ~6ms of blocking time vs 60-80ms.

![image](https://github.com/user-attachments/assets/d1b949ef-0883-4927-95ab-97ed59dd83ed)

Ultimately this will make it so Connect initializes faster and becomes interactive sooner.