### PR TITLE
fix: add HyperEVM RPC endpoint to MAINNET config

### DIFF
--- a/src/sdklegacy/config/MAINNET.ts
+++ b/src/sdklegacy/config/MAINNET.ts
@@ -30,6 +30,7 @@ const MAINNET_CONFIG: WormholeConfig = {
     Linea: 'https://linea-rpc.publicnode.com',
     Sonic: 'https://sonic-rpc.publicnode.com',
     Mezo: 'https://jsonrpc-mezo.boar.network',
+    HyperEVM: 'https://rpc.hyperliquid.xyz/evm',
   },
 };
 


### PR DESCRIPTION
## Summary
- Add missing RPC endpoint for HyperEVM chain to enable proper connectivity
- Uses the official RPC endpoint at https://rpc.hyperliquid.xyz/evm
- This may be preventing HyperEVM from appearing in Portal despite being configured

## Context
HyperEVM chain support was added in PR #3697 but was missing the RPC configuration in the legacy SDK config. This caused the chain not to appear in Portal even though it had proper NTT configuration.

The RPC endpoint was verified to be working correctly with `eth_chainId` returning `0x3e7` (999).