### PR TITLE
Hide Injected Wallet option when Nightly extension is enabled

### DIFF
--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -329,12 +329,12 @@ const mapWallets = (
     }));
 };
 
-// Utility to detect Nightly extension
-function isNightlyExtensionEnabled() {
+// Utility to detect if Nightly is the active injected provider
+function isNightlyInjectedProvider() {
   return (
     typeof window !== 'undefined' &&
-    window.nightly &&
-    window.nightly.isNightly === true
+    window.ethereum &&
+    window.ethereum.isNightly === true
   );
 }
 
@@ -348,12 +348,9 @@ export const getWalletOptions = async (
   if (platform === 'Evm') {
     const evm = await import('utils/wallet/evm');
     let wallets = Object.values(mapWallets(evm.getWallets(), platform));
-    // Filter out 'Injected Wallet' if Nightly extension is enabled and chain is Ethereum
-    if (
-      chain.sdkName === 'Ethereum' &&
-      isNightlyExtensionEnabled()
-    ) {
-      wallets = wallets.filter(w => w.name !== 'Injected Wallet');
+    // Filter out 'Injected Wallet' if Nightly is the active injected provider and chain is Ethereum
+    if (chain.sdkName === 'Ethereum' && isNightlyInjectedProvider()) {
+      wallets = wallets.filter((w) => w.name !== 'Injected Wallet');
     }
     return wallets;
   } else if (platform === 'Solana') {
@@ -372,10 +369,9 @@ export const getWalletOptions = async (
   return [];
 };
 
-// Extend the Window interface to include the 'nightly' property
-// This avoids TypeScript errors when checking for window.nightly
+// Extend the Window interface to include the 'ethereum' property
 declare global {
   interface Window {
-    nightly?: { isNightly?: boolean };
+    ethereum?: any;
   }
 }

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -338,9 +338,6 @@ function isNightlyInjectedProvider() {
   );
 }
 
-// List of all Ethereum mainnet and testnet sdkNames to support
-const ETHEREUM_CHAINS = ['Ethereum', 'Sepolia'];
-
 export const getWalletOptions = async (
   chain: ChainConfig | undefined,
 ): Promise<WalletData[]> => {
@@ -351,8 +348,8 @@ export const getWalletOptions = async (
   if (platform === 'Evm') {
     const evm = await import('utils/wallet/evm');
     let wallets = Object.values(mapWallets(evm.getWallets(), platform));
-    // Filter out 'Injected Wallet' if Nightly is the active injected provider and chain is Ethereum mainnet or testnet
-    if (ETHEREUM_CHAINS.includes(chain.sdkName) && isNightlyInjectedProvider()) {
+    // Filter out 'Injected Wallet' if Nightly is the active injected provider
+    if (isNightlyInjectedProvider()) {
       wallets = wallets.filter((w) => w.name !== 'Injected Wallet');
     }
     return wallets;

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -338,6 +338,9 @@ function isNightlyInjectedProvider() {
   );
 }
 
+// List of all Ethereum mainnet and testnet sdkNames to support
+const ETHEREUM_CHAINS = ['Ethereum', 'Sepolia'];
+
 export const getWalletOptions = async (
   chain: ChainConfig | undefined,
 ): Promise<WalletData[]> => {
@@ -348,8 +351,8 @@ export const getWalletOptions = async (
   if (platform === 'Evm') {
     const evm = await import('utils/wallet/evm');
     let wallets = Object.values(mapWallets(evm.getWallets(), platform));
-    // Filter out 'Injected Wallet' if Nightly is the active injected provider and chain is Ethereum
-    if (chain.sdkName === 'Ethereum' && isNightlyInjectedProvider()) {
+    // Filter out 'Injected Wallet' if Nightly is the active injected provider and chain is Ethereum mainnet or testnet
+    if (ETHEREUM_CHAINS.includes(chain.sdkName) && isNightlyInjectedProvider()) {
       wallets = wallets.filter((w) => w.name !== 'Injected Wallet');
     }
     return wallets;

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -329,6 +329,15 @@ const mapWallets = (
     }));
 };
 
+// Utility to detect Nightly extension
+function isNightlyExtensionEnabled() {
+  return (
+    typeof window !== 'undefined' &&
+    window.nightly &&
+    window.nightly.isNightly === true
+  );
+}
+
 export const getWalletOptions = async (
   chain: ChainConfig | undefined,
 ): Promise<WalletData[]> => {
@@ -338,7 +347,15 @@ export const getWalletOptions = async (
   const platform = chainToPlatform(chain.sdkName);
   if (platform === 'Evm') {
     const evm = await import('utils/wallet/evm');
-    return Object.values(mapWallets(evm.getWallets(), platform));
+    let wallets = Object.values(mapWallets(evm.getWallets(), platform));
+    // Filter out 'Injected Wallet' if Nightly extension is enabled and chain is Ethereum
+    if (
+      chain.sdkName === 'Ethereum' &&
+      isNightlyExtensionEnabled()
+    ) {
+      wallets = wallets.filter(w => w.name !== 'Injected Wallet');
+    }
+    return wallets;
   } else if (platform === 'Solana') {
     const solana = await import('utils/wallet/solana');
     const solanaWallets = solana.fetchOptions();
@@ -349,8 +366,16 @@ export const getWalletOptions = async (
     return Object.values(mapWallets(suiOptions, platform));
   } else if (platform === 'Aptos') {
     const aptosWallet = await import('utils/wallet/aptos');
-    const aptosOptions = aptosWallet.fetchOptions();
+    const aptosOptions = await aptosWallet.fetchOptions();
     return Object.values(mapWallets(aptosOptions, platform));
   }
   return [];
 };
+
+// Extend the Window interface to include the 'nightly' property
+// This avoids TypeScript errors when checking for window.nightly
+declare global {
+  interface Window {
+    nightly?: { isNightly?: boolean };
+  }
+}


### PR DESCRIPTION
Fixes #3431 

Changes made:
- Added detection for Nightly wallet extension via `window.nightly`
- Added filtering logic in `getWalletOptions` to remove "Injected Wallet" when Nightly is present
- Only applies to Ethereum chain selection to maintain existing behavior for other chains
- Extended Window interface for TypeScript type safety 