### PR TITLE
fix: update Kaio explorer url & gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ stats.json
 stats.html
 
 .claude/settings.local.json
+
+# Intellij
+.idea

--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -108,8 +108,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
   Klaytn: {
     displayName: 'Kaia',
     sdkName: 'Klaytn',
-    explorerUrl: 'https://kaiascope.com/',
-    explorerName: 'Kaia Scope',
+    explorerUrl: 'https://kaiascan.io/',
+    explorerName: 'KaiaScan',
     icon: 'Klaytn',
     symbol: 'KAIA',
   },

--- a/src/config/testnet/chains.ts
+++ b/src/config/testnet/chains.ts
@@ -67,8 +67,8 @@ export const TESTNET_CHAINS: ChainsConfig = {
   },
   Klaytn: {
     displayName: 'Kaia',
-    explorerUrl: 'https://kairos.kaiascope.com/',
-    explorerName: 'Kaia Scope',
+    explorerUrl: 'https://kairos.kaiascan.io/',
+    explorerName: 'KaiaScan',
     icon: 'Klaytn',
     symbol: 'KAIA',
     sdkName: 'Klaytn',


### PR DESCRIPTION
### **Fixes**

Incorrect explorer URL on mainnet and testnet for Klaryn (#3705)

### **Updates**

Added .idea to .gitignore to prevent IntelliJ IDE files from being committed