### PR TITLE
evm wallets: wagmi store existing wallet connections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@wormhole-labs/cctp-executor-route": "0.11.0",
         "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
         "@wormhole-labs/wallet-aggregator-core": "0.0.1",
-        "@wormhole-labs/wallet-aggregator-evm": "0.3.0",
+        "@wormhole-labs/wallet-aggregator-evm": "0.3.1",
         "@wormhole-labs/wallet-aggregator-solana": "0.0.1",
         "@wormhole-labs/wallet-aggregator-sui": "0.0.1",
         "axios": "1.4.0",
@@ -15922,9 +15922,9 @@
       }
     },
     "node_modules/@wormhole-labs/wallet-aggregator-evm": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-labs/wallet-aggregator-evm/-/wallet-aggregator-evm-0.3.0.tgz",
-      "integrity": "sha512-1jZpoxrBVgIEOXjv+6JMkQ1iiz7I1yoQJLOmYPO9H8seImwN6+j7cyBwfB9BJAovVw2qUlG+TsGYOCkCzURH7g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@wormhole-labs/wallet-aggregator-evm/-/wallet-aggregator-evm-0.3.1.tgz",
+      "integrity": "sha512-441ttaz7PIN19x9P9+qPUt7FeRI9ou/4bOavdE/P3BTzq4gQBAg4yeKTokDMePXPmYffSI2L857B1V3hIHE78A==",
       "license": "MIT",
       "dependencies": {
         "@wagmi/connectors": "^5.8.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@wormhole-labs/cctp-executor-route": "0.11.0",
     "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
     "@wormhole-labs/wallet-aggregator-core": "0.0.1",
-    "@wormhole-labs/wallet-aggregator-evm": "0.3.0",
+    "@wormhole-labs/wallet-aggregator-evm": "0.3.1",
     "@wormhole-labs/wallet-aggregator-solana": "0.0.1",
     "@wormhole-labs/wallet-aggregator-sui": "0.0.1",
     "axios": "1.4.0",


### PR DESCRIPTION
Fixes an issue where switching chains causes the connected wallet to ask the user permission to re-connect itself.