### PR TITLE
feat: Add SeiEVM CCTPv2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,8 +25,8 @@
         "@reduxjs/toolkit": "^2.5.1",
         "@solana/spl-token": "0.4.0",
         "@solana/wallet-adapter-wallets": "0.19.32",
-        "@wormhole-foundation/sdk": "3.0.1",
-        "@wormhole-foundation/sdk-definitions": "3.0.1",
+        "@wormhole-foundation/sdk": "3.0.3",
+        "@wormhole-foundation/sdk-definitions": "3.0.3",
         "@wormhole-foundation/sdk-definitions-ntt": "1.0.4",
         "@wormhole-foundation/sdk-evm-ntt": "1.0.4",
         "@wormhole-foundation/sdk-icons": "^1.0.4",
@@ -15115,52 +15115,52 @@
       "license": "0BSD"
     },
     "node_modules/@wormhole-foundation/sdk": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.0.1.tgz",
-      "integrity": "sha512-M+Lpivmb/tpn6LsfXDSg2zDnYYX3fCEEfZ9kdxey3Odw9SYd5gZx3INftT3GgBv77MMlD1sFcMaxndzCVY8+Pw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk/-/sdk-3.0.3.tgz",
+      "integrity": "sha512-OSlB5ZGPnb1odwFEzFL7oVsYM3scqg97UGLf5+52vOng6vK42J7tFUasXOKMYVY/HfwA6teqWGF/bVpJmepWvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.1",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.1",
-        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.0.1",
-        "@wormhole-foundation/sdk-aptos": "3.0.1",
-        "@wormhole-foundation/sdk-aptos-cctp": "3.0.1",
-        "@wormhole-foundation/sdk-aptos-core": "3.0.1",
-        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.0.1",
-        "@wormhole-foundation/sdk-base": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.0.1",
-        "@wormhole-foundation/sdk-definitions": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
-        "@wormhole-foundation/sdk-evm-cctp": "3.0.1",
-        "@wormhole-foundation/sdk-evm-core": "3.0.1",
-        "@wormhole-foundation/sdk-evm-portico": "3.0.1",
-        "@wormhole-foundation/sdk-evm-tbtc": "3.0.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.1",
-        "@wormhole-foundation/sdk-solana": "3.0.1",
-        "@wormhole-foundation/sdk-solana-cctp": "3.0.1",
-        "@wormhole-foundation/sdk-solana-core": "3.0.1",
-        "@wormhole-foundation/sdk-solana-tbtc": "3.0.1",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.1",
-        "@wormhole-foundation/sdk-sui": "3.0.1",
-        "@wormhole-foundation/sdk-sui-cctp": "3.0.1",
-        "@wormhole-foundation/sdk-sui-core": "3.0.1",
-        "@wormhole-foundation/sdk-sui-tokenbridge": "3.0.1"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-core": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-core": "3.0.3",
+        "@wormhole-foundation/sdk-aptos-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-base": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-ibc": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-definitions": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
+        "@wormhole-foundation/sdk-evm-portico": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tbtc": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tbtc": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3",
+        "@wormhole-foundation/sdk-sui-cctp": "3.0.3",
+        "@wormhole-foundation/sdk-sui-core": "3.0.3",
+        "@wormhole-foundation/sdk-sui-tokenbridge": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.0.1.tgz",
-      "integrity": "sha512-z67IBD/Wb1AcRfDYA9hlOdxIsJVhha3eP41oipT+TBorXWxXadsx9BIl77OVFaZEuWgDAN20TfDCiaRBtEN/NQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand/-/sdk-algorand-3.0.3.tgz",
+      "integrity": "sha512-tCjKvGgwW/aFkQ5gETKMjbcKtQ6uC2eVtL3DxVO+c67WFn7AayBfljr+kXAksaKVdc8hFwSWZAk5FkpAVI1CvA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "algosdk": "2.7.0"
       },
       "engines": {
@@ -15168,89 +15168,89 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.0.1.tgz",
-      "integrity": "sha512-fTHFp3P0TXqrb7YJbaR+DDAKtnhltbk/8FmHrvWVuQXSNLoW0tT2TUoEEreUa4vZI0cR6tYVQB4ma88sYx3Rfg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-core/-/sdk-algorand-core-3.0.3.tgz",
+      "integrity": "sha512-j/7SJfkr5KTWE1Nr9y46Ef3bALPU8fHDh7UwnRv4Jo76n5HBqf2HibThwmjKS1+kCBk4OGnS6W5QULLKb3Psgw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-algorand-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-0Tzl5vz8KRttoeRTfqXTDf0vjd+HMz7ET5C9QNKjs/ta7C5K/ynx7sj2dFuPzFQcUnFvcJLp9hAC33Gk3prW1A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-algorand-tokenbridge/-/sdk-algorand-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-kQi3eyPqnK+HQS8shWiahx6DyTvUtohq+lOiGd/Cy+Altq+P4wHPnA9j/LgxGmqi/6CPP/YyTqkLXp7iIW2w/Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-algorand": "3.0.1",
-        "@wormhole-foundation/sdk-algorand-core": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-algorand": "3.0.3",
+        "@wormhole-foundation/sdk-algorand-core": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.0.1.tgz",
-      "integrity": "sha512-JzCZ5SLt59XpVCV/t5y3oJD2KDq/yzMDO2likZX8IFE//9a8FQF/7vEzS5KtzCMB5rLN5i4ylfhjmaA2FA2H4A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos/-/sdk-aptos-3.0.3.tgz",
+      "integrity": "sha512-2f1w3O6b3cufZKVa0R+zSLehejb3b4D+7q1m2Wgp2134pbxSOIGMwqBXeA4/8yNnLNnZPGUfoOt5hKKi/aEVZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-cctp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.0.1.tgz",
-      "integrity": "sha512-RGVygWHiNvCtulCj0lqkJo2zF+UnMhdFrtndFcVUqvlGvrOLOrDTPIPu+VAgNFTqoFdGlTgOb6wCDA5tLvB5QQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-cctp/-/sdk-aptos-cctp-3.0.3.tgz",
+      "integrity": "sha512-noOD9pEe2hKEWydAPjfbYrrrN2Z9b5cHwP5Kaq/sx/TIbCFsYhXrCZZ4thzHKrJnaDUVdA/NLSsWAwBRif8ifw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",
-        "@wormhole-foundation/sdk-aptos": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.0.1.tgz",
-      "integrity": "sha512-FCbfCykZrapeQ6cvdVcvcZNdoghT5Js0PEFvm8PU+FTfd5gQVMJKtIql6aEmxYgVwYz52mp4lvs6R0inIWxOBQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-core/-/sdk-aptos-core-3.0.3.tgz",
+      "integrity": "sha512-ISh5+ACSw9x83BaJO/O68Y1G/DnfryCrTzQde2saJLlMJWt07Jj/WSq478cVwvDgjN0hRg04vMieVW0+2SGWdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-aptos-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-49fW1zXNRm7r5JCerrXTfxLjzlqimp7DlMdCFUYwrcHoLSiAxsB6rAgO0UcfIOODNsQaSYhvfPPqeiVwFFqUrQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-aptos-tokenbridge/-/sdk-aptos-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-KYhBwMMoe6QW0TSJEhzy8hM7shLqeeNbar17pRrzUtDzBZ++CJxaA5363tRxb1GgOG+NVkv2p+78yqlGSCPa3A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-aptos": "3.0.1",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-aptos": "3.0.3",
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-base": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.0.1.tgz",
-      "integrity": "sha512-N8JewWtsGueth9u2hcDvIK3gBmmLZmerzQ4fyJ0F1Cp31RUilppyjg5a8yaJMprRSzBFFEYuigOoGS9nVBeg4A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-base/-/sdk-base-3.0.3.tgz",
+      "integrity": "sha512-Q+1Wgle6nQeO5AhaPYaTkcX+Jj1FzBm1XyqYeUfbv7ERbZrmpPa5XdtXBSbw8tNMv6u375BRO+hZkbI6JPKqNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scure/base": "^1.1.3",
@@ -15258,13 +15258,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-connect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.0.1.tgz",
-      "integrity": "sha512-4+e5k8S+olhnjE5YVcJ74x3jFqUawCHYx+IoHSLp2zqElXbKeQnMcRJwANXRG1+gQl9rROE2BZBQvCcFYAG4Tw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-connect/-/sdk-connect-3.0.3.tgz",
+      "integrity": "sha512-/UJ3+TaCHaT2cydkrM0mZX/OJIN86RGQeNmEphvuqwdrUKjv4RCii6mQf7eHHKzOLrXoHjGfiq5GmDUAcDrIDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-base": "3.0.1",
-        "@wormhole-foundation/sdk-definitions": "3.0.1",
+        "@wormhole-foundation/sdk-base": "3.0.3",
+        "@wormhole-foundation/sdk-definitions": "3.0.3",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -15272,16 +15272,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.0.1.tgz",
-      "integrity": "sha512-hP1zIMBklnK35y87t5OS4D3rDBEEyuWnnaGpJWPyrZpiN9TXnke+E40KyVnIG2o7ImCIY0uH6qlX+xdRDOK6Bg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm/-/sdk-cosmwasm-3.0.3.tgz",
+      "integrity": "sha512-SzZpagvIl5UjsLrEAI4uW5EeAlLllRTJyq4GEALDhQKgB6NhXLlVThWYvrGA0WrFxt9Lbv9Jg6Pbc1NDnVSfSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/proto-signing": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -15289,33 +15289,33 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.0.1.tgz",
-      "integrity": "sha512-lJ3rAMiuaNnS2saZp/V6TtiKl1tfVV6rag9xiBddsAlb5CMCcJLnjnzL64KneiBQMS98guF/HKzH+XLmH/JX+A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-core/-/sdk-cosmwasm-core-3.0.3.tgz",
+      "integrity": "sha512-JK7rC1poKHelWP9BiYqEP45cwlXSSZSAqO6imUjQL5gNKg5zb43sCmJX02W3pX8tzcDM0v3cIlb6BGnL3Qf/DA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-ibc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.0.1.tgz",
-      "integrity": "sha512-GN4E2LFqKh1WdtOfVeXSu6vm7QJFjPNTjAhV5xohdKENrfI9KLTppgs7XFD/XrZ2iEoDLhzvXeLKbji5zq/RQw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-ibc/-/sdk-cosmwasm-ibc-3.0.3.tgz",
+      "integrity": "sha512-6JDw+/td9AQKrKDp5MdDFiny5xkvCAcq4LS/GeFZdchA3Id3p7XDXkJaaGPxApDe4iij6UdFFo7coayPJixUBQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@cosmjs/stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm-core": "3.0.3",
         "cosmjs-types": "^0.9.0"
       },
       "engines": {
@@ -15323,28 +15323,28 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-cosmwasm-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-XCWaDZnF6vn70ZDMlfHaOtDymExdOma6pNNnr3qqgbDaqFfLmdNO1VbV/tBMz8ZbWPOacQdni1gQ4HsoYvbqIw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-cosmwasm-tokenbridge/-/sdk-cosmwasm-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-IqXb3Yw5q7JwJbwa9BE7z5k2HGLLgtHt1K7T3pCCbyo5cu9MdrPV4PGdhPRp4PQTyRW4+A93kUYhEccI799Uig==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "^0.32.0",
         "@injectivelabs/sdk-ts": "^1.14.13-beta.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-cosmwasm": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-cosmwasm": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.0.1.tgz",
-      "integrity": "sha512-//dBH2DXi/tr0dC6dzsQ+ZV393Mzd4SXv3xSw77Lx65aWkkqgvujZL8AcjbAu/d380dHRVmKmR5PXuI9Wyz9CQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-definitions/-/sdk-definitions-3.0.3.tgz",
+      "integrity": "sha512-mwbr4il7ZK4zInAWtSQg+5/BJOZ+FcmeOw49N4EAAFCgIHLQ4KqWBt/9SThp5B/rsbFjmfGR6515m8rCuZE37g==",
       "dependencies": {
         "@noble/curves": "^1.4.0",
         "@noble/hashes": "^1.3.1",
-        "@wormhole-foundation/sdk-base": "3.0.1"
+        "@wormhole-foundation/sdk-base": "3.0.3"
       }
     },
     "node_modules/@wormhole-foundation/sdk-definitions-ntt": {
@@ -15357,12 +15357,12 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.0.1.tgz",
-      "integrity": "sha512-aIXTNaT8A7obfdvOGZ7HZKFSWYyYeVA07tJd/ST/NR0TbZXLGePRIylOquWhv+3LWDkKeWwQaXcXaxcOu3D+sg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm/-/sdk-evm-3.0.3.tgz",
+      "integrity": "sha512-7598LdmIy/fbMzBEQORZfb1nviI3mL8S20w8JJLcnuE9PrzFJ0q8uNHzW5DmT0SdLvvBAWQEQHvunOY251b3AQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15370,14 +15370,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-cctp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.0.1.tgz",
-      "integrity": "sha512-jHT1kS6eTpd76opb6nDPKVP/gdgtoFIqRq3DP/IcHFieYGvCYy2AEbunrSM5A0C4LkT9BX1WL0O53fSQLq1nGQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-cctp/-/sdk-evm-cctp-3.0.3.tgz",
+      "integrity": "sha512-dkmAd4xrJuIliHiUUGCpqyQMd7XyQ7Mu7Qq+S+4N40pIk8qe7hSvzqktI+Pz0Da5Vxo/+gd1+L+dKmZTZggZqg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
-        "@wormhole-foundation/sdk-evm-core": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15385,13 +15385,13 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.0.1.tgz",
-      "integrity": "sha512-kogw7GV9jz7l6AZTPTDd4FtmHQy/VFUbX5U+9SBXiQ+9nUKcGVjLSd4YFofWsbwwzhX0VT4GRmZSi3kpgzUW3w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-core/-/sdk-evm-core-3.0.3.tgz",
+      "integrity": "sha512-w9IZ/OSuHUlZhddcOvZbGtpbdenLi17AL31fimdgJwybYqcjO1iS1SVPeuDk58lgcIAYlFW79YGNasFE6+lIjg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15418,15 +15418,15 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-portico": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.0.1.tgz",
-      "integrity": "sha512-80t8Xd95N2J5EaKewN7SfgL82juGyuzhJb32gKx4J8ov0hYTeVXSqhp0Q0cvGOZDoU02hBqpkDda++2i+2zCLw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-portico/-/sdk-evm-portico-3.0.3.tgz",
+      "integrity": "sha512-5SDbsTFSVK5cU4qelYOm/KZA/VeGDYhnSXS+jGTbc527x1rR4eYpZhJsZyUBHMh7hEpYPpbKO8Jp9yeLLLGwWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
-        "@wormhole-foundation/sdk-evm-core": "3.0.1",
-        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
+        "@wormhole-foundation/sdk-evm-tokenbridge": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15434,14 +15434,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tbtc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.0.1.tgz",
-      "integrity": "sha512-r5MB64l9u+3DIcigAlCExJnLyUKVrP7+35yo1VGZv77wn4WijXEaKR4i3d157sR1Ku6gw3q12d3Gfx7RfLOMNA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tbtc/-/sdk-evm-tbtc-3.0.3.tgz",
+      "integrity": "sha512-Z8VI9MPeyizCxE8yRQ3HfUUgYPNcB5fG3bmmiGdWUWwQ+JG5gnqeUKK2bCK+iQVKKKm0nNsTeBFF6uVYWD4SQw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
-        "@wormhole-foundation/sdk-evm-core": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15449,14 +15449,14 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-evm-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-fMiYI/IaF6PuPMZWHjw990G2rIQup5V4ZuQ7Zbkr3QM5jkooHNFXfX8/ZYqUdgWnRJqmJF6POSr4P7GW6FvHig==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-evm-tokenbridge/-/sdk-evm-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-2KH9rQR4InGYa+qMBW5r+4xno4mOVR6qkoSTe8WjDiAtiryX8sKddoZ4l6iCP/Orp6R9Bzu4JfcObZz0AWcDnw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-evm": "3.0.1",
-        "@wormhole-foundation/sdk-evm-core": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-evm": "3.0.3",
+        "@wormhole-foundation/sdk-evm-core": "3.0.3",
         "ethers": "^6.5.1"
       },
       "engines": {
@@ -15501,16 +15501,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.0.1.tgz",
-      "integrity": "sha512-iSWzHe1mUv2D7XyJcrWJwUoPjsLRVDHDZVwIPDLWwwPdNYY+R3rEcVwJAAJeUBHZrGyMA0UKPFpL8SsfXX9MRA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana/-/sdk-solana-3.0.3.tgz",
+      "integrity": "sha512-YBwYC1zFhWWG/997gx4s8i92a9tDRKt8ITNlPoVoy+1aI+aJzLB+TumDCrU1NCEIAKLXoqKZ+206XluD/hDF3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
+        "@wormhole-foundation/sdk-connect": "3.0.3",
         "rpc-websockets": "^7.10.0"
       },
       "engines": {
@@ -15518,16 +15518,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-cctp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.0.1.tgz",
-      "integrity": "sha512-1n+vdBU5n+T4csdePxPqvkiJMo7fyx4/gnc/0+eHDjKOon1ScoN+H1WZbJrk3mFDkHdSN19VRjPCAMykFU0i1Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-cctp/-/sdk-solana-cctp-3.0.3.tgz",
+      "integrity": "sha512-MjZgo1pN5Bg4rTvg7+MeUoNaDAm8lg8WuahvJogmFe1voKC8kniRzHghm9x9S8zoUuH/HyUiBhIurgNjDe0Z2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-solana": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3"
       },
       "engines": {
         "node": ">=16"
@@ -15551,16 +15551,16 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.0.1.tgz",
-      "integrity": "sha512-CkZedgrH7ZCC7XfowM67KIStDpu0VfGWyN9nlVzxFc7VOGqxJ7vTqKC5E8Bn5gSFbs5K6lcZa3ODlXfVDpl0lA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-core/-/sdk-solana-core-3.0.3.tgz",
+      "integrity": "sha512-vP/POBI7aG+w6iUDCgDZlhm9S25c6Bszw7E2VVrgAR/lM/YnGO5AzM6nWRLt6k7MYH6AoSu88LqjYUYY45wGng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@coral-xyz/borsh": "0.29.0",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-solana": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3"
       },
       "engines": {
         "node": ">=16"
@@ -15596,18 +15596,18 @@
       "license": "MIT"
     },
     "node_modules/@wormhole-foundation/sdk-solana-tbtc": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.0.1.tgz",
-      "integrity": "sha512-urRCJ7jg//ePeeZft4AsVH3JTewBMSC/K9nCaWa+5S6xfvWlY6ZXtAouJC/fLfwGNztrnK+U2K+lsgG+KhiUKQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tbtc/-/sdk-solana-tbtc-3.0.3.tgz",
+      "integrity": "sha512-2q8olQjuYruYoMeZwGX00KuyVdW96TxuunZzhqeN2AXhUmyQVHFhO51/lfIHvH9sf2xuIuZGHC+Kk9YQKBZjlw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-solana": "3.0.1",
-        "@wormhole-foundation/sdk-solana-core": "3.0.1",
-        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3",
+        "@wormhole-foundation/sdk-solana-tokenbridge": "3.0.3"
       },
       "engines": {
         "node": ">=16"
@@ -15631,17 +15631,17 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-solana-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-52LXctlcPeM9gYqq/vsiYnBig8gyP/7kvG9xPocpOoDHd3DyaaMxscpI7Y+fqUKRqKONm4p1tywqfaxcoU0SfQ==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-solana-tokenbridge/-/sdk-solana-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-GhgChS59wyvtdnHtDFJAW5wp5POfXczLP2hBfM5zgRC/GI/Jo2AXm+Yhz7vhQTBdXvCsEY74Io8gQBjX/QlUlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
         "@solana/spl-token": "0.3.9",
         "@solana/web3.js": "^1.95.8",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-solana": "3.0.1",
-        "@wormhole-foundation/sdk-solana-core": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-solana": "3.0.3",
+        "@wormhole-foundation/sdk-solana-core": "3.0.3"
       },
       "engines": {
         "node": ">=16"
@@ -15682,56 +15682,56 @@
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.0.1.tgz",
-      "integrity": "sha512-k6y9/bpW6tdUFTXGBMbqcRBOQaTqghkvW2FfvXKq6A98f2HPo4wP8+aRlF5Hb9YpzWJzvfK4t52uBiwDZY6YLA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui/-/sdk-sui-3.0.3.tgz",
+      "integrity": "sha512-MTq3Sav0OOIz+CePdGsg12w5hQlKqBZ1qnK8BkiGOYJzsay3qdROM4l7IFQrJXq7xCVr2t+Yexrj2/5QA8Osew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-cctp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.0.1.tgz",
-      "integrity": "sha512-OByJCDS44AkMNeqNe4A6kbg3C7MU14KjLyMew2QGaH2t1ZcDxud/khHdqC8e2BPbTHjTHc5GLhrDTZE57mfZ9Q==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-cctp/-/sdk-sui-cctp-3.0.3.tgz",
+      "integrity": "sha512-ixNtj/x/rgNomLpMhof8kdfO5WC4f+3hXvY4gQnXwargFeVV0Tc4V8OZ6SnL+8vB1LurhnjpnPXdxAAHCYs47Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-sui": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.0.1.tgz",
-      "integrity": "sha512-dYsYE2bosTQrVdNYfBxonKimYlXrSRC+VO87VuGtp6WHUaa8/zNviqjI5mwYW9e9FZUeKgOui0JvB6lhSEVo6g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-core/-/sdk-sui-core-3.0.3.tgz",
+      "integrity": "sha512-uQp8LE6BtRAOkhfNdQP18WF9iF9Suyn0S122Mn4V2yUmT0Jodlah2ZsWRi6YcHsvkzPzhVnZ65I0x0UzO0CmUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-sui": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@wormhole-foundation/sdk-sui-tokenbridge": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.0.1.tgz",
-      "integrity": "sha512-1BjG1EUf0aAh7JChCJ7/Q6e0AFiik8iI02CJdCuZJvz/B74bhT+PQXtZg+GvTYKjWcA9pBixUKUoQu7S7S/nIA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@wormhole-foundation/sdk-sui-tokenbridge/-/sdk-sui-tokenbridge-3.0.3.tgz",
+      "integrity": "sha512-O4dZHLxjLH1Tufhz9DOVmnXhj1fPFE8grJCGxquza64NRHAJ3kvrT9Z/AoneQ8Fdxkp1arqtWNxGTJtb547D6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mysten/sui": "^1.21.2",
-        "@wormhole-foundation/sdk-connect": "3.0.1",
-        "@wormhole-foundation/sdk-sui": "3.0.1",
-        "@wormhole-foundation/sdk-sui-core": "3.0.1"
+        "@wormhole-foundation/sdk-connect": "3.0.3",
+        "@wormhole-foundation/sdk-sui": "3.0.3",
+        "@wormhole-foundation/sdk-sui-core": "3.0.3"
       },
       "engines": {
         "node": ">=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@wormhole-foundation/sdk-icons": "^1.0.4",
         "@wormhole-foundation/sdk-route-ntt": "1.0.4",
         "@wormhole-foundation/sdk-solana-ntt": "1.0.4",
-        "@wormhole-labs/cctp-executor-route": "0.11.0",
+        "@wormhole-labs/cctp-executor-route": "0.12.0",
         "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
         "@wormhole-labs/wallet-aggregator-core": "0.0.1",
         "@wormhole-labs/wallet-aggregator-evm": "0.4.0",
@@ -15738,9 +15738,9 @@
       }
     },
     "node_modules/@wormhole-labs/cctp-executor-route": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.11.0.tgz",
-      "integrity": "sha512-bun62HPB3JBPXJsc/iOhDIR/F78lwlnqNt6DAGi5Z0Y34SE1n0L6ILVWkI/XXrgKbGdwxWv0OPWBWceizLwtzw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.12.0.tgz",
+      "integrity": "sha512-F7khZAa25k7WbrZ9OTikmk7NsN+xIUQytnK+JKsnzL4/M+l4eUUY9D2/iAEu4W/B4DNh/bbi1zrAAFNJoiP3jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@wormhole-foundation/sdk-icons": "^1.0.4",
     "@wormhole-foundation/sdk-route-ntt": "1.0.4",
     "@wormhole-foundation/sdk-solana-ntt": "1.0.4",
-    "@wormhole-labs/cctp-executor-route": "0.11.0",
+    "@wormhole-labs/cctp-executor-route": "0.12.0",
     "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
     "@wormhole-labs/wallet-aggregator-core": "0.0.1",
     "@wormhole-labs/wallet-aggregator-evm": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
     "@reduxjs/toolkit": "^2.5.1",
     "@solana/spl-token": "0.4.0",
     "@solana/wallet-adapter-wallets": "0.19.32",
-    "@wormhole-foundation/sdk": "3.0.1",
-    "@wormhole-foundation/sdk-definitions": "3.0.1",
+    "@wormhole-foundation/sdk": "3.0.3",
+    "@wormhole-foundation/sdk-definitions": "3.0.3",
     "@wormhole-foundation/sdk-definitions-ntt": "1.0.4",
     "@wormhole-foundation/sdk-evm-ntt": "1.0.4",
     "@wormhole-foundation/sdk-icons": "^1.0.4",
@@ -179,38 +179,38 @@
       "@ledgerhq/devices": "6.27.1"
     },
     "@mayanfinance/wormhole-sdk-route": {
-      "@wormhole-foundation/sdk-connect": "3.0.1",
-      "@wormhole-foundation/sdk-evm": "3.0.1",
-      "@wormhole-foundation/sdk-solana": "3.0.1",
-      "@wormhole-foundation/sdk-sui": "3.0.1"
+      "@wormhole-foundation/sdk-connect": "3.0.3",
+      "@wormhole-foundation/sdk-evm": "3.0.3",
+      "@wormhole-foundation/sdk-solana": "3.0.3",
+      "@wormhole-foundation/sdk-sui": "3.0.3"
     },
     "@wormhole-foundation/sdk-definitions-ntt": {
-      "@wormhole-foundation/sdk-base": "3.0.1",
-      "@wormhole-foundation/sdk-definitions": "3.0.1"
+      "@wormhole-foundation/sdk-base": "3.0.3",
+      "@wormhole-foundation/sdk-definitions": "3.0.3"
     },
     "@wormhole-foundation/sdk-evm-ntt": {
-      "@wormhole-foundation/sdk-base": "3.0.1",
-      "@wormhole-foundation/sdk-definitions": "3.0.1",
-      "@wormhole-foundation/sdk-evm": "3.0.1",
-      "@wormhole-foundation/sdk-evm-core": "3.0.1"
+      "@wormhole-foundation/sdk-base": "3.0.3",
+      "@wormhole-foundation/sdk-definitions": "3.0.3",
+      "@wormhole-foundation/sdk-evm": "3.0.3",
+      "@wormhole-foundation/sdk-evm-core": "3.0.3"
     },
     "@wormhole-foundation/sdk-route-ntt": {
-      "@wormhole-foundation/sdk-connect": "3.0.1"
+      "@wormhole-foundation/sdk-connect": "3.0.3"
     },
     "@wormhole-foundation/sdk-solana-ntt": {
-      "@wormhole-foundation/sdk-base": "3.0.1",
-      "@wormhole-foundation/sdk-definitions": "3.0.1",
-      "@wormhole-foundation/sdk-solana": "3.0.1",
-      "@wormhole-foundation/sdk-solana-core": "3.0.1"
+      "@wormhole-foundation/sdk-base": "3.0.3",
+      "@wormhole-foundation/sdk-definitions": "3.0.3",
+      "@wormhole-foundation/sdk-solana": "3.0.3",
+      "@wormhole-foundation/sdk-solana-core": "3.0.3"
     },
     "@wormhole-labs/cctp-executor-route": {
-      "@wormhole-foundation/sdk-aptos": "3.0.1",
-      "@wormhole-foundation/sdk-connect": "3.0.1",
-      "@wormhole-foundation/sdk-evm": "3.0.1",
-      "@wormhole-foundation/sdk-solana": "3.0.1",
-      "@wormhole-foundation/sdk-solana-cctp": "3.0.1",
-      "@wormhole-foundation/sdk-sui": "3.0.1",
-      "@wormhole-foundation/sdk-sui-cctp": "3.0.1"
+      "@wormhole-foundation/sdk-aptos": "3.0.3",
+      "@wormhole-foundation/sdk-connect": "3.0.3",
+      "@wormhole-foundation/sdk-evm": "3.0.3",
+      "@wormhole-foundation/sdk-solana": "3.0.3",
+      "@wormhole-foundation/sdk-solana-cctp": "3.0.3",
+      "@wormhole-foundation/sdk-sui": "3.0.3",
+      "@wormhole-foundation/sdk-sui-cctp": "3.0.3"
     },
     "@wormhole-foundation/wormhole-connect": {
       "aptos": "1.5.2"

--- a/src/config/mainnet/tokens.ts
+++ b/src/config/mainnet/tokens.ts
@@ -696,6 +696,15 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.SEI,
   },
   {
+    symbol: 'USDC',
+    tokenId: {
+      chain: 'Seievm',
+      address: '0xe15fC38F6D8c56aF07bbCBe3BAf5708A2Bf42392',
+    },
+    decimals: 6,
+    icon: TokenIcon.USDC,
+  },
+  {
     symbol: 'PLUME',
     tokenId: {
       chain: 'Plume',

--- a/src/config/testnet/tokens.ts
+++ b/src/config/testnet/tokens.ts
@@ -398,6 +398,15 @@ export const TESTNET_TOKENS: TokenConfig[] = [
     icon: TokenIcon.SEI,
   },
   {
+    symbol: 'USDC',
+    tokenId: {
+      chain: 'Seievm',
+      address: '0x4fCF1784B31630811181f670Aea7A7bEF803eaED',
+    },
+    decimals: 6,
+    icon: TokenIcon.USDC,
+  },
+  {
     symbol: 'PLUME',
     decimals: 18,
     icon: TokenIcon.PLUME,

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -27,6 +27,7 @@ const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
   Sonic: 'sonic-3',
   Linea: 'ethereum',
   Worldchain: 'ethereum',
+  Seievm: 'sei',
   // TODO: add Mezo when available
 };
 
@@ -39,6 +40,7 @@ const CHAIN_IDS: Partial<Record<Chain, string>> = {
   Klaytn: 'klay-token',
   Xlayer: 'x-layer',
   Worldchain: 'world-chain',
+  Seievm: 'sei-v2',
 };
 
 export interface CoingeckoParams {


### PR DESCRIPTION
## Summary

This PR adds support for CCTPv2 on SeiEVM, enabling native USDC transfers through Circle's Cross-Chain Transfer Protocol on the Sei EVM chain.

  ## Changes

  ### Core Features
  - Added SeiEVM CCTPv2 support for both mainnet and testnet
  - Added USDC token configurations for SeiEVM mainnet/testnet

  ### Infrastructure Updates
  - Updated coingecko native token and chain mappings for SeiEVM
  - Updated SDK to v3.0.3 to include SeiEVM USDC addresses

  ### Files Modified
  - `src/config/chains.ts` - Added SeiEVM chain configurations
  - `src/utils/coingecko.ts` - Added coingecko mappings for SEI token
  - `package.json` & `package-lock.json` - Updated SDK dependencies

  ## Test Plan
  - [ ] Verify USDC transfers from SeiEVM to other CCTP-supported chains
  - [x] Verify USDC transfers from other CCTP-supported chains to SeiEVM
  - [x] Validate price feeds are working for SEI token
  
  Note the Executor is not currently configured for CCTPv2 testnet on SeiEVM.