### PR TITLE
chore: geoblock circle users

### DIFF
--- a/src/hooks/useConfirmTransaction.ts
+++ b/src/hooks/useConfirmTransaction.ts
@@ -19,6 +19,10 @@ import { toDecimals } from 'utils/balance';
 import { interpretTransferError } from 'utils/errors';
 import { addTxToLocalStorage } from 'utils/inProgressTxCache';
 import { validate, isTransferValid } from 'utils/transferValidation';
+import {
+  checkCircleGeoblock,
+  CIRCLE_GEOBLOCK_ERROR_MESSAGE,
+} from 'utils/circle-geoblock';
 
 import type { RootState } from 'store';
 import type { RelayerFee } from 'store/relay';
@@ -132,6 +136,15 @@ const useConfirmTransaction = (props: Props): ReturnProps => {
         setError('Error validating transfer');
         setErrorInternal(e);
         console.error(e);
+        return;
+      }
+    }
+
+    const isCCTPRoute = route === 'AutomaticCCTP' || route === 'CCTP';
+    if (isCCTPRoute) {
+      const isGeoblocked = await checkCircleGeoblock();
+      if (isGeoblocked) {
+        setError(CIRCLE_GEOBLOCK_ERROR_MESSAGE);
         return;
       }
     }

--- a/src/hooks/useFetchQuotes.ts
+++ b/src/hooks/useFetchQuotes.ts
@@ -12,6 +12,10 @@ import {
 } from '@wormhole-foundation/sdk';
 import { QuoteParams, QuoteResult } from 'routes/operator';
 import { calculateUSDPriceRaw } from 'utils';
+import {
+  checkCircleGeoblock,
+  CIRCLE_GEOBLOCK_ERROR_MESSAGE,
+} from 'utils/circle-geoblock';
 
 import config from 'config';
 import { Token } from 'config/tokens';
@@ -46,6 +50,9 @@ export default (routes: string[], params: Params): HookReturn => {
     Record<string, QuoteResult>
   >({});
   const [isVisible, setIsVisible] = useState(true);
+  const [isCircleGeoblocked, setIsCircleGeoblocked] = useState<boolean | null>(
+    null,
+  );
 
   useEffect(() => {
     const visibilityHandler = () => {
@@ -57,6 +64,15 @@ export default (routes: string[], params: Params): HookReturn => {
       document.removeEventListener('visibilitychange', visibilityHandler);
     };
   }, []);
+
+  useEffect(() => {
+    const hasCCTPRoute = routes.some(
+      (route) => route === 'AutomaticCCTP' || route === 'CCTP',
+    );
+    if (hasCCTPRoute && isCircleGeoblocked === null) {
+      checkCircleGeoblock().then(setIsCircleGeoblocked);
+    }
+  }, [routes, isCircleGeoblocked]);
 
   // TODO temporary
   // Calculate USD amount for temporary $10,000 Mayan limit
@@ -199,7 +215,21 @@ export default (routes: string[], params: Params): HookReturn => {
 
     config.routes.getQuotes(routes, rParams).then((quoteResults) => {
       if (!unmounted) {
-        setUnfilteredQuotes(quoteResults);
+        // Add geoblocking error to CCTP routes if user is geoblocked
+        if (isCircleGeoblocked) {
+          const modifiedQuotes = { ...quoteResults };
+          for (const routeName in modifiedQuotes) {
+            if (routeName === 'AutomaticCCTP' || routeName === 'CCTP') {
+              modifiedQuotes[routeName] = {
+                success: false,
+                error: new Error(CIRCLE_GEOBLOCK_ERROR_MESSAGE),
+              };
+            }
+          }
+          setUnfilteredQuotes(modifiedQuotes);
+        } else {
+          setUnfilteredQuotes(quoteResults);
+        }
         setIsFetchingInitialQuotes(false);
       }
     });

--- a/src/utils/circle-geoblock.ts
+++ b/src/utils/circle-geoblock.ts
@@ -1,0 +1,19 @@
+export const checkCircleGeoblock = async (): Promise<boolean> => {
+  try {
+    const response = await fetch('https://api.circle.com/ping');
+
+    // If the user is geoblocked, Circle returns a 403 or specific error
+    if (!response.ok && (response.status === 403 || response.status === 451)) {
+      return true;
+    }
+
+    return false;
+  } catch (error) {
+    // In case of network errors, we should allow the transaction to proceed to avoid blocking legitimate users with connectivity issues
+    console.warn('Failed to check Circle geoblocking status:', error);
+    return false;
+  }
+};
+
+export const CIRCLE_GEOBLOCK_ERROR_MESSAGE =
+  'You are attempting a transfer from a location that is restricted by Circle.';


### PR DESCRIPTION
[WIP] - CORS resolution pending

Uses Circle's ping api to determine if a user is geoblocked. If they receive the geoblocked status code, they are presented with the block text and unable to continue. If the request fails, we assume it's a network thing and not a geo thing, so it will still go through.

<img width="561" height="543" alt="Screenshot 2025-07-29 at 12 54 59 PM" src="https://github.com/user-attachments/assets/35b44e20-1936-424f-ab8f-55d908d5c8b2" />

I have not been able to test this, as even with a VPN in Afghanistan it wouldn't complain. This assumes Circle's API properly returns the status for these blocked regions.

https://linear.app/wormholelabs/issue/PROD-134/when-using-cctp-block-users-from-initiating-txns-if-they-are