### PR TITLE
Move empty tokensToFetch check to where we need it

### DIFF
--- a/src/hooks/useGetTokenBalances.ts
+++ b/src/hooks/useGetTokenBalances.ts
@@ -240,10 +240,6 @@ const useGetTokenBalances = ({
         }
       }
 
-      if (tokensToFetch.length === 0) {
-        return updatedBalances;
-      }
-
       // Fetch balances
       const wh = await getWormholeContextV2();
       const platformName = chainToPlatform(chain);
@@ -275,6 +271,10 @@ const useGetTokenBalances = ({
             // Fall through to individual fetching
           }
         }
+      }
+
+      if (tokensToFetch.length === 0) {
+        return updatedBalances;
       }
 
       // Fallback to individual token fetching

--- a/src/views/v2/Bridge/index.tsx
+++ b/src/views/v2/Bridge/index.tsx
@@ -272,7 +272,7 @@ const Bridge = () => {
       return {
         chain: destChain,
         wallet: receivingWallet,
-        tokens: supportedDestTokens,
+        tokens: config.tokens.getAllForChain(destChain),
       };
     }
     return undefined;


### PR DESCRIPTION
This fixes a bug where, if you select the chains first without a source token, the destination balances fail to load. This was because the computed destination tokens list is empty, and this code was preventing us from hitting the indexer for no reason (it doesn't require `tokensToFetch`).

I also changed `Bridge/index.ts` to just pass in all known destination tokens to the balances list, so that even in the fallback behavior (fetching each one individually) we just preemptively fetch all their balances.