### PR TITLE
feat: group assets in selector by owned vs all

### DIFF
--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -5,12 +5,10 @@ import { useTheme } from '@mui/material/styles';
 
 const TokenBalance = ({
   balance,
-  isSource,
   isFetching,
   price,
 }: {
   balance: sdkAmount.Amount | null;
-  isSource?: boolean;
   isFetching?: boolean;
   price?: string | null;
 }) => {
@@ -26,8 +24,8 @@ const TokenBalance = ({
     );
   }
 
-  const shouldHideBalance =
-    !isSource && balance && sdkAmount.display(balance) === '0';
+  // Hide 0 / $0 for both source and destination lists
+  const shouldHideBalance = !balance || sdkAmount.display(balance) === '0';
 
   return (
     <Stack alignItems="flex-end">

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -9,7 +9,6 @@ import {
   sortTokensByPreference,
   applyTokenWhitelist,
   applyCustomTokenSupport,
-  filterTokensByBalance,
   applyShittokenFilter,
 } from 'utils/tokenListUtils';
 import config from 'config';
@@ -60,13 +59,6 @@ export const useTokenList = ({
     if (isSourceList && !searchQuery && config.network === 'Mainnet') {
       // Filter out possible scamcoins
       tokens = applyShittokenFilter(tokens);
-    }
-
-    // Filter by balance for source tokens when not searching
-    // This allows users to search for zero-balance tokens by contract address if needed
-    // Never filter destination tokens by balance
-    if (isSourceList && !searchQuery) {
-      tokens = filterTokensByBalance(tokens, balances, wallet.address);
     }
 
     return tokens;

--- a/src/hooks/useTokenListGrouping.ts
+++ b/src/hooks/useTokenListGrouping.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import type { Token } from 'config/tokens';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import type { Balances } from 'utils/wallet';
+
+export function useTokenListGrouping({
+  sortedTokens,
+  isGroupingEnabled,
+  isWalletConnected,
+  balances,
+}: {
+  sortedTokens: Token[];
+  isWalletConnected: boolean;
+  isGroupingEnabled: boolean;
+  balances: Balances;
+}): { listItems: Token[]; ownedCount: number } {
+  return useMemo(() => {
+    if (!isGroupingEnabled) {
+      return { listItems: sortedTokens, ownedCount: 0 };
+    }
+
+    const getHasPositiveBalance = (t: Token) => {
+      if (!isWalletConnected) return false;
+      const bal = balances?.[t.key]?.balance;
+      return bal != null && sdkAmount.units(bal) > 0n;
+    };
+
+    const native = sortedTokens.find((t) => t.isNativeGasToken);
+    const nativeKey = native?.key;
+
+    const ownedTokens = sortedTokens.filter(getHasPositiveBalance);
+    const ownedKeys = new Set(ownedTokens.map((t) => t.key));
+
+    const listItems = [
+      // 1) Owned
+      ...ownedTokens,
+      // 2) Native (only if not owned)
+      ...(native && nativeKey && !ownedKeys.has(nativeKey) ? [native] : []),
+      // 3) The rest
+      ...sortedTokens.filter(
+        (t) => !ownedKeys.has(t.key) && t.key !== nativeKey,
+      ),
+    ];
+
+    return { listItems, ownedCount: ownedTokens.length };
+  }, [sortedTokens, isGroupingEnabled, isWalletConnected, balances]);
+}

--- a/src/hooks/useTokenListWithSearch.ts
+++ b/src/hooks/useTokenListWithSearch.ts
@@ -12,7 +12,6 @@ import type { Token } from 'config/tokens';
 import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
 import { getTokenSymbol } from 'utils';
-import { filterTokensByBalance } from 'utils/tokenListUtils';
 import type { Balances } from 'utils/wallet/types';
 import { unionBy } from 'es-toolkit';
 
@@ -140,11 +139,6 @@ export const useTokenListWithSearch = ({
       });
     }
 
-    // Filter by balance for source tokens when not searching
-    if (isSource && !deferredSearch) {
-      tokens = filterTokensByBalance(tokens, balances, walletAddress);
-    }
-
     // For destination token list in same-chain swaps, filter out the source token
     if (!isSource && isSameChainSwap && sourceToken) {
       tokens = tokens.filter(
@@ -161,8 +155,6 @@ export const useTokenListWithSearch = ({
     isSource,
     isSameChainSwap,
     sourceToken,
-    balances,
-    walletAddress,
   ]);
 
   const tokenPrices = useMemo(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -203,6 +203,10 @@ export const getUSDFormat = (price: number | undefined): string => {
     return '$0';
   }
 
+  if (price > 0 && price < 0.01) {
+    return '<$0.01';
+  }
+
   return Intl.NumberFormat('en-EN', {
     style: 'currency',
     currency: 'USD',

--- a/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v2/Bridge/AssetPicker/TokenItem.tsx
@@ -153,7 +153,6 @@ function TokenItem(props: TokenItemProps) {
       <TokenBalance
         balance={props.balance}
         price={props.price}
-        isSource={props.isSource}
         isFetching={props.isFetchingBalance}
       />
     </ListItemButton>

--- a/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
@@ -27,6 +27,7 @@ type TokenItemProps = {
   isSelected?: boolean;
   isFetchingBalance?: boolean;
   isSource?: boolean;
+  dimmed?: boolean;
 };
 
 function TokenItem(props: TokenItemProps) {
@@ -79,6 +80,7 @@ function TokenItem(props: TokenItemProps) {
       sx={{
         ...styles.tokenListItem,
         ...(props.isSelected && styles.tokenListItemSelected),
+        ...(props.dimmed ? { opacity: 0.6 } : {}),
       }}
       dense
       data-testid={`token-button-${chain.toLowerCase()}-${token.address.toString()}`}
@@ -154,7 +156,6 @@ function TokenItem(props: TokenItemProps) {
       <TokenBalance
         balance={props.balance}
         price={props.price}
-        isSource={props.isSource}
         isFetching={props.isFetchingBalance}
       />
     </ListItemButton>

--- a/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenItem.tsx
@@ -27,7 +27,7 @@ type TokenItemProps = {
   isSelected?: boolean;
   isFetchingBalance?: boolean;
   isSource?: boolean;
-  dimmed?: boolean;
+  isDimmed?: boolean;
 };
 
 function TokenItem(props: TokenItemProps) {
@@ -80,7 +80,7 @@ function TokenItem(props: TokenItemProps) {
       sx={{
         ...styles.tokenListItem,
         ...(props.isSelected && styles.tokenListItemSelected),
-        ...(props.dimmed ? { opacity: 0.6 } : {}),
+        ...(props.isDimmed ? { opacity: 0.6 } : {}),
       }}
       dense
       data-testid={`token-button-${chain.toLowerCase()}-${token.address.toString()}`}

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -115,28 +115,27 @@ const TokenList = (props: Props) => {
 
     // Normal state - show the token list
     return 'ready';
-  }, [
-    props.isSource,
-    props.wallet?.address,
-    props.isConnectingWallet,
-    props.isFetching,
-    sortedTokens.length,
-  ]);
+  }, [props.isFetching, sortedTokens.length]);
 
   const shouldShowLoadingState = listState === 'loading';
   const shouldShowEmptyMessage = listState === 'empty';
 
   // Build sectioned list for source picker when not searching
   const isGroupingEnabled = props.isSource && !props.searchQuery;
+  const isWalletConnected = Boolean(props.wallet?.address);
 
-  const { itemsForRender, ownedCount } = useMemo(() => {
+  const { listItems, ownedCount } = useMemo(() => {
     if (!isGroupingEnabled) {
-      return { itemsForRender: sortedTokens, ownedCount: 0 };
+      return { listItems: sortedTokens, ownedCount: 0 };
     }
 
     const hasPositiveBalance = (token: Token) => {
+      if (!isWalletConnected) {
+        return false;
+      }
+
       const bal = props.balances?.[token.key]?.balance;
-      return !!(bal && sdkAmount.units(bal) > 0n);
+      return Boolean(bal && sdkAmount.units(bal) > 0n);
     };
 
     const nativeToken = sortedTokens.find((token) => token.isNativeGasToken);
@@ -147,14 +146,14 @@ const TokenList = (props: Props) => {
       nativeToken && !ownedSet.has(nativeToken.key) ? [nativeToken] : [];
 
     const rest = sortedTokens.filter(
-      (t) =>
-        !ownedSet.has(t.key) && (!nativeToken || t.key !== nativeToken.key),
+      (tok) =>
+        !ownedSet.has(tok.key) && (!nativeToken || tok.key !== nativeToken.key),
     );
 
-    const itemsForRender = [...ownedTokens, ...nativePart, ...rest];
+    const listItems = [...ownedTokens, ...nativePart, ...rest];
 
-    return { itemsForRender, ownedCount: ownedTokens.length };
-  }, [isGroupingEnabled, props.balances, sortedTokens]);
+    return { listItems, ownedCount: ownedTokens.length };
+  }, [isGroupingEnabled, isWalletConnected, props.balances, sortedTokens]);
 
   const searchList = (
     <SearchableList<Token>
@@ -173,7 +172,7 @@ const TokenList = (props: Props) => {
           </ListItemButton>
         ))
       }
-      items={itemsForRender}
+      items={listItems}
       onQueryChange={(query) => {
         props.onSearchQueryChange(query);
       }}
@@ -185,7 +184,9 @@ const TokenList = (props: Props) => {
             ? getUSDFormat(calculateUSDPriceRaw(tokenPrice, balance, token))
             : null;
 
-        const isRestSection = isGroupingEnabled && index >= ownedCount;
+        // Do not dim when no wallet is connected
+        const isRestSection =
+          isGroupingEnabled && isWalletConnected && index >= ownedCount;
 
         return (
           <Fragment key={token.key}>

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -214,7 +214,7 @@ const TokenList = (props: Props) => {
               price={price}
               isSelected={token.key === props.selectedToken?.key}
               isFetchingBalance={props.isFetchingBalances}
-              dimmed={isRestSection}
+              isDimmed={isRestSection}
             />
           </Fragment>
         );

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -14,7 +14,8 @@ import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
 import type { Balances } from 'utils/wallet/types';
 import { useTokenListWithSearch } from 'hooks/useTokenListWithSearch';
-import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import TokenSectionHeader from './TokenSectionHeader';
+import { useTokenListGrouping } from 'hooks/useTokenListGrouping';
 
 type Props = {
   tokenList: Array<Token>;
@@ -124,36 +125,12 @@ const TokenList = (props: Props) => {
   const isGroupingEnabled = props.isSource && !props.searchQuery;
   const isWalletConnected = Boolean(props.wallet?.address);
 
-  const { listItems, ownedCount } = useMemo(() => {
-    if (!isGroupingEnabled) {
-      return { listItems: sortedTokens, ownedCount: 0 };
-    }
-
-    const hasPositiveBalance = (token: Token) => {
-      if (!isWalletConnected) {
-        return false;
-      }
-
-      const bal = props.balances?.[token.key]?.balance;
-      return Boolean(bal && sdkAmount.units(bal) > 0n);
-    };
-
-    const nativeToken = sortedTokens.find((token) => token.isNativeGasToken);
-    const ownedTokens = sortedTokens.filter(hasPositiveBalance);
-    const ownedSet = new Set(ownedTokens.map((t) => t.key));
-
-    const nativePart =
-      nativeToken && !ownedSet.has(nativeToken.key) ? [nativeToken] : [];
-
-    const rest = sortedTokens.filter(
-      (tok) =>
-        !ownedSet.has(tok.key) && (!nativeToken || tok.key !== nativeToken.key),
-    );
-
-    const listItems = [...ownedTokens, ...nativePart, ...rest];
-
-    return { listItems, ownedCount: ownedTokens.length };
-  }, [isGroupingEnabled, isWalletConnected, props.balances, sortedTokens]);
+  const { listItems, ownedCount } = useTokenListGrouping({
+    sortedTokens,
+    isWalletConnected,
+    isGroupingEnabled,
+    balances: props.balances,
+  });
 
   const searchList = (
     <SearchableList<Token>
@@ -190,20 +167,11 @@ const TokenList = (props: Props) => {
 
         return (
           <Fragment key={token.key}>
-            {isGroupingEnabled && index === 0 && ownedCount > 0 && (
-              <Box sx={{ padding: '4px 16px' }}>
-                <Typography fontSize={14} color={theme.palette.text.secondary}>
-                  Your tokens
-                </Typography>
-              </Box>
-            )}
-            {isGroupingEnabled && index === ownedCount && (
-              <Box sx={{ padding: '4px 16px' }}>
-                <Typography fontSize={14} color={theme.palette.text.secondary}>
-                  All tokens
-                </Typography>
-              </Box>
-            )}
+            <TokenSectionHeader
+              index={index}
+              ownedCount={ownedCount}
+              isGroupingEnabled={isGroupingEnabled}
+            />
             <TokenItem
               key={token.key}
               token={token}

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import { Box, Card, CardContent, Skeleton, useTheme } from '@mui/material';
 import CircularProgress from '@mui/material/CircularProgress';
 import ListItemButton from '@mui/material/ListItemButton';
@@ -14,6 +14,7 @@ import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
 import type { Balances } from 'utils/wallet/types';
 import { useTokenListWithSearch } from 'hooks/useTokenListWithSearch';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
 type Props = {
   tokenList: Array<Token>;
@@ -102,11 +103,6 @@ const TokenList = (props: Props) => {
 
   // Determine the current state of the token list
   const listState = useMemo(() => {
-    // For source list, require wallet to show balances/tokens from wallet
-    if (props.isSource && !props.wallet?.address && !props.isConnectingWallet) {
-      return 'empty';
-    }
-
     // Currently fetching initial data
     if (props.isFetching) {
       return 'loading';
@@ -130,27 +126,43 @@ const TokenList = (props: Props) => {
   const shouldShowLoadingState = listState === 'loading';
   const shouldShowEmptyMessage = listState === 'empty';
 
+  // Build sectioned list for source picker when not searching
+  const isGroupingEnabled = props.isSource && !props.searchQuery;
+
+  const { itemsForRender, ownedCount } = useMemo(() => {
+    if (!isGroupingEnabled) {
+      return { itemsForRender: sortedTokens, ownedCount: 0 };
+    }
+
+    const hasPositiveBalance = (token: Token) => {
+      const bal = props.balances?.[token.key]?.balance;
+      return !!(bal && sdkAmount.units(bal) > 0n);
+    };
+
+    const nativeToken = sortedTokens.find((token) => token.isNativeGasToken);
+    const ownedTokens = sortedTokens.filter(hasPositiveBalance);
+    const ownedSet = new Set(ownedTokens.map((t) => t.key));
+
+    const nativePart =
+      nativeToken && !ownedSet.has(nativeToken.key) ? [nativeToken] : [];
+
+    const rest = sortedTokens.filter(
+      (t) =>
+        !ownedSet.has(t.key) && (!nativeToken || t.key !== nativeToken.key),
+    );
+
+    const itemsForRender = [...ownedTokens, ...nativePart, ...rest];
+
+    return { itemsForRender, ownedCount: ownedTokens.length };
+  }, [isGroupingEnabled, props.balances, sortedTokens]);
+
   const searchList = (
     <SearchableList<Token>
       searchPlaceholder={placeholder}
       sx={styles.tokenList}
       dataTestId="token-search-list"
       searchQuery={props.searchQuery}
-      listTitle={
-        shouldShowEmptyMessage ? (
-          emptyMessage
-        ) : (
-          <Box display="flex" width="100%">
-            <Typography
-              style={{ flexGrow: '2' }}
-              fontSize={14}
-              color={theme.palette.text.secondary}
-            >
-              Tokens on {props.selectedChainConfig.displayName}
-            </Typography>
-          </Box>
-        )
-      }
+      listTitle={shouldShowEmptyMessage ? emptyMessage : ''}
       loading={
         shouldShowLoadingState &&
         [1, 2, 3].map((x) => (
@@ -161,11 +173,11 @@ const TokenList = (props: Props) => {
           </ListItemButton>
         ))
       }
-      items={sortedTokens}
+      items={itemsForRender}
       onQueryChange={(query) => {
         props.onSearchQueryChange(query);
       }}
-      renderFn={(token: Token) => {
+      renderFn={(token: Token, index: number) => {
         const balance = props.balances?.[token.key]?.balance;
         const tokenPrice = tokenPrices.get(token.key);
         const price =
@@ -173,20 +185,37 @@ const TokenList = (props: Props) => {
             ? getUSDFormat(calculateUSDPriceRaw(tokenPrice, balance, token))
             : null;
 
+        const isRestSection = isGroupingEnabled && index >= ownedCount;
+
         return (
-          <TokenItem
-            key={token.key}
-            token={token}
-            chain={props.selectedChainConfig.sdkName}
-            onClick={() => {
-              props.onSelectToken(token);
-            }}
-            isSource={props.isSource}
-            balance={balance}
-            price={price}
-            isSelected={token.key === props.selectedToken?.key}
-            isFetchingBalance={props.isFetchingBalances}
-          />
+          <Fragment key={token.key}>
+            {isGroupingEnabled && index === 0 && ownedCount > 0 && (
+              <Box sx={{ padding: '4px 16px' }}>
+                <Typography fontSize={14} color={theme.palette.text.secondary}>
+                  Your tokens
+                </Typography>
+              </Box>
+            )}
+            {isGroupingEnabled && index === ownedCount && (
+              <Box sx={{ padding: '4px 16px' }}>
+                <Typography fontSize={14} color={theme.palette.text.secondary}>
+                  All tokens
+                </Typography>
+              </Box>
+            )}
+            <TokenItem
+              key={token.key}
+              token={token}
+              chain={props.selectedChainConfig.sdkName}
+              onClick={() => props.onSelectToken(token)}
+              isSource={props.isSource}
+              balance={balance}
+              price={price}
+              isSelected={token.key === props.selectedToken?.key}
+              isFetchingBalance={props.isFetchingBalances}
+              dimmed={isRestSection}
+            />
+          </Fragment>
         );
       }}
     />
@@ -196,9 +225,6 @@ const TokenList = (props: Props) => {
     <Card sx={styles.card} variant="elevation">
       <CardContent sx={styles.tokenListContainer}>
         <Box sx={{ display: 'flex', padding: '0 16px' }}>
-          <Typography width="100%" sx={styles.title}>
-            Select a token
-          </Typography>
           {isFetchingToken || props.isFetchingBalances ? (
             <CircularProgress
               sx={{ alignSelf: 'flex-end', marginBottom: '12px' }}

--- a/src/views/v3/Bridge/AssetPicker/TokenSectionHeader.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenSectionHeader.tsx
@@ -1,0 +1,37 @@
+import { Box, useTheme } from '@mui/material';
+
+import { Typography } from '@mui/material';
+import React from 'react';
+
+const TokenSectionHeader = ({
+  index,
+  ownedCount,
+  isGroupingEnabled,
+}: {
+  index: number;
+  ownedCount: number;
+  isGroupingEnabled: boolean;
+}) => {
+  const theme = useTheme();
+
+  return (
+    <>
+      {isGroupingEnabled && index === 0 && ownedCount > 0 && (
+        <Box sx={{ padding: '4px 16px' }}>
+          <Typography fontSize={14} color={theme.palette.text.secondary}>
+            Your tokens
+          </Typography>
+        </Box>
+      )}
+      {isGroupingEnabled && index === ownedCount && (
+        <Box sx={{ padding: '4px 16px' }}>
+          <Typography fontSize={14} color={theme.palette.text.secondary}>
+            All tokens
+          </Typography>
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default TokenSectionHeader;


### PR DESCRIPTION
1. When USD balances are < $0.01, they showed as $0.00. Now they show as < $0.01
2. All assets now show in the source selector, divided by owned versus all, with all dimmed and your owned ones undimmed.
3. Removes the 'Select a Token' and 'Tokens on X' text for cleanliness
4. Changes 'Choose a network' with 'Choose chain'

<img width="609" height="644" alt="Screenshot 2025-09-03 at 7 13 17 PM" src="https://github.com/user-attachments/assets/01f5869d-6860-4794-9aba-cce4a7499684" />
<img width="713" height="720" alt="Screenshot 2025-09-03 at 7 13 23 PM" src="https://github.com/user-attachments/assets/f74f6d1c-9d26-4af1-ac5d-44524c211dec" />

https://linear.app/wormholelabs/issue/PROD-611/possibly-show-all-tokens-in-the-source-asset-picker-when-connected-to

https://linear.app/wormholelabs/issue/PROD-612/possibly-show-something-other-than-dollar0-as-the-token-balance-amount