### PR TITLE
fix: solana CCTPv2 redeem support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@wormhole-foundation/sdk-sui": "3.5.0",
         "@wormhole-foundation/sdk-sui-core": "3.5.0",
         "@wormhole-foundation/sdk-sui-ntt": "2.0.5",
-        "@wormhole-labs/cctp-executor-route": "0.15.0",
+        "@wormhole-labs/cctp-executor-route": "0.16.0",
         "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
         "@wormhole-labs/wallet-aggregator-core": "0.0.1",
         "@wormhole-labs/wallet-aggregator-evm": "0.9.0",
@@ -18378,9 +18378,9 @@
       }
     },
     "node_modules/@wormhole-labs/cctp-executor-route": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.15.0.tgz",
-      "integrity": "sha512-vaQbdUagx9WbRh1d3uGBuZIjTkZ+oJ/ouQnq76H+wk7uNkjrGR25Y5QOvI0NRqzQOgcP7tiATzW8Y5qYVsFXxw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.16.0.tgz",
+      "integrity": "sha512-dtSYyszlVYof6ttt4+BiSXAlw/NEOYgoWCWITBLn0Yh5IidbuWbdDDFS9hO74DYxFqZtsXFDLTsAMhDWDiWWZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@wormhole-foundation/sdk-sui": "3.5.0",
     "@wormhole-foundation/sdk-sui-core": "3.5.0",
     "@wormhole-foundation/sdk-sui-ntt": "2.0.5",
-    "@wormhole-labs/cctp-executor-route": "0.15.0",
+    "@wormhole-labs/cctp-executor-route": "0.16.0",
     "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
     "@wormhole-labs/wallet-aggregator-core": "0.0.1",
     "@wormhole-labs/wallet-aggregator-evm": "0.9.0",

--- a/src/utils/sdkv2.ts
+++ b/src/utils/sdkv2.ts
@@ -506,7 +506,25 @@ const parseCCTPv2Receipt = async (
   // NOTE: the sender is the shim contract, not the user's wallet
   // so don't set that here
 
-  txData.recipient = messageBody.mintRecipient.toNative(receipt.to).toString();
+  if (receipt.to === 'Solana') {
+    if (!config.rpcs.Solana) {
+      throw new Error('Missing Solana RPC');
+    }
+    // the recipient on the VAA is the ATA
+    const ata = messageBody.mintRecipient.toNative(receipt.to).toString();
+    const connection = new Connection(config.rpcs.Solana);
+    try {
+      const account = await splToken.getAccount(connection, new PublicKey(ata));
+      txData.recipient = account.owner.toBase58();
+    } catch (e) {
+      console.error(e);
+      txData.recipient = ata;
+    }
+  } else {
+    txData.recipient = messageBody.mintRecipient
+      .toNative(receipt.to)
+      .toString();
+  }
 
   // The attestation doesn't have the destination token address, but we can deduce which it is
   // just based off the destination chain

--- a/src/views/v3/Redeem/index.tsx
+++ b/src/views/v3/Redeem/index.tsx
@@ -608,7 +608,12 @@ function Redeem() {
       receivingWallet.address !== recipient &&
       routeName &&
       // These routes set the recipient address to the associated token address
-      ['ManualTokenBridge', 'ManualCCTP'].includes(routeName)
+      [
+        'ManualTokenBridge',
+        'ManualCCTP',
+        'CCTPv2FastExecutorRoute',
+        'CCTPv2StandardExecutorRoute',
+      ].includes(routeName)
     ) {
       const { address: receiveTokenAddress } = tokenIdFromTuple(receivedToken);
 


### PR DESCRIPTION
Tested a manual redeem by overriding msg.value to get an underpaid executor transaction https://snowtrace.io/tx/0x8a2b7e11e9f775f300c92f4a90128031749dbe11b0447c3b8d50e2388cd6ee75 then manually redeemed https://explorer.solana.com/tx/5AeCcmUPhsRxpCeYAtQUoyjg5KBy4p8pNXnCTfrsCsUkaeNtgGuFHcV1UNfrtyMDWrAuxx1Cngp4knGtvuDWdPoR

This requires the changes in https://github.com/wormholelabs-xyz/cctp-w7-executor-route/pull/41

I tested it by running `npm run build` in that repo and copying the `dist` folder to its entry in node_modules, but it should be tested again after this is updated with the new release of that package.