### PR TITLE
fix: the lingering quote after token switch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@wormhole-labs/cctp-executor-route": "0.17.0",
         "@wormhole-labs/wallet-aggregator-aptos": "1.3.0",
         "@wormhole-labs/wallet-aggregator-core": "0.0.1",
-        "@wormhole-labs/wallet-aggregator-evm": "^0.9.2",
+        "@wormhole-labs/wallet-aggregator-evm": "0.9.2",
         "@wormhole-labs/wallet-aggregator-solana": "0.0.1",
         "@wormhole-labs/wallet-aggregator-sui": "0.0.3",
         "axios": "1.11.0",

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -292,15 +292,31 @@ function AssetPicker(props: Props) {
       </Typography>
     ) : null;
 
-  const handleAmountChange = useCallback((newValue: string): void => {
-    setAmountInput(newValue);
-    setSelectedPercentButton(0); // Reset selected percent button when amount changes
-  }, []);
+  const handleAmountChange = useCallback(
+    (newValue: string): void => {
+      setAmountInput(newValue);
+      setSelectedPercentButton(0); // Reset selected percent button when amount changes
+
+      if (!newValue) {
+        // If the input is cleared, we need to clear the amount in handleAmountChange instead of handleDebouncedAmountChange.
+        // This case is important when user switches the token selection, which results in clearing the amount.
+        // If we do this in handleDebouncedAmountChange, it will get a new quote for the previous amount before clearing it
+        // and may cause the received amount to set to that quoted amount after user clears the input.
+        dispatch(setAmount(newValue));
+      }
+    },
+    [dispatch],
+  );
 
   const handleDebouncedAmountChange = useCallback(
     (newValue: string): void => {
-      dispatch(setAmount(newValue));
       setDebouncedAmountInput(newValue);
+      if (newValue) {
+        // Only update the amount in the store if the input is not empty
+        // When the amount is cleared, it is handled in handleAmountChange
+        // Please see the comments in handleAmountChange for more details.
+        dispatch(setAmount(newValue));
+      }
     },
     [dispatch],
   );


### PR DESCRIPTION
We want to use the debounced amount update when user changing the amount, but when it clears we want to clear it in Redux right away to prevent a token update coming before the amount clearance. This causes the fetch of a new quote which results received amount updating with a new value instead of being cleared.

Fixes PROD-766