### PR TITLE
Fall back to token amount for same-symbol tokens

### DIFF
--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -64,11 +64,6 @@ export default (routes: string[], params: Params): HookReturn => {
   const { isTransactionInProgress } = useSelector(
     (state: RootState) => state.transferInput,
   );
-  const usdValue = calculateUSDPriceRaw(
-    getTokenPrice,
-    params.amount,
-    params.sourceToken,
-  );
 
   useEffect(() => {
     if (routes.length === 0) return;
@@ -223,10 +218,19 @@ export default (routes: string[], params: Params): HookReturn => {
   ]);
 
   const quotes = useMemo(() => {
+    const usdValue = calculateUSDPriceRaw(
+      getTokenPrice,
+      params.amount,
+      params.sourceToken,
+    );
+
     let filtered = Object.assign({}, unfilteredQuotes);
 
     // Filter out quotes that would result in a large instant loss
     // (Transfers >=$1000 with >=10% value loss)
+    //
+    // OR if both tokens have the same symbol and we fail to fetch a USD for either of them
+    // we assume they are the same token and just compare the token amounts.
     for (const name in filtered) {
       const quote = filtered[name];
 
@@ -237,10 +241,26 @@ export default (routes: string[], params: Params): HookReturn => {
           params.destToken,
         );
 
-        if (usdValue && usdValueOut) {
+        if (usdValue !== undefined && usdValueOut !== undefined) {
           const valueRatio = usdValueOut / usdValue;
           if (usdValue >= 1000 && valueRatio <= 0.9) {
             // Don't offer quotes where the USD value out delta exceeds a $1,000 or 10% loss
+            console.debug(
+              `Filtering out ${name} quote with valueRatio=${valueRatio} USD delta=${
+                usdValue - usdValueOut
+              }`,
+            );
+            delete filtered[name];
+          }
+        } else if (params.sourceToken!.symbol === params.destToken!.symbol) {
+          const valueRatio =
+            parseFloat(amount.display(quote.destinationToken.amount)) /
+            parseFloat(amount.display(params.amount!));
+
+          if (valueRatio <= 0.9) {
+            console.debug(
+              `Filtering out ${name} quote with valueRatio=${valueRatio} (for same-symbol tokens)`,
+            );
             delete filtered[name];
           }
         }

--- a/wormhole-connect/src/hooks/useFetchQuotes.ts
+++ b/wormhole-connect/src/hooks/useFetchQuotes.ts
@@ -252,10 +252,15 @@ export default (routes: string[], params: Params): HookReturn => {
             );
             delete filtered[name];
           }
-        } else if (params.sourceToken!.symbol === params.destToken!.symbol) {
+        } else if (
+          params.amount &&
+          params.sourceToken &&
+          params.destToken &&
+          params.sourceToken.symbol === params.destToken.symbol
+        ) {
           const valueRatio =
             parseFloat(amount.display(quote.destinationToken.amount)) /
-            parseFloat(amount.display(params.amount!));
+            parseFloat(amount.display(params.amount));
 
           if (valueRatio <= 0.9) {
             console.debug(


### PR DESCRIPTION
If we don't have USD conversion rates available and the source & destination tokens have the same symbol, we use the raw token amount as a fallback when evaluating the quote's implied loss.