### PR TITLE
Add optional sourceToken parameter to isTokenSupportedHandler

### DIFF
--- a/wormhole-connect/src/config/types.ts
+++ b/wormhole-connect/src/config/types.ts
@@ -87,7 +87,10 @@ export type IsRouteSupportedHandler = (
   transferDetails: TransferDetails,
 ) => Promise<boolean>;
 
-export type IsTokenSupportedHandler = (token: Token) => boolean;
+export type IsTokenSupportedHandler = (
+  token: Token,
+  sourceToken?: Token, // The selected source token, if applicable
+) => boolean;
 
 // This is the integrator-provided config
 export interface WormholeConnectConfig {

--- a/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/wormhole-connect/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -253,9 +253,12 @@ const TokenList = (props: Props) => {
       );
     }
 
-    if (config.isTokenSupportedHandler) {
+    const isTokenSupportedHandler = config.isTokenSupportedHandler;
+    if (isTokenSupportedHandler) {
       // The last step is to filter the tokens by the integrator's token support handler
-      sorted = sorted.filter(config.isTokenSupportedHandler);
+      sorted = sorted.filter((token) =>
+        isTokenSupportedHandler(token, props.sourceToken),
+      );
     }
 
     if (props.isSource && props.wallet.address) {


### PR DESCRIPTION
Can be used to filter out the destination token given the source token.