### PR TITLE
[PROD-158] USDC tx explorer link for ExecutorRoute

### DIFF
--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -393,3 +393,10 @@ export const formatDuration = (seconds: number) => {
     return hours === 1 ? `${hours} hour` : `${hours} hours`;
   }
 };
+
+export const isExecutorRoute = (route: string | undefined) => {
+  if (!route) {
+    return false;
+  }
+  return route.endsWith('ExecutorRoute');
+};

--- a/wormhole-connect/src/utils/sdkv2.ts
+++ b/wormhole-connect/src/utils/sdkv2.ts
@@ -24,6 +24,7 @@ import { PublicKey } from '@solana/web3.js';
 import * as splToken from '@solana/spl-token';
 import { WORMSCAN } from 'config/constants';
 import { TokenTuple } from 'config/tokens';
+import { isExecutorRoute } from 'utils';
 
 // Used to represent an initiated transfer. Primarily for the Redeem view.
 export interface TransferInfo {
@@ -76,7 +77,8 @@ export function getExplorerInfo(
       url: `https://explorer.mayan.finance/swap/${txHash}`,
       name: 'Mayan Explorer',
     };
-  } else if (routeName.endsWith('ExecutorRoute')) {
+  } else if (isExecutorRoute(routeName)) {
+    // TODO Remove once Wormholescan explorer supports Executor routes
     return {
       url: `https://usdc.range.org/usdc/status/${txHash}`,
       name: 'USDC.range Explorer',

--- a/wormhole-connect/src/utils/sdkv2.ts
+++ b/wormhole-connect/src/utils/sdkv2.ts
@@ -79,8 +79,11 @@ export function getExplorerInfo(
     };
   } else if (isExecutorRoute(routeName)) {
     // TODO Remove once Wormholescan explorer supports Executor routes
+    // USDC.range supports Mainnet only
     return {
-      url: `https://usdc.range.org/usdc/status/${txHash}`,
+      url: config.isMainnet
+        ? `https://usdc.range.org/usdc/status/${txHash}`
+        : '',
       name: 'USDC.range Explorer',
     };
   } else {

--- a/wormhole-connect/src/utils/sdkv2.ts
+++ b/wormhole-connect/src/utils/sdkv2.ts
@@ -59,7 +59,6 @@ export interface TransferInfo {
 export type ExplorerInfo = {
   url: string;
   name: string;
-  apiUrl: string;
 };
 
 // TODO SDKV2 add a way for the Route interface to offer this
@@ -76,7 +75,11 @@ export function getExplorerInfo(
     return {
       url: `https://explorer.mayan.finance/swap/${txHash}`,
       name: 'Mayan Explorer',
-      apiUrl: `${config.mayanApi}/v3/swap/trx/${txHash}`,
+    };
+  } else if (routeName.endsWith('ExecutorRoute')) {
+    return {
+      url: `https://usdc.range.org/usdc/status/${txHash}`,
+      name: 'USDC.range Explorer',
     };
   } else {
     return {
@@ -84,7 +87,6 @@ export function getExplorerInfo(
         config.isMainnet ? '' : '?network=TESTNET'
       }`,
       name: 'Wormholescan',
-      apiUrl: `${config.wormholeApi}api/v1/operations?txHash=${txHash}`,
     };
   }
 }

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -657,9 +657,7 @@ const SingleRoute = (props: Props) => {
                     receiveNativeAmount || amount.fromBaseUnits(0n, 8)
                   }
                   disabled={isGasSliderDisabled}
-                  isExecutorRoute={props.route
-                    .toLowerCase()
-                    .endsWith('executorroute')}
+                  isExecutorRoute={props.route.endsWith('ExecutorRoute')}
                 />
               </Collapse>
             </>

--- a/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -23,6 +23,7 @@ import {
   getUSDFormat,
   millisToHumanString,
   formatDuration,
+  isExecutorRoute,
 } from 'utils';
 import { joinClass } from 'utils/style';
 
@@ -173,10 +174,7 @@ const SingleRoute = (props: Props) => {
 
     // Wesley made me do it
     // Them PMs :-/
-    if (
-      props.route.startsWith('MayanSwap') ||
-      props.route.endsWith('ExecutorRoute')
-    ) {
+    if (props.route.startsWith('MayanSwap') || isExecutorRoute(props.route)) {
       feeValue = feePriceFormatted;
     }
 
@@ -657,7 +655,7 @@ const SingleRoute = (props: Props) => {
                     receiveNativeAmount || amount.fromBaseUnits(0n, 8)
                   }
                   disabled={isGasSliderDisabled}
-                  isExecutorRoute={props.route.endsWith('ExecutorRoute')}
+                  isExecutorRoute={isExecutorRoute(props.route)}
                 />
               </Collapse>
             </>

--- a/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -308,6 +308,11 @@ const TransactionDetails = () => {
     // Get explorer name and url for the route
     const { name, url } = getExplorerInfo(route, sendTx);
 
+    // Don't show the explorer link if we don't have a valid explorer URL
+    if (!URL.canParse(url)) {
+      return null;
+    }
+
     return (
       <Stack alignItems="center" padding="24px 12px">
         <Link

--- a/wormhole-connect/src/views/v2/Redeem/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/index.tsx
@@ -64,6 +64,7 @@ import { useGetRedeemTokens } from 'hooks/useGetTokens';
 import { tokenIdFromTuple } from 'config/tokens';
 import { clearRedeem } from 'store/redeem';
 import { setSearch } from 'store/search';
+import { isExecutorRoute } from 'utils';
 
 const useStyles = makeStyles()((theme: any) => ({
   spacer: {
@@ -177,8 +178,6 @@ const Redeem = () => {
     isFailed(receipt) &&
     receipt.error instanceof routes.RelayFailedError;
   const isTxDestQueued = receipt && isDestinationQueued(receipt);
-
-  const isExecutorRoute = routeName?.endsWith('ExecutorRoute');
 
   const {
     recipient,
@@ -401,7 +400,7 @@ const Redeem = () => {
       statusText = 'Transaction completed';
     } else if (isTxRefunded) {
       statusText = 'Transaction was refunded';
-    } else if (isRelayFailed && isExecutorRoute) {
+    } else if (isRelayFailed && isExecutorRoute(routeName)) {
       statusText = `Ready to claim on ${toChain}`;
     } else if (isTxFailed) {
       statusText = 'Transaction failed';
@@ -421,8 +420,9 @@ const Redeem = () => {
   }, [
     isTxCompleted,
     isTxRefunded,
-    isTxFailed,
     isRelayFailed,
+    routeName,
+    isTxFailed,
     isTxDestQueued,
     isTxAttested,
     isAutomaticRoute,
@@ -575,7 +575,7 @@ const Redeem = () => {
           sx={{ color: theme.palette.warning.main }}
         />
       );
-    } else if (isRelayFailed && isExecutorRoute) {
+    } else if (isRelayFailed && isExecutorRoute(routeName)) {
       return (
         <TxReadyForClaim
           className={classes.txStatusIcon}
@@ -602,19 +602,20 @@ const Redeem = () => {
       return etaCircularProgress;
     }
   }, [
-    classes.txStatusIcon,
-    etaCircularProgress,
-    isAutomaticRoute,
     isTxCompleted,
     isTxRefunded,
     isTxDestQueued,
-    isTxFailed,
     isRelayFailed,
+    routeName,
+    isTxFailed,
+    isAutomaticRoute,
     isTxAttested,
+    classes.txStatusIcon,
     theme.palette.primary.light,
     theme.palette.warning.main,
     theme.palette.warning.light,
     theme.palette.error.light,
+    etaCircularProgress,
   ]);
 
   useEffect(() => {
@@ -845,7 +846,7 @@ const Redeem = () => {
     // TODO: The AutomaticRoute interface doesn't provide a way to manually claim failed relays.
     // Until that is added, we will use the "resume transaction" flow to handle this case.
     // This works as long as there is a manual route that can be used to claim the tokens.
-    if (isRelayFailed && isExecutorRoute && sendTx) {
+    if (isRelayFailed && isExecutorRoute(routeName) && sendTx) {
       return (
         <Button
           variant="primary"
@@ -887,20 +888,22 @@ const Redeem = () => {
       </>
     );
   }, [
-    claimError,
+    isClaimInProgress,
+    isTxDestQueued,
+    isAutomaticRoute,
+    isTxAttested,
+    isRelayFailed,
+    routeName,
+    sendTx,
     classes.actionButton,
     classes.claimButton,
-    dispatch,
-    handleManualClaim,
-    isAutomaticRoute,
-    isClaimInProgress,
-    isConnectedToReceivingWallet,
-    isRelayFailed,
-    isTxAttested,
     isTxCompleted,
-    isTxDestQueued,
     theme.palette.primary.contrastText,
-    sendTx,
+    isConnectedToReceivingWallet,
+    claimError,
+    handleManualClaim,
+    dispatch,
+    fromChain,
   ]);
 
   const txDelayedText = useMemo(() => {


### PR DESCRIPTION
- Added a special case to render USDC.range explorer link for ExecutorRoutes instead of WHScan. This is a temp situation that will get removed once WHScan adds the support for ExecutorRoute transactions.
- I've also added a utility isExecutorRoute. This is super simple route name check, but used in several places and it's good to have the logic in one place.