### PR TITLE
Experiment: Hide CCTP manual when automatic is present

### DIFF
--- a/wormhole-connect/src/config/index.ts
+++ b/wormhole-connect/src/config/index.ts
@@ -121,6 +121,7 @@ export function buildConfig(
     validateTransfer: customConfig.validateTransferHandler,
     isRouteSupportedHandler: customConfig.isRouteSupportedHandler,
     isTokenSupportedHandler: customConfig.isTokenSupportedHandler,
+    filterRoutes: customConfig.filterRoutes,
 
     // White lists
     chains: networkData.chains,

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -126,6 +126,9 @@ export interface WormholeConnectConfig {
   // isTokenSupportedHandler can be used to disable certain tokens from being selected
   isTokenSupportedHandler?: IsTokenSupportedHandler;
 
+  // filterRoutes can be used to filter the routes that are shown to the user
+  filterRoutes?: (routes: string[]) => string[];
+
   // UI details
   ui?: UiConfig;
 

--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -166,6 +166,7 @@ export interface InternalConfig<N extends Network> {
   validateTransfer?: ValidateTransferHandler;
   isRouteSupportedHandler?: IsRouteSupportedHandler;
   isTokenSupportedHandler?: IsTokenSupportedHandler;
+  filterRoutes?: (routes: string[]) => string[];
 
   // UI configuration
   ui: UiConfig;

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -35,7 +35,7 @@ export type TestOptions = {
   enableHeadlessSigner?: boolean;
 };
 
-export type Experiments = '';
+export type Experiments = '' | 'hideCCTPManWhenAutoPresent';
 export type Experimental = {
   [Experiment in Experiments]?: boolean;
 };

--- a/wormhole-connect/src/config/ui.ts
+++ b/wormhole-connect/src/config/ui.ts
@@ -35,7 +35,7 @@ export type TestOptions = {
   enableHeadlessSigner?: boolean;
 };
 
-export type Experiments = '' | 'hideCCTPManWhenAutoPresent';
+export type Experiments = '';
 export type Experimental = {
   [Experiment in Experiments]?: boolean;
 };

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -103,12 +103,35 @@ const useFetchSupportedRoutes = ({
         );
       }
 
-      // Experimental - Hide CCTP Manual route when CCTP automatic is present
-      if (
-        config.ui.experimental?.hideCCTPManWhenAutoPresent &&
-        _routes.includes('AutomaticCCTP')
-      ) {
-        _routes = _routes.filter((route) => route !== 'ManualCCTP');
+      // Apply routes filter if provided in the config
+      if (typeof config.filterRoutes === 'function') {
+        try {
+          const filteredRoutes = config.filterRoutes(_routes);
+          // Ensure the filtered routes are valid route names
+          // and included in the original supported routes.
+          if (
+            Array.isArray(filteredRoutes) &&
+            filteredRoutes.every(
+              (r) => typeof r === 'string' && _routes.includes(r),
+            )
+          ) {
+            _routes = filteredRoutes;
+          } else {
+            console.warn(
+              'config.filterRoutes returned one or more invalid route names',
+              filteredRoutes,
+              'Falling back to all supported routes',
+              _routes,
+            );
+          }
+        } catch (e) {
+          console.warn(
+            'Error when filtering routes',
+            e,
+            'Falling back to all supported routes',
+            _routes,
+          );
+        }
       }
 
       if (isActive) {

--- a/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
+++ b/wormhole-connect/src/hooks/useFetchSupportedRoutes.ts
@@ -103,6 +103,14 @@ const useFetchSupportedRoutes = ({
         );
       }
 
+      // Experimental - Hide CCTP Manual route when CCTP automatic is present
+      if (
+        config.ui.experimental?.hideCCTPManWhenAutoPresent &&
+        _routes.includes('AutomaticCCTP')
+      ) {
+        _routes = _routes.filter((route) => route !== 'ManualCCTP');
+      }
+
       if (isActive) {
         setIsFetching(false);
         setRoutes(_routes);


### PR DESCRIPTION
Adding a new experimental option to hide manual CCTP when automatic is present in available routes.