### PR TITLE
fix: resume aptos and sui native token transfers

### DIFF
--- a/src/utils/solana.ts
+++ b/src/utils/solana.ts
@@ -98,7 +98,7 @@ export async function setPriorityFeeInstructions(
 async function createPriorityFeeInstructions(
   connection: Connection,
   transaction: Transaction | VersionedTransaction,
-  commitment?: Commitment,
+  commitment: Commitment = 'confirmed',
 ) {
   let unitsUsed = 200_000;
   let simulationAttempts = 0;

--- a/src/utils/wallet/solana.ts
+++ b/src/utils/wallet/solana.ts
@@ -127,8 +127,18 @@ export async function signAndSendTransactionWithResends(
   const rpc = config.rpcs[request.chain];
   if (!rpc) throw new Error(`${request.chain} RPC not found`);
 
-  const commitment = options?.commitment ?? 'confirmed';
+  let commitment = options?.commitment ?? 'confirmed';
   const connection = new Connection(rpc);
+
+  // HACK: For certain transactions we need to use 'finalized' commitment, such as when posting a VAA.
+  // If you use 'confirmed' here, the Core.PostVaa transaction will fail with "Unexpected length of input"
+  // and it's not clear why.
+  if (
+    request.description === 'Core.VerifySignature' ||
+    request.description === 'Core.PostVAA'
+  ) {
+    commitment = 'finalized';
+  }
 
   const { blockhash, lastValidBlockHeight } =
     await connection.getLatestBlockhash(commitment);

--- a/src/utils/wrappedNativeTokens.ts
+++ b/src/utils/wrappedNativeTokens.ts
@@ -18,6 +18,14 @@ export function getWrappedNativeToken(
     return WSOL_ADDRESS;
   }
 
+  if (platform === 'Aptos') {
+    return '0x1::aptos_coin::AptosCoin';
+  }
+
+  if (platform === 'Sui') {
+    return '0x2::sui::SUI';
+  }
+
   return undefined;
 }
 


### PR DESCRIPTION
basically `getWrappedNativeToken` would return `undefined` for Aptos and Sui wrapped gas token and cause the resume token bridge transfers flow to never find the source token

Fixes PROD-825