### PR TITLE
fix: resolve repeated USDC output amount warning

### DIFF
--- a/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -35,7 +35,7 @@ import { formatWithCommas } from 'utils/formatNumber';
 import TimeToDestination from './TimeToDestination';
 import Provider from './Provider';
 
-const HIGH_FEE_THRESHOLD = 20; // dollhairs
+const HIGH_FEE_PERCENT = 10;
 
 type Props = {
   route: string;
@@ -120,6 +120,7 @@ const SingleRoute = (props: Props) => {
   const {
     toChain: destChain,
     fromChain: sourceChain,
+    amount: inputAmount,
     isTransactionInProgress,
   } = useSelector((state: RootState) => state.transferInput);
 
@@ -137,20 +138,30 @@ const SingleRoute = (props: Props) => {
   });
 
   const isHighFee = useMemo(() => {
-    if (!quote?.relayFee) {
+    if (!quote || !sourceToken || !destToken || !inputAmount) {
       return false;
     }
 
-    const relayFee = amount.whole(quote.relayFee.amount);
-    const feeToken = config.tokens.get(quote.relayFee.token);
-    const feePrice = calculateUSDPriceRaw(getTokenPrice, relayFee, feeToken);
+    const inputUsd = calculateUSDPriceRaw(
+      getTokenPrice,
+      inputAmount,
+      sourceToken,
+    );
+    const outputAmount = amount.whole(quote.destinationToken.amount);
+    const outputUsd = calculateUSDPriceRaw(
+      getTokenPrice,
+      outputAmount,
+      destToken,
+    );
 
-    if (feePrice === undefined) {
+    if (inputUsd === undefined || outputUsd === undefined || inputUsd <= 0) {
       return false;
     }
 
-    return feePrice > HIGH_FEE_THRESHOLD;
-  }, [getTokenPrice, quote?.relayFee]);
+    const delta = Math.max(0, inputUsd - outputUsd);
+    const percent = (delta / inputUsd) * 100;
+    return percent >= HIGH_FEE_PERCENT;
+  }, [getTokenPrice, quote, sourceToken, destToken, inputAmount]);
 
   const destinationGas = useMemo(() => {
     if (
@@ -332,14 +343,14 @@ const SingleRoute = (props: Props) => {
                 fontSize={14}
                 lineHeight="18px"
               >
-                Output amount is much lower than input amount.
+                {`Price impact is greater than ${HIGH_FEE_PERCENT}%.`}
               </Typography>
               <Typography
                 color={theme.palette.text.secondary}
                 fontSize={14}
                 lineHeight="18px"
               >
-                Double check before proceeding.
+                Please check before proceeding.
               </Typography>
             </Stack>
           </Stack>

--- a/src/views/v3/Bridge/Routes/SingleRoute.tsx
+++ b/src/views/v3/Bridge/Routes/SingleRoute.tsx
@@ -114,7 +114,7 @@ const SingleRoute = (props: Props) => {
     isTransactionInProgress,
   });
 
-  const { isHighFee } = useMemo(() => {
+  const isHighFee = useMemo(() => {
     if (!quote || !sourceToken || !destToken || !inputAmount) {
       return { isHighFee: false };
     }
@@ -132,12 +132,12 @@ const SingleRoute = (props: Props) => {
     );
 
     if (inputUsd === undefined || outputUsd === undefined || inputUsd <= 0) {
-      return { isHighFee: false };
+      return false;
     }
 
     const delta = Math.max(0, inputUsd - outputUsd);
     const percent = (delta / inputUsd) * 100;
-    return { isHighFee: percent >= HIGH_FEE_PERCENT };
+    return percent >= HIGH_FEE_PERCENT;
   }, [getTokenPrice, quote, sourceToken, destToken, inputAmount]);
 
   const destinationGas = useMemo(() => {

--- a/src/views/v3/Bridge/Routes/SingleRoute.tsx
+++ b/src/views/v3/Bridge/Routes/SingleRoute.tsx
@@ -31,7 +31,7 @@ import RouteBadge from './RouteBadge';
 import TimeToDestination from './TimeToDestination';
 import ProviderWithAmount from './ProviderWithAmount';
 
-const HIGH_FEE_THRESHOLD = 20; // dollhairs
+const HIGH_FEE_PERCENT = 10;
 
 type Props = {
   route: string;
@@ -98,6 +98,7 @@ const SingleRoute = (props: Props) => {
   const {
     toChain: destChain,
     fromChain: sourceChain,
+    amount: inputAmount,
     isTransactionInProgress,
   } = useSelector((state: RootState) => state.transferInput);
 
@@ -113,21 +114,31 @@ const SingleRoute = (props: Props) => {
     isTransactionInProgress,
   });
 
-  const isHighFee = useMemo(() => {
-    if (!quote?.relayFee) {
-      return false;
+  const { isHighFee } = useMemo(() => {
+    if (!quote || !sourceToken || !destToken || !inputAmount) {
+      return { isHighFee: false };
     }
 
-    const relayFee = amount.whole(quote.relayFee.amount);
-    const feeToken = config.tokens.get(quote.relayFee.token);
-    const feePrice = calculateUSDPriceRaw(getTokenPrice, relayFee, feeToken);
+    const inputUsd = calculateUSDPriceRaw(
+      getTokenPrice,
+      inputAmount,
+      sourceToken,
+    );
+    const outputAmount = amount.whole(quote.destinationToken.amount);
+    const outputUsd = calculateUSDPriceRaw(
+      getTokenPrice,
+      outputAmount,
+      destToken,
+    );
 
-    if (feePrice === undefined) {
-      return false;
+    if (inputUsd === undefined || outputUsd === undefined || inputUsd <= 0) {
+      return { isHighFee: false };
     }
 
-    return feePrice > HIGH_FEE_THRESHOLD;
-  }, [getTokenPrice, quote?.relayFee]);
+    const delta = Math.max(0, inputUsd - outputUsd);
+    const percent = (delta / inputUsd) * 100;
+    return { isHighFee: percent >= HIGH_FEE_PERCENT };
+  }, [getTokenPrice, quote, sourceToken, destToken, inputAmount]);
 
   const destinationGas = useMemo(() => {
     if (
@@ -309,14 +320,14 @@ const SingleRoute = (props: Props) => {
                 fontSize={14}
                 lineHeight="18px"
               >
-                Output amount is much lower than input amount.
+                {`Price impact is greater than ${HIGH_FEE_PERCENT}%.`}
               </Typography>
               <Typography
                 color={theme.palette.text.secondary}
                 fontSize={14}
                 lineHeight="18px"
               >
-                Double check before proceeding.
+                Please check before proceeding.
               </Typography>
             </Stack>
           </Stack>


### PR DESCRIPTION
This PR does 3 things:

1. Fixes an issue where all CCTP routes would show the high gas alert as long as one route had it
2. Changes the gas alert threshold to 10% rather than a fixed $20
3. Alerts the user with a more specific message that the difference is greater than 10%

<img width="936" height="884" alt="Screenshot 2025-08-22 at 1 15 41 PM" src="https://github.com/user-attachments/assets/2c2eb7d7-b0dd-4954-9260-97c44bf969bd" />
<img width="750" height="681" alt="Screenshot 2025-08-22 at 1 16 09 PM" src="https://github.com/user-attachments/assets/dd5a1fa9-cf19-49ef-ba58-2fbbac5e1f45" />


https://linear.app/wormholelabs/issue/PROD-488/investigate-cctp-routes-warning-due-to-high-ethereum-gas-fees
