### PR TITLE
feat: add new event type to WormholeConnectEventCore

### DIFF
--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -50,11 +50,14 @@ export type Experimental = {
   [Experiment in Experiments]?: boolean;
 };
 
+export interface ChainTokenSelection {
+  chain: Chain;
+  token?: string;
+}
+
 export interface DefaultInputs {
-  fromChain?: Chain;
-  toChain?: Chain;
-  fromToken?: string; // Address or symbol
-  toToken?: string; // Address or symbol
+  from?: ChainTokenSelection;
+  to?: ChainTokenSelection;
   requiredChain?: Chain;
   preferredRouteName?: string;
 }

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -50,14 +50,14 @@ export type Experimental = {
   [Experiment in Experiments]?: boolean;
 };
 
-export interface ChainTokenSelection {
+export interface ChainTokenPair {
   chain: Chain;
   token?: string;
 }
 
 export interface DefaultInputs {
-  from?: ChainTokenSelection;
-  to?: ChainTokenSelection;
+  source?: ChainTokenPair;
+  destination?: ChainTokenPair;
   requiredChain?: Chain;
   preferredRouteName?: string;
 }

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -153,10 +153,11 @@ export const validateDefaults = (
       delete defaults.destination;
     }
   }
-  if (defaults.source?.chain && defaults.destination?.chain) {
-    if (defaults.source.chain === defaults.destination.chain) {
+
+  if (defaults.source?.token && defaults.destination?.token) {
+    if (defaults.source.token === defaults.destination.token) {
       error(
-        `Source and destination chain cannot be the same, check the defaultInputs configuration`,
+        `Source and destination token cannot be the same, check the defaultInputs configuration`,
       );
     }
   }

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -135,33 +135,37 @@ export const validateDefaults = (
   tokens: TokenCache,
 ) => {
   if (!defaults) return;
-  if (defaults.from?.chain) {
-    const chain = chains[defaults.from.chain];
+  if (defaults.source?.chain) {
+    const chain = chains[defaults.source.chain];
     if (!chain) {
       error(
-        `Invalid chain name "${defaults.from.chain}" specified for defaultInputs.fromChain`,
+        `Invalid chain name "${defaults.source.chain}" specified for defaultInputs.source.chain`,
       );
-      delete defaults.from;
+      delete defaults.source;
     }
   }
-  if (defaults.to?.chain) {
-    const chain = chains[defaults.to.chain];
+  if (defaults.destination?.chain) {
+    const chain = chains[defaults.destination.chain];
     if (!chain) {
       error(
-        `Invalid chain name "${defaults.to.chain}" specified for defaultInputs.toChain`,
+        `Invalid chain name "${defaults.destination.chain}" specified for defaultInputs.destination.chain`,
       );
-      delete defaults.to;
+      delete defaults.destination;
     }
   }
-  if (defaults.from?.chain && defaults.to?.chain) {
-    if (defaults.from.chain === defaults.to.chain) {
+  if (defaults.source?.chain && defaults.destination?.chain) {
+    if (defaults.source.chain === defaults.destination.chain) {
       error(
         `Source and destination chain cannot be the same, check the defaultInputs configuration`,
       );
     }
   }
 
-  if (defaults.from?.chain && defaults.to?.chain && defaults.requiredChain) {
+  if (
+    defaults.source?.chain &&
+    defaults.destination?.chain &&
+    defaults.requiredChain
+  ) {
     const requiredConfig = chains[defaults.requiredChain];
     if (!requiredConfig) {
       error(
@@ -169,8 +173,8 @@ export const validateDefaults = (
       );
     }
     if (
-      defaults.to.chain !== defaults.requiredChain &&
-      defaults.from.chain !== defaults.requiredChain
+      defaults.destination.chain !== defaults.requiredChain &&
+      defaults.source.chain !== defaults.requiredChain
     ) {
       error(
         `Source chain or destination chain must equal the required network`,
@@ -178,29 +182,29 @@ export const validateDefaults = (
     }
   }
 
-  if (defaults.from?.chain && defaults.from?.token) {
+  if (defaults.source?.chain && defaults.source?.token) {
     const token = tokens.findByAddressOrSymbol(
-      defaults.from.chain,
-      defaults.from.token,
+      defaults.source.chain,
+      defaults.source.token,
     );
     if (!token) {
       error(
-        `Invalid token "${defaults.from?.token}" specified for defaultInputs.fromToken`,
+        `Invalid token "${defaults.source?.token}" specified for defaultInputs.fromToken`,
       );
-      delete defaults.from.token;
+      delete defaults.source.token;
     }
   }
 
-  if (defaults.to?.chain && defaults.to?.token) {
+  if (defaults.destination?.chain && defaults.destination?.token) {
     const token = tokens.findByAddressOrSymbol(
-      defaults.to.chain,
-      defaults.to.token,
+      defaults.destination.chain,
+      defaults.destination.token,
     );
     if (!token) {
       error(
-        `Invalid token "${defaults.to?.token}" specified for defaultInputs.toToken`,
+        `Invalid token "${defaults.destination?.token}" specified for defaultInputs.toToken`,
       );
-      delete defaults.to.token;
+      delete defaults.destination.token;
     }
   }
 

--- a/src/config/utils.ts
+++ b/src/config/utils.ts
@@ -135,33 +135,33 @@ export const validateDefaults = (
   tokens: TokenCache,
 ) => {
   if (!defaults) return;
-  if (defaults.fromChain) {
-    const chain = chains[defaults.fromChain];
+  if (defaults.from?.chain) {
+    const chain = chains[defaults.from.chain];
     if (!chain) {
       error(
-        `Invalid chain name "${defaults.fromChain}" specified for defaultInputs.fromChain`,
+        `Invalid chain name "${defaults.from.chain}" specified for defaultInputs.fromChain`,
       );
-      delete defaults.fromChain;
+      delete defaults.from;
     }
   }
-  if (defaults.toChain) {
-    const chain = chains[defaults.toChain];
+  if (defaults.to?.chain) {
+    const chain = chains[defaults.to.chain];
     if (!chain) {
       error(
-        `Invalid chain name "${defaults.toChain}" specified for defaultInputs.toChain`,
+        `Invalid chain name "${defaults.to.chain}" specified for defaultInputs.toChain`,
       );
-      delete defaults.fromChain;
+      delete defaults.to;
     }
   }
-  if (defaults.fromChain && defaults.toChain) {
-    if (defaults.fromChain === defaults.toChain) {
+  if (defaults.from?.chain && defaults.to?.chain) {
+    if (defaults.from.chain === defaults.to.chain) {
       error(
         `Source and destination chain cannot be the same, check the defaultInputs configuration`,
       );
     }
   }
 
-  if (defaults.fromChain && defaults.toChain && defaults.requiredChain) {
+  if (defaults.from?.chain && defaults.to?.chain && defaults.requiredChain) {
     const requiredConfig = chains[defaults.requiredChain];
     if (!requiredConfig) {
       error(
@@ -169,8 +169,8 @@ export const validateDefaults = (
       );
     }
     if (
-      defaults.toChain !== defaults.requiredChain &&
-      defaults.fromChain !== defaults.requiredChain
+      defaults.to.chain !== defaults.requiredChain &&
+      defaults.from.chain !== defaults.requiredChain
     ) {
       error(
         `Source chain or destination chain must equal the required network`,
@@ -178,29 +178,29 @@ export const validateDefaults = (
     }
   }
 
-  if (defaults.fromChain && defaults.fromToken) {
+  if (defaults.from?.chain && defaults.from?.token) {
     const token = tokens.findByAddressOrSymbol(
-      defaults.fromChain,
-      defaults.fromToken,
+      defaults.from.chain,
+      defaults.from.token,
     );
     if (!token) {
       error(
-        `Invalid token "${defaults.fromToken}" specified for defaultInputs.fromToken`,
+        `Invalid token "${defaults.from?.token}" specified for defaultInputs.fromToken`,
       );
-      delete defaults.fromToken;
+      delete defaults.from.token;
     }
   }
 
-  if (defaults.toChain && defaults.toToken) {
+  if (defaults.to?.chain && defaults.to?.token) {
     const token = tokens.findByAddressOrSymbol(
-      defaults.toChain,
-      defaults.toToken,
+      defaults.to.chain,
+      defaults.to.token,
     );
     if (!token) {
       error(
-        `Invalid token "${defaults.toToken}" specified for defaultInputs.toToken`,
+        `Invalid token "${defaults.to?.token}" specified for defaultInputs.toToken`,
       );
-      delete defaults.toToken;
+      delete defaults.to.token;
     }
   }
 

--- a/src/store/transferInput.ts
+++ b/src/store/transferInput.ts
@@ -51,11 +51,11 @@ export interface TransferInputState {
 
 // This is a function because config might have changed since we last cleared this store
 function getInitialState(): TransferInputState {
-  const { from, to } = config.ui.defaultInputs || {};
-  const fromChain = from?.chain;
-  const fromToken = from?.token;
-  const toChain = to?.chain;
-  const toToken = to?.token;
+  const { source, destination } = config.ui.defaultInputs || {};
+  const fromChain = source?.chain;
+  const fromToken = source?.token;
+  const toChain = destination?.chain;
+  const toToken = destination?.token;
   const fromTokenTuple =
     fromToken && fromChain
       ? config.tokens.findByAddressOrSymbol(fromChain, fromToken)?.tuple

--- a/src/store/transferInput.ts
+++ b/src/store/transferInput.ts
@@ -51,15 +51,17 @@ export interface TransferInputState {
 
 // This is a function because config might have changed since we last cleared this store
 function getInitialState(): TransferInputState {
-  const { fromChain, toChain, fromToken, toToken } =
-    config.ui.defaultInputs || {};
-
+  const { from, to } = config.ui.defaultInputs || {};
+  const fromChain = from?.chain;
+  const fromToken = from?.token;
+  const toChain = to?.chain;
+  const toToken = to?.token;
   const fromTokenTuple =
-    fromChain && fromToken
+    fromToken && fromChain
       ? config.tokens.findByAddressOrSymbol(fromChain, fromToken)?.tuple
       : undefined;
   const toTokenTuple =
-    toChain && toToken
+    toToken && toChain
       ? config.tokens.findByAddressOrSymbol(toChain, toToken)?.tuple
       : undefined;
 

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -103,13 +103,28 @@ export interface HistoryLoadEvent {
   };
 }
 
+export const enum UserActions {
+  SelectSrcToken = 'select.src.token',
+  SelectSrcChain = 'select.src.chain',
+  SelectDestToken = 'select.dest.token',
+  SelectDestChain = 'select.dest.chain',
+}
+
+export interface UserActionEvent {
+  type: 'user.action';
+  details: {
+    action: UserActions;
+  };
+}
+
 export type WormholeConnectEventCore =
   | LoadEvent
   | UpdateConfigEvent
   | TransferEvent
   | TransferErrorEvent
   | ConnectWalletEvent
-  | HistoryLoadEvent;
+  | HistoryLoadEvent
+  | UserActionEvent;
 
 export interface WormholeConnectEventMeta {
   meta: {

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -104,7 +104,7 @@ export interface HistoryLoadEvent {
   };
 }
 
-export const enum UserActions {
+export enum UserActions {
   SelectSrcToken = 'select.src.token',
   SelectSrcChain = 'select.src.chain',
   SelectDestToken = 'select.dest.token',

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -126,6 +126,11 @@ export type UserActionEvent<A extends UserActions = UserActions> = {
   };
 };
 
+// Helper type to narrow value by action
+export type UserActionEvents = {
+  [A in UserActions]: UserActionEvent<A>;
+}[UserActions];
+
 export type WormholeConnectEventCore =
   | LoadEvent
   | UpdateConfigEvent

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,6 +1,6 @@
 import type { Chain, amount as sdkAmount } from '@wormhole-foundation/sdk';
-import type { Token } from 'config/tokens';
 import type { WormholeConnectConfig } from 'config/types';
+import type { Token } from 'config/tokens';
 import type { TransferWallet } from 'utils/wallet';
 
 export interface LoadEvent {

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,4 +1,5 @@
 import type { Chain, amount as sdkAmount } from '@wormhole-foundation/sdk';
+import type { Token } from 'config/tokens';
 import type { WormholeConnectConfig } from 'config/types';
 import type { TransferWallet } from 'utils/wallet';
 
@@ -110,12 +111,20 @@ export const enum UserActions {
   SelectDestChain = 'select.dest.chain',
 }
 
-export interface UserActionEvent {
+type UserActionValueMap = {
+  [UserActions.SelectSrcToken]: Token;
+  [UserActions.SelectDestToken]: Token;
+  [UserActions.SelectSrcChain]: Chain;
+  [UserActions.SelectDestChain]: Chain;
+};
+
+export type UserActionEvent<A extends UserActions = UserActions> = {
   type: 'user.action';
   details: {
-    action: UserActions;
+    action: A;
+    value: UserActionValueMap[A];
   };
-}
+};
 
 export type WormholeConnectEventCore =
   | LoadEvent

--- a/src/telemetry/utils.ts
+++ b/src/telemetry/utils.ts
@@ -1,12 +1,10 @@
-import type { Network } from '@wormhole-foundation/sdk-connect';
-import type { InternalConfig } from 'config';
+import config from 'config';
 import type { Chain, Token } from 'exports';
 import { UserActions } from 'exports';
 
 export const handleTelemetryOnChainSelect = (
   chain: Chain,
   isSource: boolean,
-  config: InternalConfig<Network>,
 ) => {
   config.triggerEvent({
     type: 'user.action',
@@ -22,7 +20,6 @@ export const handleTelemetryOnChainSelect = (
 export const handleTelemetryOnTokenSelect = (
   token: Token,
   isSource: boolean,
-  config: InternalConfig<Network>,
 ) => {
   config.triggerEvent({
     type: 'user.action',

--- a/src/telemetry/utils.ts
+++ b/src/telemetry/utils.ts
@@ -1,11 +1,12 @@
+import type { Network } from '@wormhole-foundation/sdk-connect';
 import type { InternalConfig } from 'config';
 import type { Chain, Token } from 'exports';
 import { UserActions } from 'exports';
 
-export const handleSelectChain = (
+export const handleTelemetryOnChainSelect = (
   chain: Chain,
   isSource: boolean,
-  config: InternalConfig<'Mainnet' | 'Testnet' | 'Devnet'>,
+  config: InternalConfig<Network>,
 ) => {
   config.triggerEvent({
     type: 'user.action',
@@ -18,10 +19,10 @@ export const handleSelectChain = (
   });
 };
 
-export const handleSelectToken = (
+export const handleTelemetryOnTokenSelect = (
   token: Token,
   isSource: boolean,
-  config: InternalConfig<'Mainnet' | 'Testnet' | 'Devnet'>,
+  config: InternalConfig<Network>,
 ) => {
   config.triggerEvent({
     type: 'user.action',

--- a/src/telemetry/utils.ts
+++ b/src/telemetry/utils.ts
@@ -1,0 +1,35 @@
+import type { InternalConfig } from 'config';
+import type { Chain, Token, Token } from 'exports';
+import { UserActions } from 'exports';
+
+export const handleSelectChain = (
+  chain: Chain,
+  isSource: boolean,
+  config: InternalConfig<'Mainnet' | 'Testnet' | 'Devnet'>,
+) => {
+  config.triggerEvent({
+    type: 'user.action',
+    details: {
+      value: chain,
+      action: isSource
+        ? UserActions.SelectSrcChain
+        : UserActions.SelectDestChain,
+    },
+  });
+};
+
+export const handleSelectToken = (
+  token: Token,
+  isSource: boolean,
+  config: InternalConfig<'Mainnet' | 'Testnet' | 'Devnet'>,
+) => {
+  config.triggerEvent({
+    type: 'user.action',
+    details: {
+      value: token,
+      action: isSource
+        ? UserActions.SelectSrcToken
+        : UserActions.SelectDestToken,
+    },
+  });
+};

--- a/src/telemetry/utils.ts
+++ b/src/telemetry/utils.ts
@@ -1,5 +1,5 @@
 import type { InternalConfig } from 'config';
-import type { Chain, Token, Token } from 'exports';
+import type { Chain, Token } from 'exports';
 import { UserActions } from 'exports';
 
 export const handleSelectChain = (

--- a/src/telemetry/utils.ts
+++ b/src/telemetry/utils.ts
@@ -1,6 +1,7 @@
 import config from 'config';
-import type { Chain, Token } from 'exports';
-import { UserActions } from 'exports';
+import type { Chain } from '@wormhole-foundation/sdk-base';
+import type { Token } from 'config/tokens';
+import { UserActions } from './types';
 
 export const handleTelemetryOnChainSelect = (
   chain: Chain,

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -28,6 +28,7 @@ import type { Token } from 'config/tokens';
 import { useTokenList } from 'hooks/useTokenList';
 import { getTokenSymbol } from 'utils';
 import { UserActions } from 'telemetry';
+import { handleSelectChain, handleSelectToken } from 'telemetry/utils';
 
 type Props = {
   chain?: Chain | undefined;
@@ -271,14 +272,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              config.triggerEvent({
-                type: 'user.action',
-                details: {
-                  action: props.isSource
-                    ? UserActions.SelectSrcChain
-                    : UserActions.SelectDestChain,
-                },
-              });
+              handleSelectChain(key, props.isSource, config);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -299,14 +293,7 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                config.triggerEvent({
-                  type: 'user.action',
-                  details: {
-                    action: props.isSource
-                      ? UserActions.SelectSrcToken
-                      : UserActions.SelectDestToken,
-                  },
-                });
+                handleSelectToken(key, props.isSource, config);
                 props.setToken(key);
                 setIsDrawerOpen(false);
               }}
@@ -340,14 +327,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              config.triggerEvent({
-                type: 'user.action',
-                details: {
-                  action: props.isSource
-                    ? UserActions.SelectSrcChain
-                    : UserActions.SelectDestChain,
-                },
-              });
+              handleSelectChain(key, props.isSource, config);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -368,14 +348,8 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                config.triggerEvent({
-                  type: 'user.action',
-                  details: {
-                    action: props.isSource
-                      ? UserActions.SelectSrcToken
-                      : UserActions.SelectDestToken,
-                  },
-                });
+                handleSelectToken(key, props.isSource, config);
+
                 props.setToken(key);
                 popupState.close();
               }}

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -274,7 +274,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              handleTelemetryOnChainSelect(key, props.isSource, config);
+              handleTelemetryOnChainSelect(key, props.isSource);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -295,8 +295,8 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                handleTelemetryOnTokenSelect(key, props.isSource, config);
-                handleTelemetryOnChainSelect(key.chain, props.isSource, config);
+                handleTelemetryOnTokenSelect(key, props.isSource);
+                handleTelemetryOnChainSelect(key.chain, props.isSource);
                 props.setToken(key);
                 setIsDrawerOpen(false);
               }}
@@ -330,7 +330,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              handleTelemetryOnChainSelect(key, props.isSource, config);
+              handleTelemetryOnChainSelect(key, props.isSource);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -351,8 +351,8 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                handleTelemetryOnTokenSelect(key, props.isSource, config);
-                handleTelemetryOnChainSelect(key.chain, props.isSource, config);
+                handleTelemetryOnTokenSelect(key, props.isSource);
+                handleTelemetryOnChainSelect(key.chain, props.isSource);
                 props.setToken(key);
                 popupState.close();
               }}

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -27,6 +27,7 @@ import AssetBadge from 'components/AssetBadge';
 import type { Token } from 'config/tokens';
 import { useTokenList } from 'hooks/useTokenList';
 import { getTokenSymbol } from 'utils';
+import { UserActions } from 'telemetry';
 
 type Props = {
   chain?: Chain | undefined;
@@ -270,6 +271,14 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
+              config.triggerEvent({
+                type: 'user.action',
+                details: {
+                  action: props.isSource
+                    ? UserActions.SelectSrcChain
+                    : UserActions.SelectDestChain,
+                },
+              });
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -290,6 +299,14 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
+                config.triggerEvent({
+                  type: 'user.action',
+                  details: {
+                    action: props.isSource
+                      ? UserActions.SelectSrcToken
+                      : UserActions.SelectDestToken,
+                  },
+                });
                 props.setToken(key);
                 setIsDrawerOpen(false);
               }}
@@ -323,6 +340,14 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
+              config.triggerEvent({
+                type: 'user.action',
+                details: {
+                  action: props.isSource
+                    ? UserActions.SelectSrcChain
+                    : UserActions.SelectDestChain,
+                },
+              });
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -343,6 +368,14 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
+                config.triggerEvent({
+                  type: 'user.action',
+                  details: {
+                    action: props.isSource
+                      ? UserActions.SelectSrcToken
+                      : UserActions.SelectDestToken,
+                  },
+                });
                 props.setToken(key);
                 popupState.close();
               }}

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -296,6 +296,7 @@ const AssetPicker = (props: Props) => {
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
                 handleTelemetryOnTokenSelect(key, props.isSource, config);
+                handleTelemetryOnChainSelect(key.chain, props.isSource, config);
                 props.setToken(key);
                 setIsDrawerOpen(false);
               }}
@@ -351,6 +352,7 @@ const AssetPicker = (props: Props) => {
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
                 handleTelemetryOnTokenSelect(key, props.isSource, config);
+                handleTelemetryOnChainSelect(key.chain, props.isSource, config);
                 props.setToken(key);
                 popupState.close();
               }}

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -27,8 +27,10 @@ import AssetBadge from 'components/AssetBadge';
 import type { Token } from 'config/tokens';
 import { useTokenList } from 'hooks/useTokenList';
 import { getTokenSymbol } from 'utils';
-import { UserActions } from 'telemetry';
-import { handleSelectChain, handleSelectToken } from 'telemetry/utils';
+import {
+  handleTelemetryOnChainSelect,
+  handleTelemetryOnTokenSelect,
+} from 'telemetry/utils';
 
 type Props = {
   chain?: Chain | undefined;
@@ -272,7 +274,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              handleSelectChain(key, props.isSource, config);
+              handleTelemetryOnChainSelect(key, props.isSource, config);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -293,7 +295,7 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                handleSelectToken(key, props.isSource, config);
+                handleTelemetryOnTokenSelect(key, props.isSource, config);
                 props.setToken(key);
                 setIsDrawerOpen(false);
               }}
@@ -327,7 +329,7 @@ const AssetPicker = (props: Props) => {
             setShowSearch={setShowChainSearch}
             wallet={props.wallet}
             onChainSelect={(key) => {
-              handleSelectChain(key, props.isSource, config);
+              handleTelemetryOnChainSelect(key, props.isSource, config);
               props.setChain(key);
               setSearchQuery('');
             }}
@@ -348,8 +350,7 @@ const AssetPicker = (props: Props) => {
               searchQuery={searchQuery}
               onSearchQueryChange={setSearchQuery}
               onSelectToken={(key: Token) => {
-                handleSelectToken(key, props.isSource, config);
-
+                handleTelemetryOnTokenSelect(key, props.isSource, config);
                 props.setToken(key);
                 popupState.close();
               }}

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -297,7 +297,7 @@ function AssetPicker(props: Props) {
 
   const handleChainSelect = useCallback(
     (chain: Chain) => {
-      handleTelemetryOnChainSelect(chain, props.isSource, config);
+      handleTelemetryOnChainSelect(chain, props.isSource);
       props.setChain(chain);
       setSearchQuery('');
     },
@@ -306,8 +306,8 @@ function AssetPicker(props: Props) {
 
   const handleTokenSelect = useCallback(
     (token: Token) => {
-      handleTelemetryOnTokenSelect(token, props.isSource, config);
-      handleTelemetryOnChainSelect(token.chain, props.isSource, config);
+      handleTelemetryOnTokenSelect(token, props.isSource);
+      handleTelemetryOnChainSelect(token.chain, props.isSource);
       if (props.isSource && props.token?.key !== token.key) {
         // Reset amount when source token is changed
         handleAmountChange('');

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -307,6 +307,7 @@ function AssetPicker(props: Props) {
   const handleTokenSelect = useCallback(
     (token: Token) => {
       handleTelemetryOnTokenSelect(token, props.isSource, config);
+      handleTelemetryOnChainSelect(token.chain, props.isSource, config);
       if (props.isSource && props.token?.key !== token.key) {
         // Reset amount when source token is changed
         handleAmountChange('');

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -30,6 +30,10 @@ import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
 import { calculateUSDPrice, getTokenSymbol } from 'utils';
 import { formatWithCommas } from 'utils/formatNumber';
+import {
+  handleTelemetryOnChainSelect,
+  handleTelemetryOnTokenSelect,
+} from 'telemetry/utils';
 
 type Props = {
   chain?: Chain | undefined;
@@ -293,6 +297,7 @@ function AssetPicker(props: Props) {
 
   const handleChainSelect = useCallback(
     (chain: Chain) => {
+      handleTelemetryOnChainSelect(chain, props.isSource, config);
       props.setChain(chain);
       setSearchQuery('');
     },
@@ -301,6 +306,7 @@ function AssetPicker(props: Props) {
 
   const handleTokenSelect = useCallback(
     (token: Token) => {
+      handleTelemetryOnTokenSelect(token, props.isSource, config);
       if (props.isSource && props.token?.key !== token.key) {
         // Reset amount when source token is changed
         handleAmountChange('');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
   ],
   "compilerOptions": {
     "baseUrl": "src",
-    "allowImportingTsExtensions": true,
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
**Introduces breaking changes**:
- Updated defaultInput prop from 'fromChain, toChain, fromToken, toToken' to 'source' and 'destination'

**Updates**
- Added a new event type to WormholeConnectEventCore to support remembering the last chain and token the user selected so if they refresh it persists
- Fix condition which inside validateDefaults as it no longer stands because we support same chain swaps