### PR TITLE
feat: add Plume Network CoinGecko support

### DIFF
--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -31,6 +31,7 @@ const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
   Seievm: 'sei',
   Mezo: 'wrapped-bitcoin',
   HyperEVM: 'hyperliquid',
+  Plume: 'plume',
 };
 
 // This refers to Coingecko API's platform names: https://api.coingecko.com/api/v3/asset_platforms
@@ -45,6 +46,7 @@ const CHAIN_IDS: Partial<Record<Chain, string>> = {
   Seievm: 'sei-v2',
   Mezo: 'mezo',
   HyperEVM: 'hyperevm',
+  Plume: 'plume-network',
 };
 
 export interface CoingeckoParams {


### PR DESCRIPTION
## Summary
Adds CoinGecko support for Plume Network to enable price data display in Wormhole Connect.

## Changes
- Added Plume native token CoinGecko ID (`plume`)
- Added Plume platform ID for CoinGecko API (`plume-network`)

## Testing
Tested locally in Portal Bridge - Plume now displays without CoinGecko errors and shows price data correctly.