### PR TITLE
fix: prevent high has fee alert flicker between value changes

### DIFF
--- a/src/views/v2/Bridge/Routes/SingleRoute.tsx
+++ b/src/views/v2/Bridge/Routes/SingleRoute.tsx
@@ -144,7 +144,7 @@ const SingleRoute = (props: Props) => {
 
     const inputUsd = calculateUSDPriceRaw(
       getTokenPrice,
-      inputAmount,
+      amount.whole(quote.sourceToken.amount),
       sourceToken,
     );
     const outputAmount = amount.whole(quote.destinationToken.amount);

--- a/src/views/v3/Bridge/Routes/SingleRoute.tsx
+++ b/src/views/v3/Bridge/Routes/SingleRoute.tsx
@@ -121,7 +121,7 @@ const SingleRoute = (props: Props) => {
 
     const inputUsd = calculateUSDPriceRaw(
       getTokenPrice,
-      inputAmount,
+      amount.whole(quote.sourceToken.amount),
       sourceToken,
     );
     const outputAmount = amount.whole(quote.destinationToken.amount);


### PR DESCRIPTION
Now when you switch from a fee that has a high gas amount to one that does not, you don't see the flicker of the high gas fee alert.