### PR TITLE
build: update setup-node to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0