### PR TITLE
chore: change build lib to output library in esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "start:mainnet": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Mainnet vite --host --force",
     "build": "npm run build:lib; npm run build:hosted; npm run build:netlify",
     "build:lib": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
+    "build:minimal": "VITE_BUILD_MINIMAL=1 NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
     "build:hosted": "VITE_BUILD_HOSTED=1 NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
     "build:netlify": "VITE_BUILD_NETLIFY=1 NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
     "lint": "scripts/lint.sh",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,8 @@
     "use-debounce": "10.0.6"
   },
   "scripts": {
-    "start": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Testnet vite --host",
-    "start:mainnet": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Mainnet vite --host",
+    "start": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Testnet vite --host --force",
+    "start:mainnet": "NODE_OPTIONS=--max-http-header-size=32000 REACT_APP_CONNECT_ENV=Mainnet vite --host --force",
     "build": "npm run build:lib; npm run build:hosted; npm run build:netlify",
     "build:lib": "NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",
     "build:hosted": "VITE_BUILD_HOSTED=1 NODE_ENV=production NODE_OPTIONS=--max-old-space-size=10240 vite build",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -7,7 +7,7 @@ import {
   ConfigEnv,
   BuildEnvironmentOptions,
 } from 'vite';
-import type { PreRenderedAsset } from 'rollup';
+import type { InputOption, PreRenderedAsset } from 'rollup';
 import react from '@vitejs/plugin-react-swc';
 import checker from 'vite-plugin-checker';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
@@ -18,6 +18,7 @@ import packageJson from './package.json';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const { version } = packageJson;
+const isAnalyze = process.env.ANALYZE === 'true';
 
 let gitHash = 'unknown';
 
@@ -133,69 +134,87 @@ const hostedBuild: BuildEnvironmentOptions = {
   },
 };
 
-// Production build, for direct import
+const libEntry: InputOption = [
+  path.resolve(__dirname, 'src/exports/index.ts'),
+  path.resolve(__dirname, 'src/exports/mayan.ts'),
+  path.resolve(__dirname, 'src/exports/ntt.ts'),
+  path.resolve(__dirname, 'src/exports/hosted.ts'),
+  path.resolve(__dirname, 'src/exports/executor.ts'),
+];
+
+const rollupInput: InputOption = {
+  index: 'src/exports/index.ts',
+  mayan: 'src/exports/mayan.ts',
+  ntt: 'src/exports/ntt.ts',
+  hosted: 'src/exports/hosted.ts',
+  executor: 'src/exports/executor.ts',
+};
+
+const external = [
+  'react',
+  'react/jsx-runtime',
+  '@emotion/react',
+  '@emotion/styled',
+  '@mui/material',
+  '@mui/icons-material',
+  '@mui/styled-engine',
+  '@mui/system',
+];
+
+// Production build, for npm import
 const libBuild: BuildEnvironmentOptions = {
   outDir: './lib',
   lib: {
-    entry: [
-      path.resolve(__dirname, 'src/exports/index.ts'),
-      path.resolve(__dirname, 'src/exports/mayan.ts'),
-      path.resolve(__dirname, 'src/exports/ntt.ts'),
-      path.resolve(__dirname, 'src/exports/hosted.ts'),
-      path.resolve(__dirname, 'src/exports/executor.ts'),
-    ],
-    formats: ['es'],
-    // fileName: (_, entryname) => {
-    //   const n = entryname.split('/').pop()!;
-    //   return `${n.split('.')[0]}.mjs`;
-    // },
+    entry: libEntry,
+    formats: isAnalyze ? ['es'] : ['es', 'cjs'],
+    fileName: (format, entryname) => {
+      const n = entryname.split('/').pop()!;
+      return `${n.split('.')[0]}.${format === 'es' ? 'mjs' : 'js'}`;
+    },
   },
   rollupOptions: {
-    input: {
-      index: 'src/exports/index.ts',
-      mayan: 'src/exports/mayan.ts',
-      ntt: 'src/exports/ntt.ts',
-      hosted: 'src/exports/hosted.ts',
-      executor: 'src/exports/executor.ts',
-    },
+    input: rollupInput,
     output: {
-      // entryFileNames: '[name].mjs',
+      assetFileNames,
+      inlineDynamicImports: false,
+      exports: 'named' as const,
+    },
+    external,
+  },
+};
+
+// Minimal build, for submodule import
+const minimalBuild: BuildEnvironmentOptions = {
+  sourcemap: true,
+  minify: false,
+  outDir: './lib',
+  lib: {
+    entry: libEntry,
+    formats: ['es'],
+  },
+  rollupOptions: {
+    input: rollupInput,
+    output: {
+      entryFileNames: '[name].mjs',
       chunkFileNames: '[name].mjs',
       assetFileNames: '[name].[ext]',
       inlineDynamicImports: false,
       preserveModules: true,
       preserveModulesRoot: 'src',
-      entryFileNames(chunkInfo) {
-        if (chunkInfo.name.includes('node_modules')) {
-          return chunkInfo.name.replace('node_modules', 'external') + '.mjs';
-        }
-
-        return '[name].mjs';
-      },
     },
-    external: [
-      'react',
-      'react/jsx-runtime',
-      '@emotion/react',
-      '@emotion/styled',
-      '@mui/material',
-      '@mui/icons-material',
-      '@mui/styled-engine',
-      '@mui/system',
-    ],
+    external,
   },
-  minify: false,
   terserOptions: {
     mangle: false,
     compress: false,
   },
-  sourcemap: true,
 };
 
 export default defineConfig(({ command, mode }: ConfigEnv) => {
   const env = loadEnv(mode, process.cwd(), '');
   const isHosted = !!env.VITE_BUILD_HOSTED;
   const isNetlify = !!env.VITE_BUILD_NETLIFY;
+  const isMinimal = !!env.VITE_BUILD_MINIMAL;
   const isSampleApp = command === 'serve' || (command === 'build' && isNetlify);
 
   let build: BuildEnvironmentOptions | undefined = undefined;
@@ -205,6 +224,8 @@ export default defineConfig(({ command, mode }: ConfigEnv) => {
   } else if (command === 'build') {
     if (isHosted) {
       build = hostedBuild;
+    } else if (isMinimal) {
+      build = minimalBuild;
     } else {
       build = libBuild;
     }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,7 +1,12 @@
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
-import { defineConfig, loadEnv, ConfigEnv, LibraryFormats } from 'vite';
+import {
+  defineConfig,
+  loadEnv,
+  ConfigEnv,
+  BuildEnvironmentOptions,
+} from 'vite';
 import type { PreRenderedAsset } from 'rollup';
 import react from '@vitejs/plugin-react-swc';
 import checker from 'vite-plugin-checker';
@@ -12,10 +17,10 @@ import packageJson from './package.json';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
 const { version } = packageJson;
 
 let gitHash = 'unknown';
+
 try {
   gitHash = execSync('git log -1 --format=%H').toString().replace('\n', '');
 } catch (e) {
@@ -26,11 +31,6 @@ try {
 console.info(
   `\nBuilding Wormhole Connect version=${version} hash=${gitHash}\n`,
 );
-
-// There are three configs this file can return.
-// 1. local dev server
-// 2. production build, for direct import
-// 3. production build, hosted by unpkg.com (includes React, auto-binds to DOM)
 
 // TODO: consider using the "VITE_APP_" prefix which is the default for Vite
 const envPrefix = 'REACT_APP_';
@@ -65,12 +65,8 @@ const resolve = {
 };
 
 const plugins = [
-  checker({
-    typescript: true,
-  }),
-  dts({
-    insertTypesEntry: true,
-  }),
+  checker({ typescript: true }),
+  dts({ insertTypesEntry: true }),
   react(),
   nodePolyfills({
     include: [
@@ -97,135 +93,128 @@ const plugins = [
     }),
 ].filter(Boolean);
 
-const optimizeDeps = {};
+function assetFileNames(assetInfo: PreRenderedAsset) {
+  if (assetInfo.name === 'main.css') {
+    return '[name][extname]';
+  }
 
-const output: {
-  assetFileNames: (assetInfo: PreRenderedAsset) => string;
-  inlineDynamicImports: boolean;
-  exports: 'named' | 'default' | 'none' | 'auto';
-} = {
-  assetFileNames: (assetInfo: PreRenderedAsset) => {
-    if (assetInfo.name === 'main.css') {
-      return '[name][extname]';
-    }
-    return '[name]-[hash][extname]';
+  return '[name]-[hash][extname]';
+}
+
+// Netlify and local dev server
+const sampleAppBuild: BuildEnvironmentOptions = {
+  outDir: './build',
+  rollupOptions: {
+    input: {
+      main: 'src/SampleApp.tsx',
+      index: 'index.html',
+    } as Record<string, string>,
+    output: {
+      assetFileNames,
+      inlineDynamicImports: false,
+      exports: 'named' as const,
+    },
   },
-  inlineDynamicImports: false,
-  exports: 'named' as const,
+};
+
+// Legacy production build, hosted by unpkg.com (includes React, auto-binds to DOM)
+const hostedBuild: BuildEnvironmentOptions = {
+  outDir: './dist',
+  rollupOptions: {
+    input: {
+      main: 'src/main.tsx',
+    } as Record<string, string>,
+    output: {
+      entryFileNames: '[name].mjs',
+      assetFileNames,
+      inlineDynamicImports: false,
+      exports: 'named' as const,
+    },
+  },
+};
+
+// Production build, for direct import
+const libBuild: BuildEnvironmentOptions = {
+  outDir: './lib',
+  lib: {
+    entry: [
+      path.resolve(__dirname, 'src/exports/index.ts'),
+      path.resolve(__dirname, 'src/exports/mayan.ts'),
+      path.resolve(__dirname, 'src/exports/ntt.ts'),
+      path.resolve(__dirname, 'src/exports/hosted.ts'),
+      path.resolve(__dirname, 'src/exports/executor.ts'),
+    ],
+    formats: ['es'],
+    // fileName: (_, entryname) => {
+    //   const n = entryname.split('/').pop()!;
+    //   return `${n.split('.')[0]}.mjs`;
+    // },
+  },
+  rollupOptions: {
+    input: {
+      index: 'src/exports/index.ts',
+      mayan: 'src/exports/mayan.ts',
+      ntt: 'src/exports/ntt.ts',
+      hosted: 'src/exports/hosted.ts',
+      executor: 'src/exports/executor.ts',
+    },
+    output: {
+      // entryFileNames: '[name].mjs',
+      chunkFileNames: '[name].mjs',
+      assetFileNames: '[name].[ext]',
+      inlineDynamicImports: false,
+      preserveModules: true,
+      preserveModulesRoot: 'src',
+      entryFileNames(chunkInfo) {
+        if (chunkInfo.name.includes('node_modules')) {
+          return chunkInfo.name.replace('node_modules', 'external') + '.mjs';
+        }
+
+        return '[name].mjs';
+      },
+    },
+    external: [
+      'react',
+      'react/jsx-runtime',
+      '@emotion/react',
+      '@emotion/styled',
+      '@mui/material',
+      '@mui/icons-material',
+      '@mui/styled-engine',
+      '@mui/system',
+    ],
+  },
+  minify: false,
+  terserOptions: {
+    mangle: false,
+    compress: false,
+  },
+  sourcemap: true,
 };
 
 export default defineConfig(({ command, mode }: ConfigEnv) => {
   const env = loadEnv(mode, process.cwd(), '');
   const isHosted = !!env.VITE_BUILD_HOSTED;
   const isNetlify = !!env.VITE_BUILD_NETLIFY;
-  const isAnalyze = process.env.ANALYZE === 'true';
+  const isSampleApp = command === 'serve' || (command === 'build' && isNetlify);
 
-  if (command === 'serve' || (command === 'build' && isNetlify)) {
-    // Local development
-    return {
-      define,
-      envPrefix,
-      resolve,
-      build: {
-        outDir: './build',
-        rollupOptions: {
-          input: {
-            main: 'src/SampleApp.tsx',
-            index: 'index.html',
-          } as Record<string, string>,
-          output,
-        },
-      },
-      plugins,
-      optimizeDeps,
-    };
+  let build: BuildEnvironmentOptions | undefined = undefined;
+
+  if (isSampleApp) {
+    build = sampleAppBuild;
   } else if (command === 'build') {
-    //
-    // Building for production
-    // There are two possible configs here: invoked by "npm run build" and "npm run build:hosted"
-    //
-    // - by default, we build a component library that can be imported and used in React apps
-    //
-    // - alternatively, VITE_BUILD_HOSTED=1 causes Vite to build a bundle that is used
-    //   via unpkg.com hosting. This build looks for a DOM element #wormhole-connect and comes
-    //   bundled with a copy of React. This is "legacy mode" and useful only on web apps that don't
-    //   use React.
-    //
-
     if (isHosted) {
-      return {
-        define,
-        envPrefix,
-        resolve,
-        build: {
-          outDir: './dist',
-          rollupOptions: {
-            input: {
-              main: 'src/main.tsx',
-            } as Record<string, string>,
-            output: {
-              entryFileNames: '[name].js',
-              ...output,
-            },
-          },
-        },
-        plugins,
-        optimizeDeps,
-      };
+      build = hostedBuild;
     } else {
-      return {
-        define,
-        envPrefix,
-        resolve,
-        build: {
-          outDir: './lib',
-          lib: {
-            entry: [
-              path.resolve(__dirname, 'src/exports/index.ts'),
-              path.resolve(__dirname, 'src/exports/mayan.ts'),
-              path.resolve(__dirname, 'src/exports/ntt.ts'),
-              path.resolve(__dirname, 'src/exports/hosted.ts'),
-              path.resolve(__dirname, 'src/exports/executor.ts'),
-            ],
-            formats: (isAnalyze ? ['es'] : ['es', 'cjs']) as LibraryFormats[],
-            fileName: (format, entryname) => {
-              const n = entryname.split('/').pop()!;
-              return `${n.split('.')[0]}.${format === 'es' ? 'mjs' : 'js'}`;
-            },
-          },
-          rollupOptions: {
-            input: {
-              index: 'src/exports/index.ts',
-              mayan: 'src/exports/mayan.ts',
-              ntt: 'src/exports/ntt.ts',
-              hosted: 'src/exports/hosted.ts',
-              executor: 'src/exports/executor.ts',
-            },
-            output,
-            external: [
-              'react',
-              'react/jsx-runtime',
-              '@emotion/react',
-              '@emotion/styled',
-              '@mui/material',
-              '@mui/icons-material',
-              '@mui/styled-engine',
-              '@mui/system',
-            ],
-          },
-        },
-        plugins,
-        optimizeDeps,
-      };
+      build = libBuild;
     }
   }
 
-  // Default configuration if no conditions are met
   return {
+    build,
     define,
     envPrefix,
     resolve,
     plugins,
-    optimizeDeps,
   };
 });


### PR DESCRIPTION
In connect, the `lib` build is what builds the package like an npm module to be consumed by parent projects, for eg Portal. However the `lib` folder ends up with mangled/minified/chunked code that is hard to debug.

This PR adds a new build `minimal` command to do whatever the `lib` build does and additionally preserves all modules disabling any mangling/minifying/chunking.

<img width="1138" height="697" alt="Screenshot 2025-09-05 at 3 00 30 PM" src="https://github.com/user-attachments/assets/68325eba-c943-496d-81bf-148c4c5b1442" />

TODOS:

- [ ] Check non-lib builds work as before
- [ ] Check portal properly minifies and bundles
- [ ] Check monad properly minifies and bundles