### PR TITLE
test: Add e2e tests for more routes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    continue-on-error: true
     environment: ci
     permissions: read-all
     defaults:

--- a/tests/e2e/config/index.ts
+++ b/tests/e2e/config/index.ts
@@ -16,6 +16,21 @@ const mayanSWIFT = `{
   ],
 }`;
 
+const mayanMCTP = `{
+  network: 'mainnet',
+  coingecko: { customUrl: 'https://coingecko.labsapis.com' },
+  ui: {
+    experimental: { enableUIRefreshV3: true },
+    showInProgressWidget: true,
+    testOptions: {
+      enableHeadlessSigner: true,
+    },
+  },
+  routes: [
+    MayanRouteMCTP,
+  ],
+}`;
+
 const CCTPExecutor = `{
   network: 'mainnet',
   coingecko: { customUrl: 'https://coingecko.labsapis.com' },
@@ -29,6 +44,142 @@ const CCTPExecutor = `{
   routes: [
     cctpExecutorRoute({ referrerFeeDbps: 0n, }),
   ],
+}`;
+
+const CCTPV2Standard = `{
+  network: 'mainnet',
+  coingecko: { customUrl: 'https://coingecko.labsapis.com' },
+  ui: {
+    experimental: { enableUIRefreshV3: true },
+    showInProgressWidget: true,
+    testOptions: {
+      enableHeadlessSigner: true,
+    },
+  },
+  routes: [
+    cctpV2StandardExecutorRoute({ referrerFeeDbps: 0n, }),
+  ],
+}`;
+
+const NTTRoutes = `{
+  network: 'mainnet',
+  coingecko: { customUrl: 'https://coingecko.labsapis.com' },
+  ui: {
+    experimental: { enableUIRefreshV3: true },
+    showInProgressWidget: true,
+    testOptions: { enableHeadlessSigner: false },
+  },
+  routes: [
+    ...nttRoutes({
+      tokens: {
+        W: [
+          {
+            chain: "Solana",
+            manager: "NTtAaoDJhkeHeaVUHnyhwbPNAN6WgBpHkHBTc6d7vLK",
+            token: "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ",
+            transceiver: [
+              {
+                address: "NTtAaoDJhkeHeaVUHnyhwbPNAN6WgBpHkHBTc6d7vLK",
+                type: "wormhole",
+              },
+            ],
+            quoter: "Nqd6XqA8LbsCuG8MLWWuP865NV6jR1MbXeKxD4HLKDJ",
+          },
+          {
+            chain: "Ethereum",
+            manager: "0xc072B1AEf336eDde59A049699Ef4e8Fa9D594A48",
+            token: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+            transceiver: [
+              {
+                address: "0xDb55492d7190D1baE8ACbE03911C4E3E7426870c",
+                type: "wormhole",
+              },
+            ],
+          },
+          {
+            chain: "Arbitrum",
+            manager: "0x5333d0AcA64a450Add6FeF76D6D1375F726CB484",
+            token: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+            transceiver: [
+              {
+                address: "0xD1a8AB69e00266e8B791a15BC47514153A5045a6",
+                type: "wormhole",
+              },
+            ],
+          },
+          {
+            chain: "Optimism",
+            manager: "0x1a4F1a790f23Ffb9772966cB6F36dCd658033e13",
+            token: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+            transceiver: [
+              {
+                address: "0x9bD8b7b527CA4e6738cBDaBdF51C22466756073d",
+                type: "wormhole",
+              },
+            ],
+          },
+          {
+            chain: "Base",
+            manager: "0x5333d0AcA64a450Add6FeF76D6D1375F726CB484",
+            token: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+            transceiver: [
+              {
+                address: "0xD1a8AB69e00266e8B791a15BC47514153A5045a6",
+                type: "wormhole",
+              },
+            ],
+          },
+        ],
+      },
+    }),
+  ],
+  tokensConfig: {
+    Wsolana: {
+      symbol: "W",
+      tokenId: {
+        chain: "Solana",
+        address: "85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ",
+      },
+      icon: "https://assets.coingecko.com/coins/images/35087/standard/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954",
+      decimals: 6,
+    },
+    Wethereum: {
+      symbol: "W",
+      tokenId: {
+        chain: "Ethereum",
+        address: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+      },
+      icon: "https://assets.coingecko.com/coins/images/35087/standard/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954",
+      decimals: 18,
+    },
+    Warbitrum: {
+      symbol: "W",
+      tokenId: {
+        chain: "Arbitrum",
+        address: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+      },
+      icon: "https://assets.coingecko.com/coins/images/35087/standard/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954",
+      decimals: 18,
+    },
+    Woptimism: {
+      symbol: "W",
+      tokenId: {
+        chain: "Optimism",
+        address: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+      },
+      icon: "https://assets.coingecko.com/coins/images/35087/standard/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954",
+      decimals: 18,
+    },
+    Wbase: {
+      symbol: "W",
+      tokenId: {
+        chain: "Base",
+        address: "0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91",
+      },
+      icon: "https://assets.coingecko.com/coins/images/35087/standard/womrhole_logo_full_color_rgb_2000px_72ppi_fb766ac85a.png?1708688954",
+      decimals: 18,
+    },
+  },
 }`;
 
 export const testConfigs: Array<TestConfig> = [
@@ -57,6 +208,23 @@ export const testConfigs: Array<TestConfig> = [
     waitForCompletion: true,
   },
   {
+    name: 'MayanSwapMCTP',
+    config: mayanMCTP,
+    enabled: true,
+    sourceAsset: {
+      chain: 'Arbitrum',
+      symbol: 'USDC',
+      address: circle.usdcContract.get('Mainnet', 'Arbitrum'),
+    },
+    destinationAsset: {
+      chain: 'Base',
+      symbol: 'USDC',
+      address: circle.usdcContract.get('Mainnet', 'Base'),
+    },
+    amount: '10',
+    waitForCompletion: false,
+  },
+  {
     name: 'CCTPExecutorRoute',
     config: CCTPExecutor,
     enabled: true,
@@ -78,6 +246,40 @@ export const testConfigs: Array<TestConfig> = [
       address: circle.usdcContract.get('Mainnet', 'Arbitrum'),
     },
     amount: '1',
+    waitForCompletion: false,
+  },
+  {
+    name: 'CCTPV2StandardExecutorRoute',
+    config: CCTPV2Standard,
+    enabled: true,
+    sourceAsset: {
+      chain: 'Base',
+      symbol: 'USDC',
+      address: circle.usdcContract.get('Mainnet', 'Base'),
+    },
+    destinationAsset: {
+      chain: 'Arbitrum',
+      symbol: 'USDC',
+      address: circle.usdcContract.get('Mainnet', 'Arbitrum'),
+    },
+    amount: '10',
+    waitForCompletion: false,
+  },
+  {
+    name: 'NttExecutorRoute',
+    config: NTTRoutes,
+    enabled: true,
+    sourceAsset: {
+      chain: 'Ethereum',
+      symbol: 'W',
+      address: '0xB0fFa8000886e57F86dd5264b9582b2Ad87b2b91',
+    },
+    destinationAsset: {
+      chain: 'Solana',
+      symbol: 'W',
+      address: '85VBFQZC9TZkfaptBWjvUw7YbZjy52A6mjtPGjstQAmQ',
+    },
+    amount: '10',
     waitForCompletion: false,
   },
 ];

--- a/tests/e2e/config/types.ts
+++ b/tests/e2e/config/types.ts
@@ -4,7 +4,7 @@ export type TestConfig = {
   name: string;
   config: string;
   enabled: boolean;
-  sourceWallet: {
+  sourceWallet?: {
     address: string;
     privateKey: string;
   };
@@ -13,7 +13,7 @@ export type TestConfig = {
     symbol: string;
     address: string | undefined;
   };
-  destinationWallet: {
+  destinationWallet?: {
     address: string;
   };
   destinationAsset: {

--- a/tests/e2e/specs/routes.spec.ts
+++ b/tests/e2e/specs/routes.spec.ts
@@ -80,6 +80,14 @@ testConfigs.forEach(
         !destinationAsset.address,
         `Test ${name} is missing destination token address`,
       );
+      test.skip(
+        !sourceWallet?.address,
+        `Test ${name} is missing source wallet address`,
+      );
+      test.skip(
+        !destinationWallet?.address,
+        `Test ${name} is missing destination wallet address`,
+      );
 
       const configQuery = btoa(config);
 

--- a/tests/e2e/views/bridge.ts
+++ b/tests/e2e/views/bridge.ts
@@ -179,7 +179,7 @@ export class BridgeView {
     const routeToggle = this.page.getByRole('button', {
       name: 'View other routes',
     });
-    await routeToggle.isVisible();
+    await expect(routeToggle).toBeVisible();
     await routeToggle.click();
 
     // Route should be visible and selected by default
@@ -188,7 +188,12 @@ export class BridgeView {
     ).toBeVisible();
 
     // Close the routes modal/drawer
-    await this.page.getByRole('button', { name: /Close routes/ }).click();
+    const closeButton = this.page.getByRole('button', { name: /Close routes/ });
+    await expect(closeButton).toBeVisible();
+    await closeButton.click();
+
+    // Wait for modal to close
+    await expect(closeButton).not.toBeVisible();
   }
 
   async startTransaction() {


### PR DESCRIPTION
This will add no-wallet tests for:
- MayanSwapMCTP
- CCTPV2StandardExecutorRoute
- NttExecutorRoute