### PR TITLE
fix: svm add simulation compute budget instruction last

### DIFF
--- a/src/utils/solana.ts
+++ b/src/utils/solana.ts
@@ -125,7 +125,7 @@ async function createPriorityFeeInstructions(
     const message = TransactionMessage.decompile(transaction.message, {
       addressLookupTableAccounts: luts,
     });
-    message.instructions = [simComputeBudgetIx, ...message.instructions];
+    message.instructions = [...message.instructions, simComputeBudgetIx];
 
     // Create a new VersionedTransaction with the modified message
     simulationTx = new VersionedTransaction(message.compileToV0Message(luts));
@@ -135,7 +135,7 @@ async function createPriorityFeeInstructions(
     const txCopy = new Transaction();
     txCopy.recentBlockhash = transaction.recentBlockhash;
     txCopy.feePayer = transaction.feePayer;
-    txCopy.instructions = [simComputeBudgetIx, ...transaction.instructions];
+    txCopy.instructions = [...transaction.instructions, simComputeBudgetIx];
     txCopy.signatures = [...transaction.signatures];
     simulationTx = txCopy;
   }


### PR DESCRIPTION
Fixes an issue where the compute budget instruction being set before a secp256k1 instruction would cause simulation to fail