### PR TITLE
chore: add WSOL to UNI source and rename to SOL

### DIFF
--- a/src/config/mainnet/wrappedTokens.ts
+++ b/src/config/mainnet/wrappedTokens.ts
@@ -365,6 +365,7 @@ export const MAINNET_WRAPPED_TOKENS = {
       Xlayer: '0x3a859D92da2E16Ad32C5C6F3ADAddFBa4dE3A47e',
       Scroll: '0xCDf95E1F720caade4b1DC83ABfE15400D2a458AD',
       Worldchain: '0xEfae32D1c15EDBaEA3ebdDe1e2C51003AED04d30',
+      Unichain: '0xbdE8A5331E8Ac4831cf8ea9e42e229219EafaB97',
     },
     EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
       Ethereum: '0x41f7B8b9b897276b7AAE926a9016935280b44E97',

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -36,6 +36,9 @@ export type UiConfig = {
 
   // UI experimental features
   experimental?: Experimental;
+
+  // Override token names for specific chains and addresses (ex: display "SOL" instead of "WSOL")
+  tokenNameOverrides?: { [chain in Chain]?: { [address: string]: string } };
 };
 
 export type TestOptions = {

--- a/src/hooks/useTokenListWithSearch.ts
+++ b/src/hooks/useTokenListWithSearch.ts
@@ -10,6 +10,7 @@ import type { Chain } from '@wormhole-foundation/sdk';
 import type { Token } from 'config/tokens';
 import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
+import { getTokenDisplayName } from 'utils';
 import { filterTokensByBalance } from 'utils/tokenListUtils';
 import type { Balances } from 'utils/wallet/types';
 import { unionBy } from 'es-toolkit';
@@ -102,10 +103,12 @@ export const useTokenListWithSearch = ({
     if (deferredSearch) {
       const searchLower = deferredSearch.toLowerCase();
       tokens = tokens.filter((token) => {
-        if (
-          token.symbol?.toLowerCase().includes(searchLower) ||
-          token.name?.toLowerCase().includes(searchLower)
-        ) {
+        const overrideName = getTokenDisplayName(token)?.toLowerCase();
+        const symbolMatch = token.symbol?.toLowerCase().includes(searchLower);
+        const nameMatch = token.name?.toLowerCase().includes(searchLower);
+        const overrideMatch = overrideName?.includes(searchLower);
+
+        if (symbolMatch || nameMatch || overrideMatch) {
           return true;
         }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -69,6 +69,26 @@ export function getGasToken(chain: Chain): Token {
   return gasToken;
 }
 
+export function getTokenDisplayName(token: Token): string {
+  const chainOverrides = config.ui?.tokenNameOverrides?.[token.chain];
+
+  if (!chainOverrides) {
+    return token.display;
+  }
+
+  const addrLower = token.addressString.toLowerCase();
+
+  for (const [address, name] of Object.entries(chainOverrides)) {
+    if (address.toLowerCase() === addrLower) {
+      return name;
+    }
+  }
+
+  // example code for UNI WSOL -> SOL: { Unichain: { '0xb...B97': 'SOL' } }
+
+  return token.display;
+}
+
 export function chainDisplayName(chain: Chain): string {
   const chainConfig = config.chains[chain];
   if (chainConfig) {

--- a/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -13,7 +13,11 @@ import TokenIcon from 'icons/TokenIcons';
 import type { Token } from 'config/tokens';
 
 import type { Chain, amount as sdkAmount } from '@wormhole-foundation/sdk';
-import { chainDisplayName, getTokenExplorerUrl } from 'utils';
+import {
+  chainDisplayName,
+  getTokenExplorerUrl,
+  getTokenDisplayName,
+} from 'utils';
 import ChainIcon from 'icons/ChainIcons';
 import Color from 'color';
 import TokenBalance from 'components/TokenBalance';
@@ -72,6 +76,8 @@ function TokenItem(props: TokenItemProps) {
   const explorerURL = address ? getTokenExplorerUrl(chain, address) : '';
   const addressDisplay = `${token.shortAddress}`;
 
+  const displayName = getTokenDisplayName(token);
+
   return (
     <ListItemButton
       sx={{
@@ -87,7 +93,7 @@ function TokenItem(props: TokenItemProps) {
           <TokenIcon icon={props.token.icon} />
         </ListItemIcon>
         <div>
-          <Typography>{token.display}</Typography>
+          <Typography>{displayName}</Typography>
 
           <Box display="flex">
             {token.tokenBridgeOriginalTokenId ? (

--- a/src/views/v2/Bridge/AssetPicker/index.tsx
+++ b/src/views/v2/Bridge/AssetPicker/index.tsx
@@ -26,6 +26,7 @@ import TokenList from './TokenList';
 import AssetBadge from 'components/AssetBadge';
 import type { Token } from 'config/tokens';
 import { useTokenList } from 'hooks/useTokenList';
+import { getTokenDisplayName } from 'utils';
 
 type Props = {
   chain?: Chain | undefined;
@@ -112,11 +113,9 @@ const AssetPicker = (props: Props) => {
       );
     }
 
-    const tokenDisplay = props.token ? (
-      <>{props.token.display}</>
-    ) : (
-      <>Select token</>
-    );
+    const tokenDisplay = props.token
+      ? getTokenDisplayName(props.token)
+      : 'Select token';
 
     return (
       <div>

--- a/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
@@ -13,7 +13,11 @@ import TokenIcon from 'icons/TokenIcons';
 import type { Token } from 'config/tokens';
 
 import type { Chain, amount as sdkAmount } from '@wormhole-foundation/sdk';
-import { chainDisplayName, getTokenExplorerUrl } from 'utils';
+import {
+  chainDisplayName,
+  getTokenExplorerUrl,
+  getTokenDisplayName,
+} from 'utils';
 import ChainIcon from 'icons/ChainIcons';
 import Color from 'color';
 import TokenBalance from 'components/TokenBalance';
@@ -72,6 +76,8 @@ function TokenItem(props: TokenItemProps) {
   const explorerURL = address ? getTokenExplorerUrl(chain, address) : '';
   const addressDisplay = `${token.shortAddress}`;
 
+  const displayName = getTokenDisplayName(token);
+
   return (
     <ListItemButton
       sx={{
@@ -80,7 +86,7 @@ function TokenItem(props: TokenItemProps) {
       }}
       dense
       data-testid={`token-button-${chain.toLowerCase()}-${token.address.toString()}`}
-      aria-label={`Select ${token.display || token.symbol}`}
+      aria-label={`Select ${displayName || token.symbol}`}
       onMouseDown={props.onClick}
     >
       <Box sx={styles.tokenDetails}>
@@ -88,7 +94,7 @@ function TokenItem(props: TokenItemProps) {
           <TokenIcon icon={props.token.icon} />
         </ListItemIcon>
         <div>
-          <Typography>{token.display}</Typography>
+          <Typography>{displayName}</Typography>
 
           <Box display="flex">
             {token.tokenBridgeOriginalTokenId ? (

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -28,7 +28,7 @@ import { OPACITY } from 'utils/style';
 import Color from 'color';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
-import { calculateUSDPrice } from 'utils';
+import { calculateUSDPrice, getTokenDisplayName } from 'utils';
 import { formatWithCommas } from 'utils/formatNumber';
 
 type Props = {
@@ -152,10 +152,12 @@ function AssetPicker(props: Props) {
   }, [props.chain]);
 
   const selection = useMemo(() => {
-    const tokenDisplay = props.token ? <>{props.token.display}</> : <>Select</>;
-
     return (
-      <Tooltip title={props.token?.display ?? 'Select a token'}>
+      <Tooltip
+        title={
+          props.token ? getTokenDisplayName(props.token) : 'Select a token'
+        }
+      >
         <Typography
           component="div"
           fontSize="16px"
@@ -163,7 +165,7 @@ function AssetPicker(props: Props) {
           maxWidth="64px"
           noWrap
         >
-          {tokenDisplay}
+          {props.token ? getTokenDisplayName(props.token) : 'Select'}
         </Typography>
       </Tooltip>
     );


### PR DESCRIPTION
Fixes: WSOL was missing from the source wallet when UNI was selected; it was only available as the destination.

Changes: Switches UNI WSOL spelling to SOL. It still shows WSOL in small lettering beneath SOL to differentiate.

Handled via the UIConfig.

---

Note: may need to clear cache. I was seeing WSOL until I did so.

V2:
<img width="802" height="672" alt="Screenshot 2025-09-02 at 10 42 38 AM" src="https://github.com/user-attachments/assets/6cf16a21-2661-40b6-ac78-878fb68a7569" />
<img width="1030" height="867" alt="Screenshot 2025-09-02 at 10 42 49 AM" src="https://github.com/user-attachments/assets/49ad5d69-1559-4327-bee3-e857110dbf3c" />

---

V3:
<img width="756" height="792" alt="Screenshot 2025-09-02 at 10 52 59 AM" src="https://github.com/user-attachments/assets/249a3a23-5695-4d04-b793-5aecde5de38b" />
