### PR TITLE
Change card bg color in dark theme

### DIFF
--- a/wormhole-connect/src/theme.ts
+++ b/wormhole-connect/src/theme.ts
@@ -168,7 +168,7 @@ export const dark: InternalTheme = {
     select: '#ffffff' + OPACITY[10],
   },
   card: {
-    background: '#ffffff' + OPACITY[5],
+    background: '#1b2033',
     secondary: '#ffffff' + OPACITY[5],
     elevation: 'none',
   },


### PR DESCRIPTION
We can't override the Card component's background via Portal's MUI theme. Connect has its own MUI theme and two are living side by side. That's why we are adding the intended color to Connect theme directly. 

Before:
<img width="474" alt="Screenshot 2025-06-04 at 10 36 38 PM" src="https://github.com/user-attachments/assets/c6ef0f8e-00cb-4237-93a5-bd76d10c87f5" />

After:
<img width="481" alt="Screenshot 2025-06-04 at 10 36 07 PM" src="https://github.com/user-attachments/assets/2eafd234-39cb-4912-b24b-5a525c9eb978" />
