### PR TITLE
fix: ensure tbtc routes are shown

### DIFF
--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -20,6 +20,7 @@ const {
   TokenBridgeRoute,
   AutomaticCCTPRoute,
   CCTPRoute,
+  TBTCRoute,
 } = routes;
 
 export default WormholeConnect;
@@ -41,6 +42,7 @@ export {
   TokenBridgeRoute,
   AutomaticCCTPRoute,
   CCTPRoute,
+  TBTCRoute,
 };
 
 export * from 'telemetry';


### PR DESCRIPTION
This ensures that all tbtc routes are shown when available. They are available for different amounts:

0.01 -> all
0.1 -> swift and manual
1 -> manual

<img width="541" height="935" alt="Screenshot 2025-07-25 at 12 37 07 PM" src="https://github.com/user-attachments/assets/9fb11f54-3f00-4424-8b16-26491ab877b5" />
<img width="544" height="920" alt="Screenshot 2025-07-25 at 12 37 14 PM" src="https://github.com/user-attachments/assets/43d343e7-74d8-4365-bec0-eeb4137b9d13" />
<img width="533" height="769" alt="Screenshot 2025-07-25 at 12 37 20 PM" src="https://github.com/user-attachments/assets/682e5dcf-ecd6-451a-80fa-30e6c2a0a04a" />
