### PR TITLE
Remove unnecessary hook dep

### DIFF
--- a/src/hooks/useGetTokenBalances.ts
+++ b/src/hooks/useGetTokenBalances.ts
@@ -402,7 +402,6 @@ const useGetTokenBalances = ({
     source?.wallet?.address,
     destination?.chain,
     destination?.wallet?.address,
-    fetchBalancesForChain,
   ]);
 
   // Extract results for source and destination


### PR DESCRIPTION
The hook that calls `fetchBalancesForChain` unnecessarily depends on this dep `fetchBalancesForChain` which causes it to call `fetchBalancesForChain` way too many times.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/65e7a5ee-e1bf-4baf-a42a-dd522d0bfb2a" />
