### PR TITLE
feat: Add wallet address to wallet.connect event

### DIFF
--- a/src/contexts/wallet/WalletProvider.tsx
+++ b/src/contexts/wallet/WalletProvider.tsx
@@ -71,6 +71,7 @@ function WalletProvider({
           side: type,
           chain,
           wallet: wallet.getName().toLowerCase(),
+          address: wallet.getAddress(),
         },
       });
     },

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -94,6 +94,7 @@ export interface ConnectWalletEvent {
     side: TransferWallet;
     chain: Chain;
     wallet: string;
+    address: string | undefined;
   };
 }
 


### PR DESCRIPTION
We need the wallet address to be able to configure referrer fees according to user addresses. We have a few of them we need to add exemption for.