### PR TITLE
fix: handle thrown error gracefully if a route throws

### DIFF
--- a/src/routes/sdkv2/route.ts
+++ b/src/routes/sdkv2/route.ts
@@ -138,14 +138,25 @@ export class SDKv2Route {
     // If we have Mayan available, which is a swap route, by default we show the gas token and USDC.
     const mayanTokens = usdcToken ? [nativeToken, usdcToken] : [nativeToken];
 
+    const routeSupportedTokenFetcher = async () => {
+      try {
+        const tokens = await this.rc.supportedDestinationTokens(
+          sourceToken.tokenId,
+          fromContext.context,
+          toContext.context,
+        );
+
+        return tokens;
+      } catch {
+        return [];
+      }
+    };
+
     const destTokens = isMayan
       ? mayanTokens
-      : await this.tokenCache.requestWithCache(cacheKey, () =>
-          this.rc.supportedDestinationTokens(
-            sourceToken.tokenId,
-            fromContext.context,
-            toContext.context,
-          ),
+      : await this.tokenCache.requestWithCache(
+          cacheKey,
+          routeSupportedTokenFetcher,
         );
 
     const filteredTokens = destTokens.filter((t) => {


### PR DESCRIPTION
when fetching supported tokens. [M0's route throws](https://github.com/m0-foundation/ntt-sdk-route/blob/main/src/m0AutomaticRoute.ts#L131).