### PR TITLE
feat: whitelist HYPE, wHYPE, USDT0

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -28,4 +28,5 @@ export const CHAIN_ORDER: Chain[] = [
   'Berachain',
   'Mezo',
   'Fogo',
+  'HyperEVM',
 ];

--- a/src/config/mainnet/tokens.ts
+++ b/src/config/mainnet/tokens.ts
@@ -723,4 +723,31 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     decimals: 18,
     icon: TokenIcon.BTC,
   },
+  {
+    symbol: 'HYPE',
+    tokenId: {
+      chain: 'HyperEVM',
+      address: 'native',
+    },
+    decimals: 18,
+    icon: TokenIcon.HYPE,
+  },
+  {
+    symbol: 'wHYPE',
+    tokenId: {
+      chain: 'HyperEVM',
+      address: '0x5555555555555555555555555555555555555555',
+    },
+    decimals: 18,
+    icon: TokenIcon.HYPE,
+  },
+  {
+    symbol: 'USDT0',
+    tokenId: {
+      chain: 'HyperEVM',
+      address: '0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb',
+    },
+    decimals: 6,
+    icon: TokenIcon.USDT,
+  },
 ];


### PR DESCRIPTION
Loads hyperliquid assets: HYPE, wHYPE, and USDT0

<img width="641" height="611" alt="Screenshot 2025-08-25 at 12 44 44 PM" src="https://github.com/user-attachments/assets/82402a28-1d52-4b6d-a2e6-d2ceb0c729d7" />
<img width="691" height="676" alt="Screenshot 2025-08-25 at 12 49 38 PM" src="https://github.com/user-attachments/assets/cd876559-0693-4112-8712-48797a933a78" />
<img width="692" height="764" alt="Screenshot 2025-08-25 at 1 08 37 PM" src="https://github.com/user-attachments/assets/5d84128d-965f-4004-bb73-4051e2e6a905" />
