### PR TITLE
fix: fixed and refactored signAndSendTransaction on solana

### DIFF
--- a/src/utils/inProgressTxCache.ts
+++ b/src/utils/inProgressTxCache.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 import type { TransactionLocal } from 'config/types';
-import { isEmptyObject, JSONReplacer } from 'utils';
+import { isEmptyObject, stringifyWithBigInt } from 'utils';
 
 const LOCAL_STORAGE_KEY = 'transactions:inprogress';
 const LOCAL_STORAGE_MAX = 3;
@@ -169,7 +169,10 @@ export const addTxToLocalStorage = (
 
   // Update the list
   try {
-    ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(newList));
+    ls.setItem(
+      config.cacheKey(LOCAL_STORAGE_KEY),
+      stringifyWithBigInt(newList),
+    );
   } catch (e: any) {
     // We can get two different errors:
     // 1- TypeError from JSON.stringify
@@ -193,7 +196,10 @@ export const removeTxFromLocalStorage = (txHash: string) => {
       // remove the item and update localStorage
       items.splice(removeIndex, 1);
       try {
-        ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(items));
+        ls.setItem(
+          config.cacheKey(LOCAL_STORAGE_KEY),
+          stringifyWithBigInt(items),
+        );
       } catch (e: any) {
         // We can get two different errors:
         // 1- TypeError from JSON.stringify
@@ -223,7 +229,10 @@ export const updateTxInLocalStorage = (
       // Update item property and put back in local storage
       items[idx][key] = value;
       try {
-        ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(items));
+        ls.setItem(
+          config.cacheKey(LOCAL_STORAGE_KEY),
+          stringifyWithBigInt(items),
+        );
       } catch (e: any) {
         // We can get two different errors:
         // 1- TypeError from JSON.stringify

--- a/src/utils/inProgressTxCache.ts
+++ b/src/utils/inProgressTxCache.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 import type { TransactionLocal } from 'config/types';
-import { isEmptyObject } from 'utils';
+import { isEmptyObject, JSONReplacer } from 'utils';
 
 const LOCAL_STORAGE_KEY = 'transactions:inprogress';
 const LOCAL_STORAGE_MAX = 3;
@@ -8,8 +8,6 @@ const LOCAL_STORAGE_MAX = 3;
 // Bigint types cannot be serialized to a string
 // That's why we need to provide a replacer function to handle it separately
 // Please see for details: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/BigInt_not_serializable
-const JSONReplacer = (_, value: any) =>
-  typeof value === 'bigint' ? value.toString() : value;
 
 // Checks the existance of the props with the given types in a parent object
 const validateChildPropTypes = (
@@ -171,10 +169,7 @@ export const addTxToLocalStorage = (
 
   // Update the list
   try {
-    ls.setItem(
-      config.cacheKey(LOCAL_STORAGE_KEY),
-      JSON.stringify(newList, JSONReplacer),
-    );
+    ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(newList));
   } catch (e: any) {
     // We can get two different errors:
     // 1- TypeError from JSON.stringify
@@ -198,10 +193,7 @@ export const removeTxFromLocalStorage = (txHash: string) => {
       // remove the item and update localStorage
       items.splice(removeIndex, 1);
       try {
-        ls.setItem(
-          config.cacheKey(LOCAL_STORAGE_KEY),
-          JSON.stringify(items, JSONReplacer),
-        );
+        ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(items));
       } catch (e: any) {
         // We can get two different errors:
         // 1- TypeError from JSON.stringify
@@ -231,10 +223,7 @@ export const updateTxInLocalStorage = (
       // Update item property and put back in local storage
       items[idx][key] = value;
       try {
-        ls.setItem(
-          config.cacheKey(LOCAL_STORAGE_KEY),
-          JSON.stringify(items, JSONReplacer),
-        );
+        ls.setItem(config.cacheKey(LOCAL_STORAGE_KEY), JSONReplacer(items));
       } catch (e: any) {
         // We can get two different errors:
         // 1- TypeError from JSON.stringify

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -424,3 +424,9 @@ export const isExecutorRoute = (route: string | undefined) => {
   }
   return route.endsWith('ExecutorRoute');
 };
+
+export const JSONReplacer = (json: any) => {
+  return JSON.stringify(json, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value,
+  );
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -425,7 +425,7 @@ export const isExecutorRoute = (route: string | undefined) => {
   return route.endsWith('ExecutorRoute');
 };
 
-export const JSONReplacer = (json: any) => {
+export const stringifyWithBigInt = (json: any) => {
   return JSON.stringify(json, (_key, value) =>
     typeof value === 'bigint' ? value.toString() : value,
   );

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -65,7 +65,7 @@ export const signAndSendTransaction = async (
     return tx;
   } else if (platform === 'Solana') {
     const solana = await import('utils/wallet/solana');
-    const signature = await solana.signAndSendTransaction(
+    const signature = await solana.signAndSendTransactionWithRetry(
       request as SolanaUnsignedTransaction<Network>,
       wallet,
       options,

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -65,7 +65,7 @@ export const signAndSendTransaction = async (
     return tx;
   } else if (platform === 'Solana') {
     const solana = await import('utils/wallet/solana');
-    const signature = await solana.signAndSendTransactionWithRetry(
+    const signature = await solana.signAndSendTransactionWithResends(
       request as SolanaUnsignedTransaction<Network>,
       wallet,
       options,

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -29,10 +29,13 @@ import {
 
 import config from 'config';
 
+const CONFIRMATION_PROMISE_TIMER = 3_000; // How long to wait for confirmation before resending
+
 import type { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
 import type { Chain, Network } from '@wormhole-foundation/sdk';
 import { setPriorityFeeInstructions } from 'utils/solana';
 import { retry } from 'es-toolkit';
+import { JSONReplacer } from 'utils';
 
 const getWalletName = (wallet: Wallet) =>
   wallet.getName().toLowerCase().replaceAll('wallet', '').trim();
@@ -140,79 +143,17 @@ export async function signAndSendTransactionWithResends(
     commitment,
   );
 
-  const confirmationPromiseTimer = 3_000; // How long to wait for confirmation before resending
+  const transaction = { serializedTransaction, sendOptions };
 
-  const signature = await signAndConfirmTransactionWhilstResending(
-    { serializedTransaction, sendOptions },
+  const signature = await resendTransactionUntilConfirmed(
     connection,
+    transaction,
     blockhash,
     lastValidBlockHeight,
     commitment,
-    confirmationPromiseTimer,
   );
 
   return signature;
-}
-
-async function signAndConfirmTransactionWhilstResending(
-  transaction: {
-    serializedTransaction: Uint8Array | Buffer | number[];
-    sendOptions?: SendOptions;
-  },
-  connection: Connection,
-  blockHash: string,
-  lastValidBlockHeight: number,
-  commitment: Commitment,
-  confirmationPromiseTimer: number,
-): Promise<string> {
-  const { signature, confirmPromise } =
-    await sendTransactionAndGetConfirmPromise(
-      transaction,
-      connection,
-      blockHash,
-      lastValidBlockHeight,
-      commitment,
-    );
-
-  await resendTransactionUntilConfirmed(
-    signature,
-    connection,
-    transaction,
-    confirmationPromiseTimer,
-    confirmPromise,
-  );
-
-  return signature;
-}
-
-async function sendTransactionAndGetConfirmPromise(
-  transaction: {
-    serializedTransaction: Uint8Array | Buffer | number[];
-    sendOptions?: SendOptions;
-  },
-  connection: Connection,
-  blockHash: string,
-  lastValidBlockHeight: number,
-  commitment: Commitment,
-): Promise<{
-  signature: string;
-  confirmPromise: Promise<RpcResponseAndContext<SignatureResult>>;
-}> {
-  const signature = await connection.sendRawTransaction(
-    transaction.serializedTransaction,
-    transaction.sendOptions,
-  );
-
-  const confirmPromise = connection.confirmTransaction(
-    {
-      signature,
-      blockhash: blockHash,
-      lastValidBlockHeight,
-    },
-    commitment,
-  );
-
-  return { signature, confirmPromise };
 }
 
 /**
@@ -228,33 +169,42 @@ async function sendTransactionAndGetConfirmPromise(
  */
 
 async function resendTransactionUntilConfirmed(
-  signature: string,
   connection: Connection,
   transaction: {
     serializedTransaction: Uint8Array | Buffer | number[];
     sendOptions?: SendOptions;
   },
-  confirmationPromiseTimer: number,
-  confirmTransactionPromise: Promise<RpcResponseAndContext<SignatureResult>>,
-) {
+  blockhash: string,
+  lastValidBlockHeight: number,
+  commitment: Commitment,
+): Promise<string> {
   let isTransactionConfirmed: RpcResponseAndContext<SignatureResult> | null =
     null;
+
+  const signature = await connection.sendRawTransaction(
+    transaction.serializedTransaction,
+    transaction.sendOptions,
+  );
+
   try {
     while (!isTransactionConfirmed) {
+      const confirmPromise = connection.confirmTransaction(
+        { signature, blockhash, lastValidBlockHeight },
+        commitment,
+      );
+
       isTransactionConfirmed = await Promise.race([
-        confirmTransactionPromise,
+        confirmPromise,
         new Promise<null>((resolve) =>
-          setTimeout(() => {
-            resolve(null);
-          }, confirmationPromiseTimer),
+          setTimeout(() => resolve(null), CONFIRMATION_PROMISE_TIMER),
         ),
       ]);
+
       if (isTransactionConfirmed) {
         break;
       }
 
-      // This is the same signature so don't need response.
-      // Need to await since we are explicilty resending before confirming again
+      // Resend transaction as it's not yet confirmed
       await connection.sendRawTransaction(
         transaction.serializedTransaction,
         transaction.sendOptions,
@@ -263,18 +213,20 @@ async function resendTransactionUntilConfirmed(
   } catch (e) {
     if (e instanceof Error) {
       if (e.name === 'TransactionExpiredBlockheightExceededError') {
-        recoverBlockheightExceededTransaction(e, connection, signature);
+        await recoverBlockheightExceededTransaction(connection, signature);
       }
       console.error('Failed to resend transaction:', e);
     }
   }
 
-  if (isTransactionConfirmed && isTransactionConfirmed.value.err) {
+  if (isTransactionConfirmed?.value.err) {
     const errorMessage = formatConfirmationError(
       isTransactionConfirmed.value.err,
     );
     throw new Error(`Transaction failed: ${errorMessage}`);
   }
+
+  return signature;
 }
 
 /**
@@ -288,23 +240,22 @@ async function resendTransactionUntilConfirmed(
  * @returns The signature once found, or throws if retries are exhausted
  */
 async function recoverBlockheightExceededTransaction(
-  e: unknown,
   connection: Connection,
   signature: string,
   { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
-): Promise<string | null> {
-  const findTransaction = async (): Promise<string> => {
+) {
+  const findTransaction = async () => {
     const tx = await connection.getTransaction(signature, {
       commitment: 'confirmed',
       maxSupportedTransactionVersion: 0,
     });
 
-    if (tx) return signature;
+    if (tx) return;
 
     throw new Error('Transaction not yet found on chain');
   };
 
-  return retry(findTransaction, { retries, delay });
+  retry(findTransaction, { retries, delay });
 }
 
 async function createSolanaTransaction(
@@ -340,9 +291,7 @@ function formatConfirmationError(err: TransactionError): string {
 
   if (typeof err === 'object') {
     try {
-      return JSON.stringify(err, (_key, value) =>
-        typeof value === 'bigint' ? value.toString() : value,
-      );
+      return JSONReplacer(err);
     } catch {
       return 'Unstringifiable error object';
     }

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -35,7 +35,7 @@ import type { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana'
 import type { Chain, Network } from '@wormhole-foundation/sdk';
 import { setPriorityFeeInstructions } from 'utils/solana';
 import { retry } from 'es-toolkit';
-import { JSONReplacer } from 'utils';
+import { stringifyWithBigInt } from 'utils';
 
 const getWalletName = (wallet: Wallet) =>
   wallet.getName().toLowerCase().replaceAll('wallet', '').trim();
@@ -186,13 +186,13 @@ async function resendTransactionUntilConfirmed(
     transaction.sendOptions,
   );
 
+  const confirmPromise = connection.confirmTransaction(
+    { signature, blockhash, lastValidBlockHeight },
+    commitment,
+  );
+
   try {
     while (!isTransactionConfirmed) {
-      const confirmPromise = connection.confirmTransaction(
-        { signature, blockhash, lastValidBlockHeight },
-        commitment,
-      );
-
       isTransactionConfirmed = await Promise.race([
         confirmPromise,
         new Promise<null>((resolve) =>
@@ -291,7 +291,7 @@ function formatConfirmationError(err: TransactionError): string {
 
   if (typeof err === 'object') {
     try {
-      return JSONReplacer(err);
+      return stringifyWithBigInt(err);
     } catch {
       return 'Unstringifiable error object';
     }

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -134,7 +134,7 @@ export async function signAndSendTransactionWithRetry(
     sendOptions,
   );
 
-  confirmTransactionWithRetry(
+  const newSignature = await confirmTransactionWithRetry(
     signature,
     { serializedTransaction, sendOptions },
     connection,
@@ -143,7 +143,9 @@ export async function signAndSendTransactionWithRetry(
     commitment,
   );
 
-  return signature;
+  if (!newSignature) throw new Error('Transaction failed');
+
+  return newSignature;
 }
 
 async function confirmTransactionWithRetry(
@@ -167,12 +169,10 @@ async function confirmTransactionWithRetry(
     commitment,
   );
   if (!confirmTransactionPromise.value.err) {
-    return confirmTransactionPromise;
+    return currentSignature;
   }
 
   try {
-    let hasTransactionBeenResent = false;
-    const NO_OF_RETRIES = 5;
     const RETRY_DELAY = 1000;
 
     await retry(
@@ -181,7 +181,7 @@ async function confirmTransactionWithRetry(
           try {
             confirmTransactionPromise = await connection.confirmTransaction(
               {
-                signature,
+                signature: currentSignature,
                 blockhash: blockHash,
                 lastValidBlockHeight,
               },
@@ -192,10 +192,10 @@ async function confirmTransactionWithRetry(
               !confirmTransactionPromise.value.err;
 
             if (isTransactionSuccessful) {
-              return confirmTransactionPromise;
+              return currentSignature;
             }
 
-            if (!isTransactionSuccessful && !hasTransactionBeenResent) {
+            if (!isTransactionSuccessful) {
               console.log(
                 'Transaction confirmation failed, resending transaction...',
               );
@@ -206,7 +206,18 @@ async function confirmTransactionWithRetry(
                   transaction.sendOptions,
                 );
 
-                hasTransactionBeenResent = true;
+                const retriedTx = await connection.confirmTransaction(
+                  {
+                    signature: currentSignature,
+                    blockhash: blockHash,
+                    lastValidBlockHeight,
+                  },
+                  commitment,
+                );
+                if (!retriedTx.value.err) {
+                  return currentSignature;
+                }
+                throw new Error(`Resent tx failed: ${retriedTx.value.err}`);
               } catch (resendError) {
                 console.error('Failed to resend transaction:', resendError);
 
@@ -233,7 +244,7 @@ async function confirmTransactionWithRetry(
         })();
       },
       {
-        retries: NO_OF_RETRIES,
+        retries: Infinity,
         delay: RETRY_DELAY,
       },
     );

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -14,8 +14,7 @@ import {
 import type {
   Commitment,
   ConfirmOptions,
-  RpcResponseAndContext,
-  SignatureResult,
+  SendOptions,
   Transaction,
 } from '@solana/web3.js';
 import { clusterApiUrl, Connection } from '@solana/web3.js';

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -105,12 +105,6 @@ export function fetchFogoOptions() {
 // This function signs and sends the transaction while constantly checking for confirmation
 // and resending the transaction if it hasn't been confirmed after the specified interval
 // See https://docs.triton.one/chains/solana/sending-txs for more information
-
-/*
-
-  This function signs and sends the transaction, no confirmation checking.
-
-*/
 export async function signAndSendTransactionWithRetry(
   request: SolanaUnsignedTransaction<Network>,
   wallet: Wallet | undefined,
@@ -140,7 +134,7 @@ export async function signAndSendTransactionWithRetry(
     sendOptions,
   );
 
-  waitForConfirmation(
+  confirmTransactionWithRetry(
     signature,
     { serializedTransaction, sendOptions },
     connection,
@@ -152,7 +146,7 @@ export async function signAndSendTransactionWithRetry(
   return signature;
 }
 
-async function waitForConfirmation(
+async function confirmTransactionWithRetry(
   signature: string,
   transaction: {
     serializedTransaction: Uint8Array | Buffer | number[];
@@ -244,12 +238,19 @@ async function waitForConfirmation(
       },
     );
   } catch (e: unknown) {
-    checkTransactionLanded(e, connection, signature);
+    const recoveredSignature = await recoverBlockheightExceededTransaction(
+      e,
+      connection,
+      signature,
+    );
+    if (recoveredSignature) {
+      return recoveredSignature;
+    }
     throw e;
   }
 }
 
-async function checkTransactionLanded(
+async function recoverBlockheightExceededTransaction(
   e: unknown,
   connection: Connection,
   signature: string,

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -18,6 +18,7 @@ import type {
   SendOptions,
   SignatureResult,
   Transaction,
+  TransactionError,
 } from '@solana/web3.js';
 import { clusterApiUrl, Connection } from '@solana/web3.js';
 
@@ -104,9 +105,16 @@ export function fetchFogoOptions() {
   };
 }
 
-// This function signs and sends the transaction while constantly checking for confirmation
-// and resending the transaction if it hasn't been confirmed after the specified interval
-// See https://docs.triton.one/chains/solana/sending-txs for more information
+/**
+ * This function signs and sends the transaction while constantly checking for confirmation
+ * and resending the transaction if it hasn't been confirmed after the specified interval
+ * See https://docs.triton.one/chains/solana/sending-txs for more information.
+ *
+ * @param request The unsigned transaction to sign and send
+ * @param wallet The wallet to use for signing and sending the transaction
+ * @param options Optional confirmation options
+ * @returns The transaction signature
+ */
 export async function signAndSendTransactionWithResends(
   request: SolanaUnsignedTransaction<Network>,
   wallet: Wallet | undefined,
@@ -132,12 +140,15 @@ export async function signAndSendTransactionWithResends(
     commitment,
   );
 
+  const confirmationPromiseTimer = 1_000; // How long to wait for confirmation before resending
+
   const signature = await signAndConfirmTransactionWhilstResending(
     { serializedTransaction, sendOptions },
     connection,
     blockhash,
     lastValidBlockHeight,
     commitment,
+    confirmationPromiseTimer,
   );
 
   return signature;
@@ -152,9 +163,7 @@ async function signAndConfirmTransactionWhilstResending(
   blockHash: string,
   lastValidBlockHeight: number,
   commitment: Commitment,
-  {
-    initialDelay = 1000, // 1 second
-  }: { retries?: number; initialDelay?: number; maxDelay?: number } = {},
+  confirmationPromiseTimer: number,
 ): Promise<string> {
   const { signature, confirmPromise } =
     await sendTransactionAndGetConfirmPromise(
@@ -169,7 +178,7 @@ async function signAndConfirmTransactionWhilstResending(
     signature,
     connection,
     transaction,
-    initialDelay,
+    confirmationPromiseTimer,
     confirmPromise,
   );
 
@@ -225,9 +234,9 @@ async function resendTransactionUntilConfirmed(
     serializedTransaction: Uint8Array | Buffer | number[];
     sendOptions?: SendOptions;
   },
-  txRetryInterval = 1000,
+  confirmationPromiseTimer: number,
   confirmTransactionPromise: Promise<RpcResponseAndContext<SignatureResult>>,
-): Promise<void> {
+) {
   let isTransactionConfirmed: RpcResponseAndContext<SignatureResult> | null =
     null;
   try {
@@ -237,7 +246,7 @@ async function resendTransactionUntilConfirmed(
         new Promise<null>((resolve) =>
           setTimeout(() => {
             resolve(null);
-          }, txRetryInterval),
+          }, confirmationPromiseTimer),
         ),
       ]);
       if (isTransactionConfirmed) {
@@ -260,30 +269,42 @@ async function resendTransactionUntilConfirmed(
     }
   }
 
-  return;
+  if (isTransactionConfirmed && isTransactionConfirmed.value.err) {
+    const errorMessage = formatConfirmationError(
+      isTransactionConfirmed.value.err,
+    );
+    throw new Error(`Transaction failed: ${errorMessage}`);
+  }
 }
 
+/**
+ * Attempt to recover a transaction that exceeded its blockheight,
+ * by polling until it appears on chain.
+ *
+ * @param connection Solana RPC connection
+ * @param signature The transaction signature to look up
+ * @param retries Number of retries (default: 5)
+ * @param delay Delay between retries in ms (default: 2000)
+ * @returns The signature once found, or throws if retries are exhausted
+ */
 async function recoverBlockheightExceededTransaction(
   e: unknown,
   connection: Connection,
   signature: string,
   { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
 ): Promise<string | null> {
-  return retry(
-    async () => {
-      const tx = await connection.getTransaction(signature, {
-        commitment: 'confirmed',
-        maxSupportedTransactionVersion: 0,
-      });
+  const findTransaction = async (): Promise<string> => {
+    const tx = await connection.getTransaction(signature, {
+      commitment: 'confirmed',
+      maxSupportedTransactionVersion: 0,
+    });
 
-      if (!tx) {
-        throw new Error('Transaction not yet found on chain');
-      }
+    if (tx) return signature;
 
-      return signature;
-    },
-    { retries, delay },
-  );
+    throw new Error('Transaction not yet found on chain');
+  };
+
+  return retry(findTransaction, { retries, delay });
 }
 
 async function createSolanaTransaction(
@@ -312,4 +333,20 @@ async function createSolanaTransaction(
     preFlightCommitment: commitment, // See PR and linked issue for why setting this matters: https://github.com/anza-xyz/agave/pull/483
   };
   return { serializedTransaction: serializedTx, sendOptions };
+}
+
+function formatConfirmationError(err: TransactionError): string {
+  if (!err) return 'Unknown error';
+
+  if (typeof err === 'object') {
+    try {
+      return JSON.stringify(err, (_key, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      );
+    } catch {
+      return 'Unstringifiable error object';
+    }
+  }
+
+  return String(err);
 }

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -12,6 +12,7 @@ import {
 } from '@solana/wallet-adapter-wallets';
 
 import type {
+  Commitment,
   ConfirmOptions,
   RpcResponseAndContext,
   SignatureResult,
@@ -29,7 +30,7 @@ import config from 'config';
 import type { SolanaUnsignedTransaction } from '@wormhole-foundation/sdk-solana';
 import type { Chain, Network } from '@wormhole-foundation/sdk';
 import { setPriorityFeeInstructions } from 'utils/solana';
-import { sleep } from 'utils';
+import { retry } from 'es-toolkit';
 
 const getWalletName = (wallet: Wallet) =>
   wallet.getName().toLowerCase().replaceAll('wallet', '').trim();
@@ -105,122 +106,204 @@ export function fetchFogoOptions() {
 // This function signs and sends the transaction while constantly checking for confirmation
 // and resending the transaction if it hasn't been confirmed after the specified interval
 // See https://docs.triton.one/chains/solana/sending-txs for more information
-export async function signAndSendTransaction(
+
+/*
+
+  This function signs and sends the transaction, no confirmation checking.
+
+*/
+export async function signAndSendTransactionWithRetry(
   request: SolanaUnsignedTransaction<Network>,
   wallet: Wallet | undefined,
   options?: ConfirmOptions,
-) {
+): Promise<string> {
   if (!wallet) throw new Error('Wallet not found');
   const rpc = config.rpcs[request.chain];
   if (!rpc) throw new Error(`${request.chain} RPC not found`);
 
   const commitment = options?.commitment ?? 'finalized';
   const connection = new Connection(rpc);
+
   const { blockhash, lastValidBlockHeight } =
     await connection.getLatestBlockhash(commitment);
 
-  const unsignedTx = await setPriorityFeeInstructions(
+  const { serializedTransaction, sendOptions } = await createSolanaTransaction(
+    request,
+    wallet,
     connection,
     blockhash,
     lastValidBlockHeight,
-    request,
+    commitment,
   );
 
-  let confirmTransactionPromise: Promise<
-    RpcResponseAndContext<SignatureResult>
-  > | null = null;
-  let confirmedTx: RpcResponseAndContext<SignatureResult> | null = null;
-  let txSendAttempts = 1;
-  let signature = '';
+  const signature = await connection.sendRawTransaction(
+    serializedTransaction,
+    sendOptions,
+  );
+
+  waitForConfirmation(
+    signature,
+    { serializedTransaction, sendOptions },
+    connection,
+    blockhash,
+    lastValidBlockHeight,
+    commitment,
+  );
+
+  return signature;
+}
+
+async function waitForConfirmation(
+  signature: string,
+  transaction: {
+    serializedTransaction: Uint8Array | Buffer | number[];
+    sendOptions?: SendOptions;
+  },
+  connection: Connection,
+  blockHash: string,
+  lastValidBlockHeight: number,
+  commitment?: Commitment,
+) {
+  let currentSignature = signature;
+  let confirmTransactionPromise = await connection.confirmTransaction(
+    {
+      signature: currentSignature,
+      blockhash: blockHash,
+      lastValidBlockHeight,
+    },
+    commitment,
+  );
+  if (!confirmTransactionPromise.value.err) {
+    return confirmTransactionPromise;
+  }
+
+  try {
+    let hasTransactionBeenResent = false;
+    const NO_OF_RETRIES = 5;
+    const RETRY_DELAY = 1000;
+
+    await retry(
+      () => {
+        return (async () => {
+          try {
+            confirmTransactionPromise = await connection.confirmTransaction(
+              {
+                signature,
+                blockhash: blockHash,
+                lastValidBlockHeight,
+              },
+              commitment,
+            );
+
+            const isTransactionSuccessful =
+              !confirmTransactionPromise.value.err;
+
+            if (isTransactionSuccessful) {
+              return confirmTransactionPromise;
+            }
+
+            if (!isTransactionSuccessful && !hasTransactionBeenResent) {
+              console.log(
+                'Transaction confirmation failed, resending transaction...',
+              );
+
+              try {
+                currentSignature = await connection.sendRawTransaction(
+                  transaction.serializedTransaction,
+                  transaction.sendOptions,
+                );
+
+                hasTransactionBeenResent = true;
+              } catch (resendError) {
+                console.error('Failed to resend transaction:', resendError);
+
+                // If resend failed, still throw the original confirmation error
+                let errorMessage = `Transaction failed: ${confirmTransactionPromise.value.err}`;
+                if (typeof confirmTransactionPromise.value.err === 'object') {
+                  try {
+                    errorMessage = `Transaction failed: ${JSON.stringify(
+                      confirmTransactionPromise.value.err,
+                      (_key, value) =>
+                        typeof value === 'bigint' ? value.toString() : value,
+                    )}`;
+                  } catch (e: unknown) {
+                    throw new Error(`Transaction failed: Unknown error`);
+                  }
+                }
+                throw new Error(errorMessage);
+              }
+            }
+          } catch (e) {
+            console.error('Failed to confirm transaction:', e);
+            throw e;
+          }
+        })();
+      },
+      {
+        retries: NO_OF_RETRIES,
+        delay: RETRY_DELAY,
+      },
+    );
+  } catch (e: unknown) {
+    checkTransactionLanded(e, connection, signature);
+    throw e;
+  }
+}
+
+async function checkTransactionLanded(
+  e: unknown,
+  connection: Connection,
+  signature: string,
+  { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
+): Promise<string | null> {
+  if (
+    e instanceof Error &&
+    e.name === 'TransactionExpiredBlockheightExceededError'
+  ) {
+    return retry(
+      async () => {
+        const tx = await connection.getTransaction(signature, {
+          commitment: 'confirmed',
+          maxSupportedTransactionVersion: 0,
+        });
+
+        if (!tx) {
+          throw new Error('Transaction not yet found on chain');
+        }
+
+        return signature;
+      },
+      { retries, delay },
+    ).catch(() => null); // return null if all retries fail
+  }
+
+  return Promise.resolve(null);
+}
+
+async function createSolanaTransaction(
+  request: SolanaUnsignedTransaction<Network>,
+  wallet: Wallet,
+  connection: Connection,
+  blockHash: string,
+  lastValidBlockHeight: number,
+  commitment?: Commitment,
+): Promise<{
+  serializedTransaction: Uint8Array | Buffer | number[];
+  sendOptions?: SendOptions;
+}> {
+  const txToSign = await setPriorityFeeInstructions(
+    connection,
+    blockHash,
+    lastValidBlockHeight,
+    request,
+  );
   // TODO: VersionedTransaction is supported, but the interface needs to be updated
-  const tx = await wallet.signTransaction(unsignedTx as Transaction);
+  const tx = await wallet.signTransaction(txToSign as Transaction);
   const serializedTx = tx.serialize();
   const sendOptions = {
     skipPreflight: true,
     maxRetries: 0,
     preFlightCommitment: commitment, // See PR and linked issue for why setting this matters: https://github.com/anza-xyz/agave/pull/483
   };
-  signature = await connection.sendRawTransaction(serializedTx, sendOptions);
-  confirmTransactionPromise = connection.confirmTransaction(
-    {
-      signature,
-      blockhash,
-      lastValidBlockHeight,
-    },
-    commitment,
-  );
-
-  try {
-    // This loop will break once the transaction has been confirmed or the block height is exceeded.
-    // An exception will be thrown if the block height is exceeded by the confirmTransactionPromise.
-    // The transaction will be resent if it hasn't been confirmed after the interval.
-    const txRetryInterval = 5000;
-    while (!confirmedTx) {
-      confirmedTx = await Promise.race([
-        confirmTransactionPromise,
-        new Promise<null>((resolve) =>
-          setTimeout(() => {
-            resolve(null);
-          }, txRetryInterval),
-        ),
-      ]);
-      if (confirmedTx) {
-        break;
-      }
-      console.log(
-        `Tx not confirmed after ${
-          txRetryInterval * txSendAttempts++
-        }ms, resending`,
-      );
-      try {
-        await connection.sendRawTransaction(serializedTx, sendOptions);
-      } catch (e) {
-        console.error('Failed to resend transaction:', e);
-      }
-    }
-  } catch (e: unknown) {
-    if (
-      e instanceof Error &&
-      e.name === 'TransactionExpiredBlockheightExceededError'
-    ) {
-      // Sometimes the transaction actually landed,
-      // so spend some additional time to check for it
-      const maxRetries = 5;
-      const retryDelay = 2000;
-      for (let i = 0; i < maxRetries; ++i) {
-        try {
-          const tx = await connection.getTransaction(signature, {
-            commitment: 'confirmed',
-            maxSupportedTransactionVersion: 0,
-          });
-          if (tx) return signature; // Transaction actually landed
-        } catch {
-          // Ignore errors, we will retry
-        }
-        await sleep(retryDelay);
-      }
-    }
-    throw e;
-  }
-
-  if (confirmedTx.value.err) {
-    let errorMessage = `Transaction failed: ${confirmedTx.value.err}`;
-    if (typeof confirmedTx.value.err === 'object') {
-      try {
-        errorMessage = `Transaction failed: ${JSON.stringify(
-          confirmedTx.value.err,
-          (_key, value) =>
-            typeof value === 'bigint' ? value.toString() : value, // Handle bigint props
-        )}`;
-      } catch (e: unknown) {
-        // Most likely a circular reference error, we can't stringify this error object.
-        // See for more details:
-        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#exceptions
-        errorMessage = `Transaction failed: Unknown error`;
-      }
-    }
-    throw new Error(`Transaction failed: ${errorMessage}`);
-  }
-
-  return signature;
+  return { serializedTransaction: serializedTx, sendOptions };
 }

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -211,12 +211,14 @@ async function resendTransactionUntilConfirmed(
       );
     }
   } catch (e) {
-    if (e instanceof Error) {
-      if (e.name === 'TransactionExpiredBlockheightExceededError') {
-        await recoverBlockheightExceededTransaction(connection, signature);
-      }
-      console.error('Failed to resend transaction:', e);
+    if (
+      e instanceof Error &&
+      e.name === 'TransactionExpiredBlockheightExceededError'
+    ) {
+      await recoverBlockheightExceededTransaction(connection, signature);
+      return signature;
     }
+    throw e;
   }
 
   if (isTransactionConfirmed?.value.err) {
@@ -245,14 +247,16 @@ async function recoverBlockheightExceededTransaction(
   { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
 ) {
   const findTransaction = async () => {
-    const tx = await connection.getTransaction(signature, {
-      commitment: 'confirmed',
-      maxSupportedTransactionVersion: 0,
-    });
+    try {
+      const tx = await connection.getTransaction(signature, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0,
+      });
 
-    if (tx) return;
-
-    throw new Error('Transaction not yet found on chain');
+      if (tx) return;
+    } catch {
+      // Ignore errors
+    }
   };
 
   retry(findTransaction, { retries, delay });

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -140,7 +140,7 @@ export async function signAndSendTransactionWithResends(
     commitment,
   );
 
-  const confirmationPromiseTimer = 1_000; // How long to wait for confirmation before resending
+  const confirmationPromiseTimer = 3_000; // How long to wait for confirmation before resending
 
   const signature = await signAndConfirmTransactionWhilstResending(
     { serializedTransaction, sendOptions },

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -14,7 +14,9 @@ import {
 import type {
   Commitment,
   ConfirmOptions,
+  RpcResponseAndContext,
   SendOptions,
+  SignatureResult,
   Transaction,
 } from '@solana/web3.js';
 import { clusterApiUrl, Connection } from '@solana/web3.js';
@@ -105,7 +107,7 @@ export function fetchFogoOptions() {
 // This function signs and sends the transaction while constantly checking for confirmation
 // and resending the transaction if it hasn't been confirmed after the specified interval
 // See https://docs.triton.one/chains/solana/sending-txs for more information
-export async function signAndSendTransactionWithRetry(
+export async function signAndSendTransactionWithResends(
   request: SolanaUnsignedTransaction<Network>,
   wallet: Wallet | undefined,
   options?: ConfirmOptions,
@@ -114,12 +116,13 @@ export async function signAndSendTransactionWithRetry(
   const rpc = config.rpcs[request.chain];
   if (!rpc) throw new Error(`${request.chain} RPC not found`);
 
-  const commitment = options?.commitment ?? 'finalized';
+  const commitment = options?.commitment ?? 'confirmed';
   const connection = new Connection(rpc);
 
   const { blockhash, lastValidBlockHeight } =
     await connection.getLatestBlockhash(commitment);
 
+  // Create tx
   const { serializedTransaction, sendOptions } = await createSolanaTransaction(
     request,
     wallet,
@@ -129,13 +132,7 @@ export async function signAndSendTransactionWithRetry(
     commitment,
   );
 
-  const signature = await connection.sendRawTransaction(
-    serializedTransaction,
-    sendOptions,
-  );
-
-  const newSignature = await confirmTransactionWithRetry(
-    signature,
+  const signature = await signAndConfirmTransactionWhilstResending(
     { serializedTransaction, sendOptions },
     connection,
     blockhash,
@@ -143,13 +140,10 @@ export async function signAndSendTransactionWithRetry(
     commitment,
   );
 
-  if (!newSignature) throw new Error('Transaction failed');
-
-  return newSignature;
+  return signature;
 }
 
-async function confirmTransactionWithRetry(
-  signature: string,
+async function signAndConfirmTransactionWhilstResending(
   transaction: {
     serializedTransaction: Uint8Array | Buffer | number[];
     sendOptions?: SendOptions;
@@ -157,108 +151,116 @@ async function confirmTransactionWithRetry(
   connection: Connection,
   blockHash: string,
   lastValidBlockHeight: number,
-  commitment?: Commitment,
-) {
-  let currentSignature = signature;
-  let confirmTransactionPromise = await connection.confirmTransaction(
+  commitment: Commitment,
+  {
+    initialDelay = 1000, // 1 second
+  }: { retries?: number; initialDelay?: number; maxDelay?: number } = {},
+): Promise<string> {
+  const { signature, confirmPromise } =
+    await sendTransactionAndGetConfirmPromise(
+      transaction,
+      connection,
+      blockHash,
+      lastValidBlockHeight,
+      commitment,
+    );
+
+  await resendTransactionUntilConfirmed(
+    signature,
+    connection,
+    transaction,
+    initialDelay,
+    confirmPromise,
+  );
+
+  return signature;
+}
+
+async function sendTransactionAndGetConfirmPromise(
+  transaction: {
+    serializedTransaction: Uint8Array | Buffer | number[];
+    sendOptions?: SendOptions;
+  },
+  connection: Connection,
+  blockHash: string,
+  lastValidBlockHeight: number,
+  commitment: Commitment,
+): Promise<{
+  signature: string;
+  confirmPromise: Promise<RpcResponseAndContext<SignatureResult>>;
+}> {
+  const signature = await connection.sendRawTransaction(
+    transaction.serializedTransaction,
+    transaction.sendOptions,
+  );
+
+  const confirmPromise = connection.confirmTransaction(
     {
-      signature: currentSignature,
+      signature,
       blockhash: blockHash,
       lastValidBlockHeight,
     },
     commitment,
   );
-  if (!confirmTransactionPromise.value.err) {
-    return currentSignature;
-  }
 
+  return { signature, confirmPromise };
+}
+
+/**
+ * **We race against the confirmation promise to mitigate the risk of the transaction
+ * not being confirmed before the blockhash expires.**
+ *
+ * If the confirmation promise resolves slower than the `txRetryInterval`, we resend.
+ * This is for performance.
+ *
+ * @param signature The transaction signature
+ * @param connection The Solana connection object
+ * @param transaction The transaction to resend
+ */
+
+async function resendTransactionUntilConfirmed(
+  signature: string,
+  connection: Connection,
+  transaction: {
+    serializedTransaction: Uint8Array | Buffer | number[];
+    sendOptions?: SendOptions;
+  },
+  txRetryInterval = 1000,
+  confirmTransactionPromise: Promise<RpcResponseAndContext<SignatureResult>>,
+): Promise<void> {
+  let isTransactionConfirmed: RpcResponseAndContext<SignatureResult> | null =
+    null;
   try {
-    const RETRY_DELAY = 1000;
+    while (!isTransactionConfirmed) {
+      isTransactionConfirmed = await Promise.race([
+        confirmTransactionPromise,
+        new Promise<null>((resolve) =>
+          setTimeout(() => {
+            resolve(null);
+          }, txRetryInterval),
+        ),
+      ]);
+      if (isTransactionConfirmed) {
+        break;
+      }
 
-    await retry(
-      () => {
-        return (async () => {
-          try {
-            confirmTransactionPromise = await connection.confirmTransaction(
-              {
-                signature: currentSignature,
-                blockhash: blockHash,
-                lastValidBlockHeight,
-              },
-              commitment,
-            );
-
-            const isTransactionSuccessful =
-              !confirmTransactionPromise.value.err;
-
-            if (isTransactionSuccessful) {
-              return currentSignature;
-            }
-
-            if (!isTransactionSuccessful) {
-              console.log(
-                'Transaction confirmation failed, resending transaction...',
-              );
-
-              try {
-                currentSignature = await connection.sendRawTransaction(
-                  transaction.serializedTransaction,
-                  transaction.sendOptions,
-                );
-
-                const retriedTx = await connection.confirmTransaction(
-                  {
-                    signature: currentSignature,
-                    blockhash: blockHash,
-                    lastValidBlockHeight,
-                  },
-                  commitment,
-                );
-                if (!retriedTx.value.err) {
-                  return currentSignature;
-                }
-                throw new Error(`Resent tx failed: ${retriedTx.value.err}`);
-              } catch (resendError) {
-                console.error('Failed to resend transaction:', resendError);
-
-                // If resend failed, still throw the original confirmation error
-                let errorMessage = `Transaction failed: ${confirmTransactionPromise.value.err}`;
-                if (typeof confirmTransactionPromise.value.err === 'object') {
-                  try {
-                    errorMessage = `Transaction failed: ${JSON.stringify(
-                      confirmTransactionPromise.value.err,
-                      (_key, value) =>
-                        typeof value === 'bigint' ? value.toString() : value,
-                    )}`;
-                  } catch (e: unknown) {
-                    throw new Error(`Transaction failed: Unknown error`);
-                  }
-                }
-                throw new Error(errorMessage);
-              }
-            }
-          } catch (e) {
-            console.error('Failed to confirm transaction:', e);
-            throw e;
-          }
-        })();
-      },
-      {
-        retries: Infinity,
-        delay: RETRY_DELAY,
-      },
-    );
-  } catch (e: unknown) {
-    const recoveredSignature = await recoverBlockheightExceededTransaction(
-      e,
-      connection,
-      signature,
-    );
-    if (recoveredSignature) {
-      return recoveredSignature;
+      // This is the same signature so don't need response.
+      // Need to await since we are explicilty resending before confirming again
+      await connection.sendRawTransaction(
+        transaction.serializedTransaction,
+        transaction.sendOptions,
+      );
     }
-    throw e;
+  } catch (e) {
+    if (e instanceof Error) {
+      if (e.name === 'TransactionExpiredBlockheightExceededError') {
+        recoverBlockheightExceededTransaction(e, connection, signature);
+      }
+      console.error('Failed to resend transaction:', e);
+    }
   }
+
+  return;
 }
 
 async function recoverBlockheightExceededTransaction(
@@ -267,28 +269,21 @@ async function recoverBlockheightExceededTransaction(
   signature: string,
   { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
 ): Promise<string | null> {
-  if (
-    e instanceof Error &&
-    e.name === 'TransactionExpiredBlockheightExceededError'
-  ) {
-    return retry(
-      async () => {
-        const tx = await connection.getTransaction(signature, {
-          commitment: 'confirmed',
-          maxSupportedTransactionVersion: 0,
-        });
+  return retry(
+    async () => {
+      const tx = await connection.getTransaction(signature, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0,
+      });
 
-        if (!tx) {
-          throw new Error('Transaction not yet found on chain');
-        }
+      if (!tx) {
+        throw new Error('Transaction not yet found on chain');
+      }
 
-        return signature;
-      },
-      { retries, delay },
-    ).catch(() => null); // return null if all retries fail
-  }
-
-  return Promise.resolve(null);
+      return signature;
+    },
+    { retries, delay },
+  );
 }
 
 async function createSolanaTransaction(

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -247,16 +247,12 @@ async function recoverBlockheightExceededTransaction(
   { retries = 5, delay = 2000 }: { retries?: number; delay?: number } = {},
 ) {
   const findTransaction = async () => {
-    try {
-      const tx = await connection.getTransaction(signature, {
-        commitment: 'confirmed',
-        maxSupportedTransactionVersion: 0,
-      });
+    const tx = await connection.getTransaction(signature, {
+      commitment: 'confirmed',
+      maxSupportedTransactionVersion: 0,
+    });
 
-      if (tx) return;
-    } catch {
-      // Ignore errors
-    }
+    if (tx) return;
   };
 
   retry(findTransaction, { retries, delay });


### PR DESCRIPTION
- Refactored retry and resend logic on solana signAndSendTransaction
  - Changed promise race delay from 5 seconds -> 1 second, this means we resend every second if confirmation promise doesn't resolve.
  - Remove custom retry loop for retry from es-toolkit and added function recoverBlockheightExceededTransaction
 
  