### PR TITLE
Remove redundant search query state

### DIFF
--- a/src/views/v2/Bridge/AssetPicker/ChainList.tsx
+++ b/src/views/v2/Bridge/AssetPicker/ChainList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTheme } from '@mui/material/styles';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -31,6 +31,7 @@ const SHORT_LIST_SIZE = 5;
 
 const ChainList = (props: Props) => {
   const theme = useTheme();
+  const [chainSearchQuery, setChainSearchQuery] = useState('');
 
   const styles = useMemo(
     () => ({
@@ -175,6 +176,8 @@ const ChainList = (props: Props) => {
         searchPlaceholder="Search for a chain"
         sx={styles.chainSearch}
         items={chainList ?? []}
+        searchQuery={chainSearchQuery}
+        onQueryChange={setChainSearchQuery}
         filterFn={(chain, query) =>
           !query ||
           chain.displayName.toLowerCase().includes(query.toLowerCase())
@@ -201,6 +204,7 @@ const ChainList = (props: Props) => {
     ),
     [
       chainList,
+      chainSearchQuery,
       styles.chainItem,
       styles.chainSearch,
       onChainSelect,

--- a/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/SearchableList/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState, ReactNode, useMemo } from 'react';
+import React, { memo, ReactNode, useMemo } from 'react';
 
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
@@ -18,12 +18,12 @@ type SearchableListProps<T> = {
   sx?: SxProps<Theme>;
   renderFn: (item: T, index: number) => ReactNode;
   filterFn: (item: T, query: string) => boolean;
-  onQueryChange?: (query: string) => void;
+  onQueryChange: (query: string) => void;
+  searchQuery: string;
 };
 
 function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
   const scrollbarStyles = useCustomScrollbar();
-  const [query, setQuery] = useState('');
 
   const styles = {
     wrapper: {
@@ -38,11 +38,11 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
     },
   };
 
-  const { items, filterFn } = props;
+  const { items, filterFn, searchQuery } = props;
 
   const filteredList = useMemo(() => {
-    return items.filter((item) => filterFn(item, query));
-  }, [items, filterFn, query]);
+    return items.filter((item) => filterFn(item, searchQuery));
+  }, [items, filterFn, searchQuery]);
 
   return (
     <Box
@@ -51,14 +51,9 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
     >
       {props.title}
       <SearchInput
-        value={query}
+        value={props.searchQuery}
         dataTestId={props.dataTestId}
-        onChange={(val: string) => {
-          setQuery(val);
-          if (props.onQueryChange) {
-            props.onQueryChange(val);
-          }
-        }}
+        onChange={props.onQueryChange}
         placeholder={props.searchPlaceholder}
       />
       <List

--- a/src/views/v2/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v2/Bridge/AssetPicker/TokenList.tsx
@@ -175,6 +175,7 @@ const TokenList = (props: Props) => {
       searchPlaceholder={placeholder}
       sx={styles.tokenList}
       dataTestId="token-search-list"
+      searchQuery={props.searchQuery}
       listTitle={
         shouldShowEmptyMessage ? (
           emptyMessage

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -271,6 +271,7 @@ const AssetPicker = (props: Props) => {
             wallet={props.wallet}
             onChainSelect={(key) => {
               props.setChain(key);
+              setSearchQuery('');
             }}
           />
           {!showChainSearch && chainConfig && (

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -322,6 +322,7 @@ const AssetPicker = (props: Props) => {
             wallet={props.wallet}
             onChainSelect={(key) => {
               props.setChain(key);
+              setSearchQuery('');
             }}
           />
           {!showChainSearch && chainConfig && (


### PR DESCRIPTION
Right now, there are two state variables for the AssetPicker search query. This is causing bugs where we have phantom search query state that the UI isn't showing.

This change removes the state var in `SearchableList` and makes it a controlled input via prop. Changes apply to both `AssetPicker` and `ChainList` (both of them use `SearchableList`).