### PR TITLE
Normalize token addresses to lowercase

### DIFF
--- a/wormhole-connect/src/config/tokens.ts
+++ b/wormhole-connect/src/config/tokens.ts
@@ -195,7 +195,9 @@ export class TokenMapping<T> {
       this._mapping.set(token.chain, new Map());
     }
 
-    this._mapping.get(token.chain)!.set(addressString(token), value);
+    this._mapping
+      .get(token.chain)!
+      .set(addressString(token).toLowerCase(), value);
     this.lastUpdate = new Date();
     this.size += 1;
   }
@@ -214,7 +216,7 @@ export class TokenMapping<T> {
       typeof address === 'string' &&
       isChain(firstArg)
     ) {
-      return this._mapping.get(firstArg)?.get(address);
+      return this._mapping.get(firstArg)?.get(address.toLowerCase());
     } else if (firstArg instanceof TokenIdLazy) {
       // Doing the instanceof TokenIdLazy check before isTokenId() is important here for perf reasons.
       // All we need is the stringified address. TokenIdLazy is optimized for that.
@@ -225,16 +227,20 @@ export class TokenMapping<T> {
       // immediately re-stringifiy it.
       //
       // It's weird but it speeds up token cache operations a lot.
-      return this._mapping.get(firstArg.chain)?.get(firstArg.addressString);
+      return this._mapping
+        .get(firstArg.chain)
+        ?.get(firstArg.addressString.toLowerCase());
     } else if (isTokenId(firstArg)) {
       return this._mapping
         .get(firstArg.chain)
-        ?.get(firstArg.address.toString());
+        ?.get(firstArg.address.toString().toLowerCase());
     } else if (isTokenTuple(firstArg)) {
-      return this._mapping.get(firstArg[0])?.get(firstArg[1]);
+      return this._mapping.get(firstArg[0])?.get(firstArg[1].toLowerCase());
     } else {
       const tokenId = parseTokenKey(firstArg);
-      return this._mapping.get(tokenId.chain)?.get(addressString(tokenId));
+      return this._mapping
+        .get(tokenId.chain)
+        ?.get(addressString(tokenId).toLowerCase());
     }
   }
 
@@ -277,14 +283,6 @@ export class TokenMapping<T> {
   getAll(): T[] {
     return Array.from(this._mapping.values()).flatMap((chainMap) =>
       Array.from(chainMap.values()),
-    );
-  }
-
-  getAllTokenIds(): TokenId[] {
-    return Array.from(this._mapping.keys()).flatMap((chain) =>
-      Array.from(this._mapping.get(chain)!.keys()).map(
-        (address) => new TokenIdLazy(chain, address),
-      ),
     );
   }
 

--- a/wormhole-connect/src/contexts/TokensContext.tsx
+++ b/wormhole-connect/src/contexts/TokensContext.tsx
@@ -59,9 +59,7 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
   const [tokenPrices, _setTokenPrices] = useState<TokenMapping<TokenPrice>>(
     new TokenMapping(),
   );
-  const [tokenPricesToFetch, _setTokenPricesToFetch] = useState<
-    TokenMapping<boolean>
-  >(new TokenMapping());
+  const tokenPricesToFetch = React.useRef<Set<string>>(new Set());
 
   const [isFetchingTokenPrices, setIsFetchingPrices] = useState(false);
   const [lastTokenPriceUpdate, setLastPriceUpdate] = useState(new Date());
@@ -110,9 +108,11 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
   );
 
   const updateTokenPrices = useDebouncedCallback(async () => {
-    if (tokenPricesToFetch.empty) return;
+    if (tokenPricesToFetch.current.size === 0) return;
 
-    const tokens = tokenPricesToFetch.getAllTokenIds();
+    const tokens = config.tokens.getList(
+      Array.from(tokenPricesToFetch.current.values()),
+    );
     console.info('Fetching token prices', tokens);
 
     try {
@@ -126,10 +126,17 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
           price: undefined,
           isFetching: true,
         });
+        if (token.tokenBridgeOriginalTokenId !== undefined) {
+          tokenPrices.add(token.tokenBridgeOriginalTokenId, {
+            timestamp,
+            price: undefined,
+            isFetching: true,
+          });
+        }
       }
 
       // Clear list for future invocations of getTokenPrice
-      tokenPricesToFetch.clear();
+      tokenPricesToFetch.current.clear();
 
       const prices = await fetchTokenPrices(tokens);
 
@@ -140,11 +147,12 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
             timestamp,
             price,
           });
-        } else {
-          tokenPrices.add(token, {
-            timestamp,
-            price: undefined,
-          });
+          if (token.tokenBridgeOriginalTokenId !== undefined) {
+            tokenPrices.add(token.tokenBridgeOriginalTokenId, {
+              timestamp,
+              price,
+            });
+          }
         }
       }
     } catch (e) {
@@ -163,7 +171,7 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
     if (cachedPrice) {
       return cachedPrice.price;
     } else {
-      tokenPricesToFetch.add(tokenId, true);
+      tokenPricesToFetch.current.add(token.key);
       updateTokenPrices();
       return undefined;
     }

--- a/wormhole-connect/src/utils/coingecko.ts
+++ b/wormhole-connect/src/utils/coingecko.ts
@@ -116,7 +116,6 @@ export const fetchTokenPrices = async (
         params,
       )
         .then((data) => {
-          console.log(data);
           if (data['error'] !== undefined || data['error_code'] !== undefined) {
             reject(data['error']);
           } else {

--- a/wormhole-connect/src/utils/coingecko.ts
+++ b/wormhole-connect/src/utils/coingecko.ts
@@ -116,7 +116,8 @@ export const fetchTokenPrices = async (
         params,
       )
         .then((data) => {
-          if (data['error'] !== undefined) {
+          console.log(data);
+          if (data['error'] !== undefined || data['error_code'] !== undefined) {
             reject(data['error']);
           } else {
             resolve(
@@ -135,7 +136,7 @@ export const fetchTokenPrices = async (
                     }
                   } catch (e) {
                     // Error parsing address
-                    console.error(e);
+                    console.error('Coingecko error', e);
                     return null;
                   }
                 })

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -114,7 +114,7 @@ const TokenList = (props: Props) => {
       return 4;
     }
     // Native gas tokens are next
-    if (isNative(token.address)) {
+    if (isNative(token.addressString)) {
       return 3;
     }
     // USDC preferred next


### PR DESCRIPTION
- Lowercase token addresses when using them for TokenMapping keys
- Stop relying on the TokenMapping keys to be valid addresses; `TokenContext` needed some changes to accommodate