### PR TITLE
chore: fix padding in asset picker

### DIFF
--- a/src/views/v3/Bridge/AssetPicker/PickerModal.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PickerModal.tsx
@@ -82,6 +82,7 @@ function AssetPickerPopover({
             background: theme.palette.input.background,
             backdropFilter: 'blur(4px)',
             WebkitBackdropFilter: 'blur(4px)', // Safari support
+            boxShadow: '0 8px 32px rgba(0, 0, 0, 0.24)',
           },
         },
         root: {

--- a/src/views/v3/Bridge/AssetPicker/SearchableList/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/SearchableList/index.tsx
@@ -66,7 +66,7 @@ function SearchableList<T>(props: SearchableListProps<T>): ReactNode {
         sx={{ ...styles.searchList, ...scrollbarStyles }}
         data-testid={props.dataTestId}
       >
-        <Box sx={{ padding: '0 16px' }}>{props.listTitle}</Box>
+        <Box sx={{ padding: '16px' }}>{props.listTitle}</Box>
         {props.loading || filteredList.map(props.renderFn)}
       </List>
     </Box>

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -49,9 +49,13 @@ const TokenList = (props: Props) => {
     let message = '';
 
     if (props.isSource) {
-      message = props.wallet?.address
-        ? 'No supported tokens found in wallet'
-        : '';
+      if (props.searchQuery) {
+        message = 'No tokens found matching your search';
+      } else {
+        message = props.wallet?.address
+          ? 'No supported tokens found in wallet'
+          : '';
+      }
     } else {
       message = 'No supported destination tokens for this route';
     }
@@ -61,7 +65,12 @@ const TokenList = (props: Props) => {
         {message}
       </Typography>
     );
-  }, [props.wallet?.address, props.isSource, theme.palette.grey.A400]);
+  }, [
+    props.wallet?.address,
+    props.isSource,
+    props.searchQuery,
+    theme.palette.grey.A400,
+  ]);
 
   const placeholder = `Search for a token${
     tokenPastingIsEnabled ? ' or paste an address' : ''


### PR DESCRIPTION
Adds some padding to the bottom of empty asset pickers and adds a slight shadow so it doesn't fade into the picker background.

Also improved the wording for no search results vs no results at all.

<img width="588" height="470" alt="Screenshot 2025-09-19 at 4 39 28 PM" src="https://github.com/user-attachments/assets/07d51826-b5c3-4ba1-bb27-7e9eb47c01f2" />
