### PR TITLE
chore: fix loading spinner jank in v3 asset picker

### DIFF
--- a/src/components/TokenBalance.tsx
+++ b/src/components/TokenBalance.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Stack, Typography, CircularProgress } from '@mui/material';
+import { Box, Skeleton, Stack, Typography } from '@mui/material';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 import { useTheme } from '@mui/material/styles';
 
@@ -13,33 +13,45 @@ const TokenBalance = ({
   price?: string | null;
 }) => {
   const theme = useTheme();
+  const shouldHideBalance = !balance || sdkAmount.display(balance) === '0';
+  const containerWidth = 120; // Reserve space to prevent layout shift
 
-  if (isFetching && balance === null) {
+  if (isFetching) {
     return (
-      <Stack alignItems="flex-end">
-        <Typography fontSize={14}>
-          <CircularProgress size={24} />
-        </Typography>
-      </Stack>
+      <Box sx={{ width: containerWidth }}>
+        <Stack alignItems="flex-end">
+          <Skeleton
+            variant="rounded"
+            height={14}
+            width="80%"
+            sx={{ borderRadius: '8px' }}
+          />
+          <Skeleton
+            variant="rounded"
+            height={14}
+            width="60%"
+            sx={{ borderRadius: '8px', mt: 0.5 }}
+          />
+        </Stack>
+      </Box>
     );
   }
 
-  // Hide 0 / $0 for both source and destination lists
-  const shouldHideBalance = !balance || sdkAmount.display(balance) === '0';
-
   return (
-    <Stack alignItems="flex-end">
-      <Typography fontSize={14}>
-        {balance && !shouldHideBalance
-          ? sdkAmount.display(sdkAmount.truncate(balance, 6))
-          : ''}
-      </Typography>
-      {price && !shouldHideBalance && (
-        <Typography color={theme.palette.text.secondary} fontSize="10px">
-          {price}
+    <Box sx={{ width: containerWidth }}>
+      <Stack alignItems="flex-end">
+        <Typography fontSize={14}>
+          {balance && !shouldHideBalance
+            ? sdkAmount.display(sdkAmount.truncate(balance, 6))
+            : ''}
         </Typography>
-      )}
-    </Stack>
+        {price && !shouldHideBalance && (
+          <Typography color={theme.palette.text.secondary} fontSize="10px">
+            {price}
+          </Typography>
+        )}
+      </Stack>
+    </Box>
   );
 };
 

--- a/src/views/v3/Bridge/AssetPicker/SearchableList/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/SearchableList/index.tsx
@@ -34,7 +34,7 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
       padding: 0,
     },
     searchList: {
-      marginTop: '12px',
+      marginTop: 0,
       overflow: 'auto',
     },
   };
@@ -62,6 +62,7 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
         placeholder={props.searchPlaceholder}
       />
       <List
+        disablePadding
         sx={{ ...styles.searchList, ...scrollbarStyles }}
         data-testid={props.dataTestId}
       >

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -1,9 +1,6 @@
 import React, { Fragment, useMemo } from 'react';
-import { Box, Card, CardContent, Skeleton, useTheme } from '@mui/material';
-import CircularProgress from '@mui/material/CircularProgress';
-import ListItemButton from '@mui/material/ListItemButton';
+import { Card, CardContent, useTheme } from '@mui/material';
 import Typography from '@mui/material/Typography';
-
 import type { ChainConfig } from 'config/types';
 import type { Token } from 'config/tokens';
 import type { WalletData } from 'store/wallet';
@@ -11,7 +8,6 @@ import SearchableList from 'views/v3/Bridge/AssetPicker/SearchableList';
 import TokenItem from 'views/v3/Bridge/AssetPicker/TokenItem';
 import { getUSDFormat, calculateUSDPriceRaw } from 'utils';
 import config from 'config';
-import { useTokens } from 'contexts/TokensContext';
 import type { Balances } from 'utils/wallet/types';
 import { useTokenListWithSearch } from 'hooks/useTokenListWithSearch';
 import TokenSectionHeader from './TokenSectionHeader';
@@ -38,7 +34,6 @@ type Props = {
 const TokenList = (props: Props) => {
   const theme = useTheme();
   const tokenPastingIsEnabled = config.ui.disableUserInputtedTokens !== true;
-  const { isFetchingToken } = useTokens();
 
   const { sortedTokens, tokenPrices } = useTokenListWithSearch({
     baseTokenList: props.tokenList,
@@ -87,10 +82,10 @@ const TokenList = (props: Props) => {
         fontSize: 14,
         marginBottom: '8px',
       },
-      tokenLoader: {
-        padding: 0,
+      tokenLoaderRow: {
         display: 'flex',
         justifyContent: 'space-between',
+        padding: '8px 16px',
       },
       tokenList: {
         maxHeight: '360px',
@@ -118,9 +113,6 @@ const TokenList = (props: Props) => {
     return 'ready';
   }, [props.isFetching, sortedTokens.length]);
 
-  const shouldShowLoadingState = listState === 'loading';
-  const shouldShowEmptyMessage = listState === 'empty';
-
   // Build sectioned list for source picker when not searching
   const isGroupingEnabled = props.isSource && !props.searchQuery;
   const isWalletConnected = Boolean(props.wallet?.address);
@@ -132,76 +124,52 @@ const TokenList = (props: Props) => {
     balances: props.balances,
   });
 
-  const searchList = (
-    <SearchableList<Token>
-      searchPlaceholder={placeholder}
-      sx={styles.tokenList}
-      dataTestId="token-search-list"
-      searchQuery={props.searchQuery}
-      listTitle={shouldShowEmptyMessage ? emptyMessage : ''}
-      loading={
-        shouldShowLoadingState &&
-        [1, 2, 3].map((x) => (
-          <ListItemButton sx={styles.tokenLoader} dense key={x}>
-            <Box padding="8px 16px">
-              <Skeleton variant="circular" width="36px" height="36px" />
-            </Box>
-          </ListItemButton>
-        ))
-      }
-      items={listItems}
-      onQueryChange={(query) => {
-        props.onSearchQueryChange(query);
-      }}
-      renderFn={(token: Token, index: number) => {
-        const balance = props.balances?.[token.key]?.balance;
-        const tokenPrice = tokenPrices.get(token.key);
-        const price =
-          balance && tokenPrice !== undefined
-            ? getUSDFormat(calculateUSDPriceRaw(tokenPrice, balance, token))
-            : null;
-
-        // Do not dim when no wallet is connected
-        const isRestSection =
-          isGroupingEnabled && isWalletConnected && index >= ownedCount;
-
-        return (
-          <Fragment key={token.key}>
-            <TokenSectionHeader
-              index={index}
-              ownedCount={ownedCount}
-              isGroupingEnabled={isGroupingEnabled}
-            />
-            <TokenItem
-              key={token.key}
-              token={token}
-              chain={props.selectedChainConfig.sdkName}
-              onClick={() => props.onSelectToken(token)}
-              isSource={props.isSource}
-              balance={balance}
-              price={price}
-              isSelected={token.key === props.selectedToken?.key}
-              isFetchingBalance={props.isFetchingBalances}
-              isDimmed={isRestSection}
-            />
-          </Fragment>
-        );
-      }}
-    />
-  );
-
   return (
     <Card sx={styles.card} variant="elevation">
       <CardContent sx={styles.tokenListContainer}>
-        <Box sx={{ display: 'flex', padding: '0 16px' }}>
-          {isFetchingToken || props.isFetchingBalances ? (
-            <CircularProgress
-              sx={{ alignSelf: 'flex-end', marginBottom: '12px' }}
-              size={14}
-            />
-          ) : null}
-        </Box>
-        {searchList}
+        <SearchableList<Token>
+          searchPlaceholder={placeholder}
+          sx={styles.tokenList}
+          dataTestId="token-search-list"
+          searchQuery={props.searchQuery}
+          listTitle={listState === 'empty' ? emptyMessage : ''}
+          items={listItems}
+          onQueryChange={props.onSearchQueryChange}
+          renderFn={(token: Token, index: number) => {
+            const balance = props.balances?.[token.key]?.balance;
+            const tokenPrice = tokenPrices.get(token.key);
+            const price =
+              balance && tokenPrice !== undefined
+                ? getUSDFormat(calculateUSDPriceRaw(tokenPrice, balance, token))
+                : null;
+
+            // Do not dim when no wallet is connected
+            const isRestSection =
+              isGroupingEnabled && isWalletConnected && index >= ownedCount;
+
+            return (
+              <Fragment key={token.key}>
+                <TokenSectionHeader
+                  index={index}
+                  ownedCount={ownedCount}
+                  isGroupingEnabled={isGroupingEnabled}
+                />
+                <TokenItem
+                  key={token.key}
+                  token={token}
+                  chain={props.selectedChainConfig.sdkName}
+                  onClick={() => props.onSelectToken(token)}
+                  isSource={props.isSource}
+                  balance={balance}
+                  price={price}
+                  isSelected={token.key === props.selectedToken?.key}
+                  isFetchingBalance={props.isFetchingBalances}
+                  isDimmed={isRestSection}
+                />
+              </Fragment>
+            );
+          }}
+        />
       </CardContent>
     </Card>
   );

--- a/src/views/v3/Bridge/AssetPicker/TokenSectionHeader.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenSectionHeader.tsx
@@ -1,5 +1,4 @@
 import { Box, useTheme } from '@mui/material';
-
 import { Typography } from '@mui/material';
 import React from 'react';
 
@@ -14,23 +13,39 @@ const TokenSectionHeader = ({
 }) => {
   const theme = useTheme();
 
+  if (!isGroupingEnabled) {
+    return null;
+  }
+
+  let label: string | null = null;
+
+  if (index === 0 && ownedCount > 0) {
+    label = 'Your tokens';
+  }
+
+  if (index === ownedCount) {
+    label = 'All tokens';
+  }
+
+  if (!label) {
+    return null;
+  }
+
   return (
-    <>
-      {isGroupingEnabled && index === 0 && ownedCount > 0 && (
-        <Box sx={{ padding: '4px 16px' }}>
-          <Typography fontSize={14} color={theme.palette.text.secondary}>
-            Your tokens
-          </Typography>
-        </Box>
-      )}
-      {isGroupingEnabled && index === ownedCount && (
-        <Box sx={{ padding: '4px 16px' }}>
-          <Typography fontSize={14} color={theme.palette.text.secondary}>
-            All tokens
-          </Typography>
-        </Box>
-      )}
-    </>
+    <Box
+      sx={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 2,
+        padding: `${theme.spacing(1)} 16px 4px 16px`,
+        background: theme.palette.input.background,
+        transition: 'background-color 150ms ease',
+      }}
+    >
+      <Typography fontSize={14} color={theme.palette.text.secondary}>
+        {label}
+      </Typography>
+    </Box>
   );
 };
 


### PR DESCRIPTION
- Improves jank in asset picker when assets are loading and once they load.
- Fixes the all tokens / your tokens headers to the top as you scroll

https://github.com/user-attachments/assets/12784d4f-cd27-42e8-9c50-16c8c75a0fef

