### PR TITLE
fix: add CoinGecko ID for Ink native token (ETH)

### DIFF
--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -32,6 +32,7 @@ const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
   Mezo: 'wrapped-bitcoin',
   HyperEVM: 'hyperliquid',
   Plume: 'plume',
+  Ink: 'ethereum',
 };
 
 // This refers to Coingecko API's platform names: https://api.coingecko.com/api/v3/asset_platforms
@@ -47,6 +48,7 @@ const CHAIN_IDS: Partial<Record<Chain, string>> = {
   Mezo: 'mezo',
   HyperEVM: 'hyperevm',
   Plume: 'plume-network',
+  Ink: 'ink',
 };
 
 export interface CoingeckoParams {


### PR DESCRIPTION
## Summary
- Added CoinGecko ID mapping for Ink chain's native token (ETH)
- Added Ink chain platform ID for CoinGecko API integration

This enables proper price fetching for Ink's native ETH token through the CoinGecko API.

## Test plan
- [x] Verify Ink native token prices display correctly
- [x] Confirm CoinGecko API calls work for Ink chain
- [x] Test bridging with Ink native token