### PR TITLE
fix: filter asset picker tokens properly

### DIFF
--- a/src/utils/tokenHelpers.ts
+++ b/src/utils/tokenHelpers.ts
@@ -13,6 +13,6 @@ export const getAllTokenIdsForChain = memoize(
   {
     // Invalidate when token cache updates by including lastUpdate in the key
     serializer: (args: unknown[]) =>
-      `${String(args[0])}|${config.tokens.lastUpdate.getTime()}`,
+      `${String(args)}|${config.tokens.lastUpdate.getTime()}`,
   },
 );


### PR DESCRIPTION
This returns a string (a primitive). The cache key was causing problems.