### PR TITLE
Add NTT token price fallback mechanism

### DIFF
--- a/src/contexts/TokensContext.tsx
+++ b/src/contexts/TokensContext.tsx
@@ -18,6 +18,7 @@ import React, {
 import { fetchTokenPrices } from 'utils/coingecko';
 import { useDebouncedCallback } from 'use-debounce';
 import { getAddress } from 'ethers';
+import { isNttToken, getNttTokenGroup } from 'utils/ntt';
 
 interface TokensContextType {
   getOrFetchToken: (tokenId: TokenId) => Promise<Token | undefined>;
@@ -135,6 +136,49 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
     [priceState.prices],
   );
 
+  // Helper function to apply NTT fallback prices
+  const applyNttFallbackPrices = useCallback(
+    (
+      tokens: Token[],
+      updatedPrices: TokenMapping<TokenPrice>,
+      fetchedPrices: TokenMapping<number> | undefined,
+      timestamp: Date,
+    ) => {
+      for (const token of tokens) {
+        const cachedPrice = updatedPrices.get(token);
+
+        // If token still doesn't have a price and is an NTT token
+        if (!cachedPrice?.price && isNttToken(token)) {
+          const alternativeTokens = getNttTokenGroup(token);
+
+          // Check if any alternative tokens have prices
+          for (const altToken of alternativeTokens) {
+            // Check both fetched prices and updated cache
+            let altPrice = fetchedPrices?.get(altToken);
+            if (!altPrice) {
+              const altCachedPrice = updatedPrices.get(altToken);
+              altPrice = altCachedPrice?.price;
+            }
+
+            if (altPrice !== undefined) {
+              console.debug(
+                `Using price from ${altToken.symbol} on ${altToken.chain} as fallback for ${token.symbol} on ${token.chain}`,
+              );
+
+              // Cache the fallback price for the original token
+              updatedPrices.add(token, {
+                timestamp,
+                price: altPrice,
+              });
+              break;
+            }
+          }
+        }
+      }
+    },
+    [],
+  );
+
   // Debounced function to batch fetch token prices
   const debouncedFetchPrices = useDebouncedCallback(async () => {
     if (tokensToFetch.current.size === 0) return;
@@ -178,6 +222,9 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
           tokensFetching.current.delete(tokenKey(tokenId));
         }
 
+        // Handle NTT fallback prices for tokens that still don't have prices
+        applyNttFallbackPrices(tokens, updatedPrices, prices, timestamp);
+
         return {
           prices: updatedPrices,
           isFetching: false,
@@ -204,6 +251,9 @@ export const TokensProvider: React.FC<TokensProviderProps> = ({ children }) => {
 
           tokensFetching.current.delete(tokenKey(tokenId));
         }
+
+        // Even on error, try NTT fallback using existing cached prices
+        applyNttFallbackPrices(tokens, updatedPrices, undefined, timestamp);
 
         return {
           prices: updatedPrices,

--- a/src/utils/ntt.ts
+++ b/src/utils/ntt.ts
@@ -1,33 +1,91 @@
 import { Chain, TokenId } from '@wormhole-foundation/sdk';
 import config from 'config';
-import { addressString } from 'config/tokens';
+import { Token, addressString } from 'config/tokens';
+
+export const nttRoutes = [
+  'ManualNtt',
+  'AutomaticNtt',
+  'M0AutomaticRoute',
+  'NttExecutorRoute',
+] as const;
+
+interface NttTokenOption {
+  chain: Chain;
+  token: string;
+}
+
+type NttTokensConfig = Record<string, NttTokenOption[]>;
+
+export const getNttTokens = (
+  routeName: string,
+): NttTokensConfig | undefined => {
+  const route = config.routes.get(routeName);
+  if (!route) return undefined;
+
+  const routeConfig = (route.rc as any).config;
+  if (!routeConfig) return undefined;
+
+  // NttExecutorRoute has a different structure
+  if (routeName === 'NttExecutorRoute') {
+    return routeConfig.ntt?.tokens;
+  }
+
+  return routeConfig.tokens;
+};
 
 export const isNttToken = (tokenId: TokenId): boolean => {
-  return (
-    ['ManualNtt', 'AutomaticNtt', 'M0AutomaticRoute', 'NttExecutorRoute']
-      .map((rn) => {
-        const route = config.routes.get(rn);
-        if (route) {
-          const nttConfig = (route.rc as any).config;
-          if (nttConfig) {
-            for (const key in nttConfig.tokens) {
-              const options: { chain: Chain; token: string }[] = nttConfig[key];
+  const tokenAddress = addressString(tokenId);
 
-              if (options) {
-                for (const opt of options) {
-                  if (
-                    opt.chain === tokenId.chain &&
-                    opt.token === addressString(tokenId)
-                  ) {
-                    return true;
-                  }
-                }
-              }
+  for (const routeName of nttRoutes) {
+    const nttTokens = getNttTokens(routeName);
+    if (!nttTokens) continue;
+
+    for (const tokenKey in nttTokens) {
+      const options = nttTokens[tokenKey];
+      if (!options) continue;
+
+      const hasToken = options.some(
+        (opt) => opt.chain === tokenId.chain && opt.token === tokenAddress,
+      );
+
+      if (hasToken) return true;
+    }
+  }
+
+  return false;
+};
+
+export const getNttTokenGroup = (tokenId: TokenId): Token[] => {
+  const alternativeTokens: Token[] = [];
+  const tokenAddress = addressString(tokenId);
+
+  for (const routeName of nttRoutes) {
+    const nttTokens = getNttTokens(routeName);
+    if (!nttTokens) continue;
+
+    for (const tokenKey in nttTokens) {
+      const options = nttTokens[tokenKey];
+      if (!options) continue;
+
+      const isInGroup = options.some(
+        (opt) => opt.chain === tokenId.chain && opt.token === tokenAddress,
+      );
+
+      if (isInGroup) {
+        // Add all tokens from this group (except the original)
+        for (const opt of options) {
+          if (opt.chain !== tokenId.chain || opt.token !== tokenAddress) {
+            const token = config.tokens.get(opt.chain, opt.token);
+            if (token) {
+              alternativeTokens.push(token);
             }
           }
         }
-        return false;
-      })
-      .find((r) => r) !== undefined
-  );
+        // We found the group, no need to check other routes
+        return alternativeTokens;
+      }
+    }
+  }
+
+  return alternativeTokens;
 };


### PR DESCRIPTION
When transferring NTT tokens, if the price for the source token is unavailable, the system now falls back to using prices from other tokens in the same NTT configuration group. This ensures better USD value estimation for transfers involving NTT tokens with limited price data.

- Add getNttTokenGroup() to find alternative tokens in the same NTT config
- Update getTokenPrice() to implement fallback logic for NTT tokens
- Extract nttRoutes constant for better code reuse