### PR TITLE
Clear destination tokens before fetching; add loading skeleton UI

### DIFF
--- a/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
+++ b/wormhole-connect/src/hooks/useComputeDestinationTokens.ts
@@ -41,6 +41,8 @@ const useComputeDestinationTokens = (props: Props): ReturnProps => {
     const computeDestTokens = async () => {
       let supported: Token[] = [];
 
+      setSupportedDestTokens([]);
+
       // Start fetching and setting all supported tokens
 
       if (!sourceChain && destChain) {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Card, CardContent, useTheme } from '@mui/material';
+import { Box, Card, CardContent, Skeleton, useTheme } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import ListItemButton from '@mui/material/ListItemButton';
 import Typography from '@mui/material/Typography';
@@ -44,6 +44,7 @@ const useStyles = makeStyles()((theme: any) => ({
     marginBottom: '8px',
   },
   tokenLoader: {
+    padding: 0,
     display: 'flex',
     justifyContent: 'space-between',
   },
@@ -308,11 +309,14 @@ const TokenList = (props: Props) => {
         )
       }
       loading={
-        props.isFetching && (
+        props.isFetching &&
+        [1, 2, 3].map((_) => (
           <ListItemButton className={classes.tokenLoader} dense>
-            <CircularProgress />
+            <Box height="39px" padding="8px 16px">
+              <Skeleton variant="circular" width="36px" height="36px" />
+            </Box>
           </ListItemButton>
-        )
+        ))
       }
       items={sortedTokens}
       onQueryChange={(query) => {


### PR DESCRIPTION
This is a combo bugfix and UI improvement.

- clears destination tokens before fetching them, so we're not showing the old chain's tokens in the meantime
- replaces the loading spinner with a more subtle skeleton (like we do when loading routes)


https://github.com/user-attachments/assets/b5b77cd0-1347-4487-b6c0-994af725e661

