### PR TITLE
fix: remove extra comma formatting from pre-formatted value

### DIFF
--- a/src/views/v2/Bridge/AmountInput/index.tsx
+++ b/src/views/v2/Bridge/AmountInput/index.tsx
@@ -252,7 +252,7 @@ const AmountInput = (props: Props) => {
             fontSize="14px"
             lineHeight="14px"
           >
-            {formatWithCommas(price)}
+            {price}
           </Typography>
         </Stack>
       </InputAdornment>


### PR DESCRIPTION
This value is already formatted in `tokenPriceAdornment`, so it was rendering incorrectly.