### PR TITLE
chore: Refactored getExplorerUrl to handle query params in baseUrl

### DIFF
--- a/src/config/testnet/chains.ts
+++ b/src/config/testnet/chains.ts
@@ -43,7 +43,7 @@ export const TESTNET_CHAINS: ChainsConfig = {
   },
   Solana: {
     displayName: 'Solana',
-    explorerUrl: 'https://explorer.solana.com/',
+    explorerUrl: 'https://explorer.solana.com/?cluster=devnet',
     explorerName: 'Solana Explorer',
     icon: 'Solana',
     symbol: 'SOL',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -253,6 +253,13 @@ export const isEmptyObject = (value: object | null | undefined) => {
 
 export type ExplorerPathType = 'wallet' | 'tx' | 'token';
 
+// Helper function to append path while preserving query params
+const appendPathToUrl = (baseUrl: string, pathSegment: string): string => {
+  const url = new URL(baseUrl);
+  url.pathname = `${url.pathname}/${pathSegment}`;
+  return url.toString();
+};
+
 export const getExplorerUrl = (
   chain: Chain,
   path: string,
@@ -268,27 +275,31 @@ export const getExplorerUrl = (
 
   switch (pathType) {
     case 'wallet':
-      return chain === 'Aptos'
-        ? `${baseUrl}account/${path}`
-        : `${baseUrl}address/${path}`;
+      switch (chain) {
+        case 'Aptos':
+          return appendPathToUrl(baseUrl, `account/${path}`);
+        default:
+          return appendPathToUrl(baseUrl, `address/${path}`);
+      }
     case 'tx':
       return chain === 'Aptos'
-        ? `${baseUrl}txn/${path}`
-        : `${baseUrl}tx/${path}`;
+        ? appendPathToUrl(baseUrl, `txn/${path}`)
+        : appendPathToUrl(baseUrl, `tx/${path}`);
     default:
       switch (chain) {
         case 'Sui':
-          return `${baseUrl}coin/${path}`;
+          return appendPathToUrl(baseUrl, `coin/${path}`);
         case 'Aptos':
-          return `${baseUrl}${
-            isHexString(path) ? 'fungible_asset' : 'coin'
-          }/${path}`;
+          return appendPathToUrl(
+            baseUrl,
+            `${isHexString(path) ? 'fungible_asset' : 'coin'}/${path}`,
+          );
         case 'Fantom':
         case 'Solana':
         case 'Fogo':
           return `${baseUrl}address/${path}`;
         default:
-          return `${baseUrl}token/${path}`;
+          return appendPathToUrl(baseUrl, `token/${path}`);
       }
   }
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -256,7 +256,12 @@ export type ExplorerPathType = 'wallet' | 'tx' | 'token';
 // Helper function to append path while preserving query params
 const appendPathToUrl = (baseUrl: string, pathSegment: string): string => {
   const url = new URL(baseUrl);
-  url.pathname = `${url.pathname}/${pathSegment}`;
+
+  // Trim trailing slash from base pathname and leading slash from pathSegment
+  const basePath = url.pathname.replace(/\/+$/, '');
+  const segment = pathSegment.replace(/^\/+/, '');
+
+  url.pathname = `${basePath}/${segment}`;
   return url.toString();
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -265,49 +265,64 @@ const appendPathToUrl = (baseUrl: string, pathSegment: string): string => {
   return url.toString();
 };
 
-export const getExplorerUrl = (
+export const getTokenExplorerUrl = (
   chain: Chain,
   path: string,
-  pathType: ExplorerPathType,
 ): string | undefined => {
   const chainConfig = config.chains[chain];
-
   if (!chainConfig?.explorerUrl) {
     return undefined;
   }
 
   const baseUrl = chainConfig.explorerUrl;
 
-  switch (pathType) {
-    case 'wallet':
-      switch (chain) {
-        case 'Aptos':
-          return appendPathToUrl(baseUrl, `account/${path}`);
-        default:
-          return appendPathToUrl(baseUrl, `address/${path}`);
-      }
-    case 'tx':
-      return chain === 'Aptos'
-        ? appendPathToUrl(baseUrl, `txn/${path}`)
-        : appendPathToUrl(baseUrl, `tx/${path}`);
+  switch (chain) {
+    case 'Sui':
+      return appendPathToUrl(baseUrl, `coin/${path}`);
+    case 'Aptos':
+      return appendPathToUrl(
+        baseUrl,
+        `${isHexString(path) ? 'fungible_asset' : 'coin'}/${path}`,
+      );
+    case 'Fantom':
+    case 'Solana':
+    case 'Fogo':
+      return `${baseUrl}address/${path}`;
     default:
-      switch (chain) {
-        case 'Sui':
-          return appendPathToUrl(baseUrl, `coin/${path}`);
-        case 'Aptos':
-          return appendPathToUrl(
-            baseUrl,
-            `${isHexString(path) ? 'fungible_asset' : 'coin'}/${path}`,
-          );
-        case 'Fantom':
-        case 'Solana':
-        case 'Fogo':
-          return `${baseUrl}address/${path}`;
-        default:
-          return appendPathToUrl(baseUrl, `token/${path}`);
-      }
+      return appendPathToUrl(baseUrl, `token/${path}`);
   }
 };
+
+export const getTransactionExplorerUrl = (
+  chain: Chain,
+  path: string,
+): string | undefined => {
+  const chainConfig = config.chains[chain];
+  if (!chainConfig?.explorerUrl) {
+    return undefined;
+  }
+
+  const baseUrl = chainConfig.explorerUrl;
+  return chain === 'Aptos'
+    ? appendPathToUrl(baseUrl, `txn/${path}`)
+    : appendPathToUrl(baseUrl, `tx/${path}`);
+};
+
+export const getWalletExplorerUrl = (
+  chain: Chain,
+  path: string,
+): string | undefined => {
+  const chainConfig = config.chains[chain];
+  if (!chainConfig?.explorerUrl) {
+    return undefined;
+  }
+
+  const baseUrl = chainConfig.explorerUrl;
+  return chain === 'Aptos'
+    ? appendPathToUrl(baseUrl, `account/${path}`)
+    : appendPathToUrl(baseUrl, `address/${path}`);
+};
+
 // Frankenstein tokens are wormhole-wrapped tokens that are not native to the chain
 // and likely have no liquidity.
 // An example of a Frankenstein token is wormhole-wrapped Arbitrum WETH on Solana.

--- a/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -15,7 +15,7 @@ import TokenIcon from 'icons/TokenIcons';
 import { Token } from 'config/tokens';
 
 import type { Chain } from '@wormhole-foundation/sdk';
-import { chainDisplayName, getExplorerUrl } from 'utils';
+import { chainDisplayName, getTokenExplorerUrl } from 'utils';
 import ChainIcon from 'icons/ChainIcons';
 import Color from 'color';
 
@@ -69,9 +69,7 @@ function TokenItem(props: TokenItemProps) {
 
   const { chain, token } = props;
   const address = token.tokenId?.address.toString();
-  const explorerURL = address
-    ? getExplorerUrl(chain, address, 'token')
-    : undefined;
+  const explorerURL = address ? getTokenExplorerUrl(chain, address) : '';
   const addressDisplay = `${token.shortAddress}`;
 
   return (

--- a/src/views/v2/Redeem/TransactionDetails/index.tsx
+++ b/src/views/v2/Redeem/TransactionDetails/index.tsx
@@ -15,7 +15,8 @@ import AssetBadge from 'components/AssetBadge';
 import ExplorerLink from 'components/ExplorerLink';
 import {
   calculateUSDPrice,
-  getExplorerUrl,
+  getTransactionExplorerUrl,
+  getWalletExplorerUrl,
   millisToHumanString,
   trimAddress,
 } from 'utils';
@@ -90,9 +91,7 @@ const TransactionDetails = () => {
     );
 
     const senderAddress = sender ? trimAddress(sender) : '';
-    const explorerUrl = sender
-      ? getExplorerUrl(fromChain, sender, 'wallet')
-      : '';
+    const explorerUrl = sender ? getWalletExplorerUrl(fromChain, sender) : '';
 
     const formattedAmount = sdkAmount.display(sdkAmount.truncate(amount, 6));
 
@@ -151,7 +150,7 @@ const TransactionDetails = () => {
 
     const recipientAddress = recipient ? trimAddress(recipient) : '';
     const explorerUrl = recipient
-      ? getExplorerUrl(toChain, recipient, 'wallet')
+      ? getWalletExplorerUrl(toChain, recipient)
       : '';
 
     const formattedReceiveAmount = receiveAmount
@@ -309,7 +308,9 @@ const TransactionDetails = () => {
   }, [eta, theme.palette.text.secondary, toChain]);
 
   const trimmedTx = sendTx ? trimAddress(sendTx) : '';
-  const explorerUrl = sendTx ? getExplorerUrl(fromChain, sendTx, 'tx') : '';
+  const explorerUrl = sendTx
+    ? getTransactionExplorerUrl(fromChain, sendTx)
+    : '';
 
   return (
     <Box sx={styles.container}>

--- a/src/views/v2/TxHistory/Item/index.tsx
+++ b/src/views/v2/TxHistory/Item/index.tsx
@@ -12,7 +12,7 @@ import config from 'config';
 import AssetBadge from 'components/AssetBadge';
 import {
   calculateUSDPrice,
-  getExplorerUrl,
+  getTransactionExplorerUrl,
   getUSDFormat,
   millisToRelativeTime,
   trimTxHash,
@@ -181,7 +181,7 @@ const TxHistoryItem = (props: Props) => {
   }, [senderTimestamp]);
 
   const chainExplorerLink = useMemo(() => {
-    const explorerUrl = getExplorerUrl(fromChain, txHash, 'tx');
+    const explorerUrl = getTransactionExplorerUrl(fromChain, txHash);
     const txHashTrimmed = trimTxHash(txHash, 4, 4);
     return explorerUrl ? (
       <ExplorerLink url={explorerUrl} text={txHashTrimmed} />

--- a/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
@@ -15,7 +15,7 @@ import TokenIcon from 'icons/TokenIcons';
 import { Token } from 'config/tokens';
 
 import type { Chain } from '@wormhole-foundation/sdk';
-import { chainDisplayName, getExplorerUrl } from 'utils';
+import { chainDisplayName, getTokenExplorerUrl } from 'utils';
 import ChainIcon from 'icons/ChainIcons';
 import Color from 'color';
 
@@ -69,9 +69,7 @@ function TokenItem(props: TokenItemProps) {
 
   const { chain, token } = props;
   const address = token.tokenId?.address.toString();
-  const explorerURL = address
-    ? getExplorerUrl(chain, address, 'token')
-    : undefined;
+  const explorerURL = address ? getTokenExplorerUrl(chain, address) : '';
   const addressDisplay = `${token.shortAddress}`;
 
   return (

--- a/src/views/v3/Redeem/TransactionDetails/index.tsx
+++ b/src/views/v3/Redeem/TransactionDetails/index.tsx
@@ -15,7 +15,8 @@ import AssetBadge from 'components/AssetBadge';
 import ExplorerLink from 'components/ExplorerLink';
 import {
   calculateUSDPrice,
-  getExplorerUrl,
+  getTransactionExplorerUrl,
+  getWalletExplorerUrl,
   millisToHumanString,
   trimAddress,
 } from 'utils';
@@ -90,9 +91,7 @@ const TransactionDetails = () => {
     );
 
     const senderAddress = sender ? trimAddress(sender) : '';
-    const explorerUrl = sender
-      ? getExplorerUrl(fromChain, sender, 'wallet')
-      : '';
+    const explorerUrl = sender ? getWalletExplorerUrl(fromChain, sender) : '';
 
     const formattedAmount = sdkAmount.display(sdkAmount.truncate(amount, 6));
 
@@ -151,7 +150,7 @@ const TransactionDetails = () => {
 
     const recipientAddress = recipient ? trimAddress(recipient) : '';
     const explorerUrl = recipient
-      ? getExplorerUrl(toChain, recipient, 'wallet')
+      ? getWalletExplorerUrl(toChain, recipient)
       : '';
 
     const formattedReceiveAmount = receiveAmount
@@ -316,7 +315,9 @@ const TransactionDetails = () => {
   }, [eta, theme.palette.text.secondary, toChain]);
 
   const trimmedTx = sendTx ? trimAddress(sendTx) : '';
-  const explorerUrl = sendTx ? getExplorerUrl(fromChain, sendTx, 'tx') : '';
+  const explorerUrl = sendTx
+    ? getTransactionExplorerUrl(fromChain, sendTx)
+    : '';
 
   return (
     <Box sx={styles.container}>

--- a/src/views/v3/TxHistory/Item/index.tsx
+++ b/src/views/v3/TxHistory/Item/index.tsx
@@ -12,7 +12,7 @@ import config from 'config';
 import AssetBadge from 'components/AssetBadge';
 import {
   calculateUSDPrice,
-  getExplorerUrl,
+  getTransactionExplorerUrl,
   getUSDFormat,
   millisToRelativeTime,
   trimTxHash,
@@ -181,7 +181,7 @@ const TxHistoryItem = (props: Props) => {
   }, [senderTimestamp]);
 
   const chainExplorerLink = useMemo(() => {
-    const explorerUrl = getExplorerUrl(fromChain, txHash, 'tx');
+    const explorerUrl = getTransactionExplorerUrl(fromChain, txHash);
     const txHashTrimmed = trimTxHash(txHash, 4, 4);
     return explorerUrl ? (
       <ExplorerLink url={explorerUrl} text={txHashTrimmed} />


### PR DESCRIPTION
- Created helper function `appendPathToUrl()` to append a path segment while retaining query params from the base
- Separated `getExplorerUrl()` into three separate helper functions based on type of URL - token, wallet, txn
- Updated Solana devnet to have correct baseUrl with `?cluster=devnet`