### PR TITLE
fix: rename KLAY symbol to KAIA

### DIFF
--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -111,7 +111,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerUrl: 'https://kaiascope.com/',
     explorerName: 'Kaia Scope',
     icon: 'Klaytn',
-    symbol: 'KLAY',
+    symbol: 'KAIA',
   },
   Scroll: {
     displayName: 'Scroll',

--- a/src/config/mainnet/tokens.ts
+++ b/src/config/mainnet/tokens.ts
@@ -455,7 +455,7 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.WSTETH,
   },
   {
-    symbol: 'KLAY',
+    symbol: 'KAIA',
     decimals: 18,
     icon: TokenIcon.KLAY,
     tokenId: { chain: 'Klaytn', address: 'native' },

--- a/src/config/testnet/chains.ts
+++ b/src/config/testnet/chains.ts
@@ -70,7 +70,7 @@ export const TESTNET_CHAINS: ChainsConfig = {
     explorerUrl: 'https://kairos.kaiascope.com/',
     explorerName: 'Kaia Scope',
     icon: 'Klaytn',
-    symbol: 'KLAY',
+    symbol: 'KAIA',
     sdkName: 'Klaytn',
   },
   Sepolia: {

--- a/src/config/testnet/tokens.ts
+++ b/src/config/testnet/tokens.ts
@@ -145,7 +145,7 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.USDC,
   },
   {
-    symbol: 'KLAY',
+    symbol: 'KAIA',
     icon: TokenIcon.KLAY,
     decimals: 18,
     tokenId: { chain: 'Klaytn', address: 'native' },


### PR DESCRIPTION
This PR updates the display name of the Klaytn chain from **KLAY** to **KAIA** in Wormhole Connect.

**Context:**
Kaia is the rebranded name of the Klaytn blockchain, and the display symbol should reflect this change for consistency with the updated ecosystem branding.

**Changes:**
- Updated the chain symbol name from `KLAY` to `KAIA` in the `chains.ts`, `tokens.ts` files.

![스크린샷 2025-06-16 오후 6 25 29](https://github.com/user-attachments/assets/916f9834-30e0-4f0f-98e4-216698b3027e)

Let me know if any additional updates are required.