### PR TITLE
Fix coingecko ID for Optimism

### DIFF
--- a/wormhole-connect/src/utils/coingecko.ts
+++ b/wormhole-connect/src/utils/coingecko.ts
@@ -31,7 +31,7 @@ const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
 const CHAIN_IDS: Partial<Record<Chain, string>> = {
   Bsc: 'binance-smart-chain',
   Arbitrum: 'arbitrum-one',
-  Optimism: 'optimism-ethereum',
+  Optimism: 'optimistic-ethereum',
   Polygon: 'polygon-pos',
   Klaytn: 'kaia-token',
   Xlayer: 'x-layer',


### PR DESCRIPTION
CG calls Optimism "Optimistic Ethereum" 🙄 

<img width="293" alt="image" src="https://github.com/user-attachments/assets/4b5891fd-2533-4135-a164-a99e1efec4ce" />
