### PR TITLE
Fix hydration error in wallet connect button

### DIFF
--- a/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/WalletConnector/index.tsx
@@ -1,7 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { useTheme } from '@mui/material/styles';
-import { useMediaQuery } from '@mui/material';
 import Tooltip from '@mui/material/Tooltip';
 import Typography from '@mui/material/Typography';
 
@@ -24,9 +22,6 @@ type Props = {
 const WalletConnector = (props: Props) => {
   const { disabled = false, type } = props;
 
-  const theme = useTheme();
-
-  const mobile = useMediaQuery(theme.breakpoints.down('sm'));
   const wallet = useSelector((state: RootState) => state.wallet[type]);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -73,13 +68,7 @@ const WalletConnector = (props: Props) => {
           onClick={() => connectWallet()}
         >
           <Typography textTransform="none">
-            {mobile
-              ? props.side === 'source'
-                ? 'Connect'
-                : 'Select wallet'
-              : `${props.side === 'source' ? 'Connect' : 'Select'} ${
-                  props.side
-                } wallet`}
+            {`Connect ${props.side} wallet`}
           </Typography>
         </Button>
       </span>
@@ -106,7 +95,7 @@ const WalletConnector = (props: Props) => {
         </>
       );
     }
-  }, [disabled, isOpen, mobile, props.side, props.type, connectWallet]);
+  }, [disabled, isOpen, props.side, props.type, connectWallet]);
 
   if (wallet && wallet.address) {
     return connected;


### PR DESCRIPTION
This removes code from the wallet connect button that changes the button text on mobile. Doing conditional rendering like this causes React hydration errors:

https://github.com/user-attachments/assets/fb2fac79-6ad8-4b06-a4ce-f6e54debc7cb

I noticed the button text always fits, even on iPhone SE viewport size, so it seems unnecessary to begin with.

![image](https://github.com/user-attachments/assets/901bdb9c-9b28-40e2-9250-dcbb73fce492)
