### PR TITLE
fix: Styling for chain icon and close and back icons is asset picker

### DIFF
--- a/src/views/v3/Bridge/AssetPicker/ChainList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainList.tsx
@@ -104,7 +104,6 @@ function ChainList(props: Props) {
         whiteSpace: 'nowrap',
       },
       chainIcon: {
-        border: '1px solid transparent',
         borderRadius: '100%',
         width: '24px',
         height: '24px',

--- a/src/views/v3/Bridge/AssetPicker/PickerHeader.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PickerHeader.tsx
@@ -36,16 +36,13 @@ function AssetPickerHeader({
       justifyContent: 'center',
     },
     iconButton: {
-      padding: 0,
       position: 'absolute',
       backgroundColor: theme.palette.background.form,
       border: '1px solid ' + theme.palette.input.border,
       '&:hover': { backgroundColor: theme.palette.background.form },
-    },
-    icon: {
-      height: '16px',
-      width: '16px',
-      padding: '8px',
+      height: '32px',
+      width: '32px',
+      fontSize: '16px',
     },
   };
 
@@ -62,7 +59,7 @@ function AssetPickerHeader({
             aria-label="Go back"
             data-testid="back-button"
           >
-            <ArrowBackRoundedIcon sx={styles.icon} />
+            <ArrowBackRoundedIcon fontSize="inherit" />
           </IconButton>
         )}
         <Typography sx={styles.title} role="heading" aria-level={2}>
@@ -77,7 +74,7 @@ function AssetPickerHeader({
           aria-label="Close routes"
           data-testid="routes-close-button"
         >
-          <CloseRoundedIcon sx={styles.icon} />
+          <CloseRoundedIcon fontSize="inherit" />
         </IconButton>
       </Box>
     </>


### PR DESCRIPTION
Verified on Portal.

<img width="676" height="709" alt="Screenshot 2025-10-06 at 6 43 34 PM" src="https://github.com/user-attachments/assets/622ace5c-ff39-473d-8473-f09c638ebbf1" />
