### PR TITLE
Fix/3448: Display "No routes found" message after wallet disconnect

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/index.tsx
@@ -232,7 +232,7 @@ const Bridge = () => {
     quotes,
     tokenSymbol: sourceToken?.symbol ?? '',
     isLoading: isFetchingBalances || isFetchingQuotes,
-    disabled: !sendingWallet.address || !sourceChain || !sourceToken,
+    disabled: !sourceChain || !sourceToken,
   });
 
   //useFetchTokenPrices(sourceToken ? [sourceToken.tokenId] : []);


### PR DESCRIPTION
When the wallet was disconnected, the `useAmountValidation` hook in the Bridge view was being disabled because the `disabled` prop included a check for `!sendingWallet.address`. This prevented the hook from evaluating the route finding status and displaying the "No routes found" message when applicable.

This change removes the `!sendingWallet.address` check from the `disabled` prop, allowing the validation to run and the "No routes found" message to be displayed correctly even when the wallet is disconnected.