### PR TITLE
fix: Direct navigation to history view

### DIFF
--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -27,9 +27,9 @@ import { useExternalSearch } from 'hooks/useExternalSearch';
 import BridgeV2 from 'views/v2/Bridge';
 import RedeemV2 from 'views/v2/Redeem';
 import TxHistoryV2 from 'views/v2/TxHistory';
+import type { BridgeProps } from 'views/v3/Bridge';
 import BridgeV3 from 'views/v3/Bridge';
 import RedeemV3 from 'views/v3/Redeem';
-import TxHistoryV3 from 'views/v3/TxHistory';
 import { RouteContext } from 'contexts/RouteContext';
 import SvgDefs from 'icons/SvgDefs';
 import { Box } from '@mui/material';
@@ -66,8 +66,12 @@ const AppRouterContent: React.FC = () => {
   }, [hasExternalSearch, dispatch]);
 
   // TODO: Deprecate with UI refresh v3
-  const bridgeView = useMemo(() => {
-    return getExperiment('enableUIRefreshV3') ? <BridgeV3 /> : <BridgeV2 />;
+  const getBridgeView = useCallback((props: BridgeProps) => {
+    return getExperiment('enableUIRefreshV3') ? (
+      <BridgeV3 {...props} />
+    ) : (
+      <BridgeV2 />
+    );
   }, []);
 
   // TODO: Deprecate with UI refresh v3
@@ -78,7 +82,7 @@ const AppRouterContent: React.FC = () => {
   // TODO: Deprecate with UI refresh v3
   const txHistoryView = useMemo(() => {
     return getExperiment('enableUIRefreshV3') ? (
-      <TxHistoryV3 />
+      getBridgeView({ showHistory: true })
     ) : (
       <TxHistoryV2 />
     );
@@ -100,7 +104,7 @@ const AppRouterContent: React.FC = () => {
       }}
     >
       <SvgDefs />
-      {route === 'bridge' && bridgeView}
+      {route === 'bridge' && getBridgeView({ showHistory: false })}
       {route === 'redeem' && redeemView}
       {route === 'history' && txHistoryView}
       {route === 'search' && <TxSearch />}

--- a/src/views/v3/Bridge/index.tsx
+++ b/src/views/v3/Bridge/index.tsx
@@ -58,11 +58,15 @@ import TxHistory from '../TxHistory';
 import AmountValidationError from './AmountValidationError';
 import { getFilteredChains } from 'utils/sdkv2';
 
-function Bridge() {
+export type BridgeProps = {
+  showHistory?: boolean;
+};
+
+function Bridge(props: BridgeProps) {
   const theme: any = useTheme();
   const dispatch = useDispatch();
 
-  const [showHistory, setShowHistory] = useState(false);
+  const [showHistory, setShowHistory] = useState(props.showHistory ?? false);
 
   const { lastTokenCacheUpdate } = useTokens();
   const [errorCopied, setErrorCopied] = useState(false);


### PR DESCRIPTION
This change will ensure that user goes back to History view after clicking the back button on Search view. In Connect UI refresh we changed the History view and it's no longer a separate route, but part of Bridge view (we will eventually make it an overlay in Bridge view). That's why we need to introduce a new prop to Bridge view to show it by default when needed.