### PR TITLE
chore: Remove Portico route

### DIFF
--- a/src/components/SampleApp/index.tsx
+++ b/src/components/SampleApp/index.tsx
@@ -69,8 +69,6 @@ const parseConfig = (config: string): WormholeConnectConfig => {
       /* @ts-ignore */
       window.CCTPRoute = routes.CCTPRoute;
       /* @ts-ignore */
-      window.AutomaticPorticoRoute = routes.AutomaticPorticoRoute;
-      /* @ts-ignore */
       window.TBTCRoute = routes.TBTCRoute;
       /* @ts-ignore */
       window.MayanRoute = MayanRoute;
@@ -263,10 +261,6 @@ function SampleApp() {
                   </li>
                   <li>
                     <pre>CCTPRoute</pre>
-                    <i>{'RouteConstructor'}</i>
-                  </li>
-                  <li>
-                    <pre>AutomaticPorticoRoute</pre>
                     <i>{'RouteConstructor'}</i>
                   </li>
                   <li>

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -20,7 +20,6 @@ const {
   TokenBridgeRoute,
   AutomaticCCTPRoute,
   CCTPRoute,
-  AutomaticPorticoRoute,
 } = routes;
 
 export default WormholeConnect;
@@ -42,7 +41,6 @@ export {
   TokenBridgeRoute,
   AutomaticCCTPRoute,
   CCTPRoute,
-  AutomaticPorticoRoute,
 };
 
 export * from 'telemetry';

--- a/src/routes/operator.ts
+++ b/src/routes/operator.ts
@@ -28,7 +28,6 @@ export const DEFAULT_ROUTES = [
   routes.CCTPRoute,
   routes.AutomaticTokenBridgeRoute,
   routes.TokenBridgeRoute,
-  routes.AutomaticPorticoRoute,
   routes.TBTCRoute,
 ];
 


### PR DESCRIPTION
## Summary

This PR removes the Portico token transfer route (ETH Bridge, wstETH Bridge, USDT Bridge) from Wormhole Connect while preserving the ability to display historical Portico transactions.

## Changes

### 🚫 Route Removal
  - Removed `AutomaticPorticoRoute` from `DEFAULT_ROUTES` in [`src/routes/operator.ts`](src/routes/operator.ts)
  - Removed `AutomaticPorticoRoute` from exports in [`src/exports/index.ts`](src/exports/index.ts)
  - Removed Portico route from sample app window assignments and documentation in [`src/components/SampleApp/index.tsx`](src/components/SampleApp/index.tsx)

### ✅ Historical Transaction Support
  - **Preserved** all Portico parsing logic in [`src/hooks/useTransactionHistoryWHScan.ts`](src/hooks/useTransactionHistoryWHScan.ts)
    - Kept `WormholeScanPorticoParsedPayload` interface
    - Kept `parsePorticoTx` function
    - Kept ETH_BRIDGE and USDT_BRIDGE transaction handlers
    - Maintained all necessary imports for parsing

## Rationale

This approach differs from the upstream draft PR #3384 by maintaining historical transaction parsing capabilities. This ensures:
  - Users cannot initiate new Portico transfers (route is disabled)
  - Existing Portico transactions continue to display properly in transaction history
  - Better user experience with backwards compatibility

## Testing

  - [x] Verified Portico route no longer appears in available routes
  - [x] Confirmed historical Portico transactions can still be parsed
  - [x] Linting passes with no errors related to these changes

## Related

  - References upstream PR: #3384
  - Addresses the concern raised about historical transaction visibility

## Breaking Changes

  - **Yes** - The Portico route is no longer available for new transfers
  - Historical transactions remain viewable (non-breaking for transaction history)