### PR TITLE
chore: add cctpv2 to connect

### DIFF
--- a/src/routes/operator.ts
+++ b/src/routes/operator.ts
@@ -8,6 +8,10 @@ import type { Chain, TransactionId, TokenId } from '@wormhole-foundation/sdk';
 import { routes, amount as sdkAmount } from '@wormhole-foundation/sdk';
 
 import SDKv2Route from './sdkv2';
+import {
+  cctpV2FastExecutorRoute,
+  cctpV2StandardExecutorRoute,
+} from '@wormhole-labs/cctp-executor-route';
 
 export interface TxInfo {
   route: string;
@@ -19,9 +23,11 @@ export type QuoteResult = routes.QuoteResult<routes.Options>;
 type forEachCallback<T> = (name: string, route: SDKv2Route) => T;
 
 export const DEFAULT_ROUTES = [
-  routes.AutomaticCCTPRoute,
-  routes.CCTPRoute,
   routes.AutomaticTokenBridgeRoute,
+  routes.AutomaticCCTPRoute, // CCTP v1 automatic
+  routes.CCTPRoute, // CCTP v1 manual
+  cctpV2FastExecutorRoute() as routes.RouteConstructor, // CCTPv2 automatic/fast
+  cctpV2StandardExecutorRoute() as routes.RouteConstructor, // CCTPv2 manual/standard
   routes.TokenBridgeRoute,
   routes.TBTCRoute,
 ];


### PR DESCRIPTION
There are no visual differences. This just enables CCTPv2.

Official USDC site says CCTPV2. https://usdc.range.org/status?id=arb1/0x183f43c13216e74789d5b08a34a2ce8ae43484ada2f7858a85853809fa4a0463

Wormhole says CCTP. https://wormholescan.io/#/tx/0x6be1c2424f1cbcc84c85b5a938a02e39be49612763bbb6cab0912470804e34f1
<img width="1409" height="831" alt="Screenshot 2025-08-15 at 4 15 29 PM" src="https://github.com/user-attachments/assets/4be4198f-d07f-44c1-bee3-3831972302df" />
