### PR TITLE
Fix Tx History when no chain config is found for the API tx item

### DIFF
--- a/wormhole-connect/src/utils/index.ts
+++ b/wormhole-connect/src/utils/index.ts
@@ -257,8 +257,13 @@ export const getExplorerUrl = (
   chain: Chain,
   path: string,
   pathType: ExplorerPathType,
-) => {
-  const chainConfig = config.chains[chain]!;
+): string | undefined => {
+  const chainConfig = config.chains[chain];
+
+  if (!chainConfig?.explorerUrl) {
+    return undefined;
+  }
+
   const baseUrl = chainConfig.explorerUrl;
 
   switch (pathType) {

--- a/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/wormhole-connect/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -110,8 +110,12 @@ const TransactionDetails = () => {
                 {usdAmount}
                 {usdAmount ? separator : null}
                 {sourceChainConfig.displayName}
-                {separator}
-                <ExplorerLink url={explorerUrl} text={senderAddress} />
+                {explorerUrl ? (
+                  <>
+                    {separator}
+                    <ExplorerLink url={explorerUrl} text={senderAddress} />
+                  </>
+                ) : null}
               </>
             )}
           </Typography>
@@ -168,8 +172,12 @@ const TransactionDetails = () => {
                 {usdAmount}
                 {usdAmount ? separator : null}
                 {destChainConfig.displayName}
-                {separator}
-                <ExplorerLink url={explorerUrl} text={recipientAddress} />
+                {explorerUrl ? (
+                  <>
+                    {separator}
+                    <ExplorerLink url={explorerUrl} text={recipientAddress} />
+                  </>
+                ) : null}
               </>
             )}
           </Typography>
@@ -308,7 +316,11 @@ const TransactionDetails = () => {
         <CardContent>
           <Typography color={theme.palette.text.secondary} marginBottom="12px">
             {`Transaction #`}
-            <ExplorerLink url={explorerUrl} text={trimmedTx} />
+            {explorerUrl ? (
+              <ExplorerLink url={explorerUrl} text={trimmedTx} />
+            ) : (
+              trimmedTx
+            )}
           </Typography>
           {sentAmount}
           {verticalConnector}

--- a/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
+++ b/wormhole-connect/src/views/v2/TxHistory/Item/index.tsx
@@ -180,11 +180,12 @@ const TxHistoryItem = (props: Props) => {
   }, [senderTimestamp]);
 
   const chainExplorerLink = useMemo(() => {
-    return (
-      <ExplorerLink
-        url={getExplorerUrl(fromChain, txHash, 'tx')}
-        text={trimTxHash(txHash, 4, 4)}
-      />
+    const explorerUrl = getExplorerUrl(fromChain, txHash, 'tx');
+    const txHashTrimmed = trimTxHash(txHash, 4, 4);
+    return explorerUrl ? (
+      <ExplorerLink url={explorerUrl} text={txHashTrimmed} />
+    ) : (
+      txHashTrimmed
     );
   }, [fromChain, txHash]);
 


### PR DESCRIPTION
If the chain config not found, we will render the tx hash as text instead of a link.

<img width="482" alt="Screenshot 2025-06-03 at 9 01 28 PM" src="https://github.com/user-attachments/assets/8f4c2342-fa0c-447b-b19b-91f56446c267" />
