### PR TITLE
feat: Do not show fastest/cheapest pills when no distinct fastest and cheapest routes

### DIFF
--- a/src/views/v3/Bridge/Routes/index.tsx
+++ b/src/views/v3/Bridge/Routes/index.tsx
@@ -226,7 +226,7 @@ function Routes({
     if (
       fastestRoute.name &&
       cheapestRoute.name &&
-      routesWithQuotes.length > 1
+      cheapestRoute.name !== fastestRoute.name
     ) {
       return (
         <Box sx={{ maxWidth: '174px' }}>


### PR DESCRIPTION
The logic will be only show the tabs when there is a fastest *and* cheapest available.