### PR TITLE
feat: Enable Solana routes to HyperCore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@ledgerhq/logs": "6.12.0",
         "@lifi/sdk": "3.12.14",
-        "@mayanfinance/swap-sdk": "11.1.0",
+        "@mayanfinance/swap-sdk": "11.3.0",
         "@metaplex-foundation/mpl-token-metadata": "3.4.0",
         "@metaplex-foundation/umi": "0.9.2",
         "@metaplex-foundation/umi-bundle-defaults": "0.9.2",
@@ -5652,9 +5652,9 @@
       }
     },
     "node_modules/@mayanfinance/swap-sdk": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-11.1.0.tgz",
-      "integrity": "sha512-VaDnn4/5SbP5ZcVdEckVfWoGaiMQHFutVj+THseYPOKqlytIWqzBlNXUjx4w3Iv6GdaFvEfTHLb5w5MVvC1l1Q==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-11.3.0.tgz",
+      "integrity": "sha512-1pT7yUvO+JIl2Tgrxv6H5cG9mH7vOf6+xlj/ShD2DuiCDfGym3KJwJ3FGqAtBze/aqW5kpCGcfDK3uvVS2WPXw==",
       "license": "MIT",
       "dependencies": {
         "@mysten/sui": "^1.34.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@ledgerhq/hw-transport-webhid": "6.27.1",
     "@ledgerhq/logs": "6.12.0",
     "@lifi/sdk": "3.12.14",
-    "@mayanfinance/swap-sdk": "11.1.0",
+    "@mayanfinance/swap-sdk": "11.3.0",
     "@metaplex-foundation/mpl-token-metadata": "3.4.0",
     "@metaplex-foundation/umi": "0.9.2",
     "@metaplex-foundation/umi-bundle-defaults": "0.9.2",

--- a/src/routes/mayan/MayanRouteBase.ts
+++ b/src/routes/mayan/MayanRouteBase.ts
@@ -649,11 +649,10 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
       );
 
       if (request.fromChain.chain === 'Solana') {
-        // Uncomment and use this when we want to support HyperCore USDC deposits on SOL
-        // const solanaOptions = {
-        //   allowSwapperOffCurve: true,
-        //   usdcPermitSignature,
-        // };
+        const solanaOptions = {
+          allowSwapperOffCurve: true,
+          ...(usdcPermitSignature ? { usdcPermitSignature } : {}),
+        };
 
         const { instructions, signers, lookupTables } =
           await (this.isTestnetRequest(request)
@@ -663,7 +662,7 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
                 destinationAddress,
                 null,
                 rpc,
-                { allowSwapperOffCurve: true },
+                solanaOptions,
               )
             : createSwapFromSolanaInstructions(
                 quote.details!,
@@ -671,7 +670,7 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
                 destinationAddress,
                 null,
                 rpc,
-                { allowSwapperOffCurve: true },
+                solanaOptions,
               ));
 
         const payerKey = new PublicKey(originAddress);

--- a/src/routes/mayan/MayanRouteBase.ts
+++ b/src/routes/mayan/MayanRouteBase.ts
@@ -651,7 +651,7 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
       if (request.fromChain.chain === 'Solana') {
         const solanaOptions = {
           allowSwapperOffCurve: true,
-          ...(usdcPermitSignature ? { usdcPermitSignature } : {}),
+          usdcPermitSignature,
         };
 
         const { instructions, signers, lookupTables } =

--- a/src/utils/hypercore.ts
+++ b/src/utils/hypercore.ts
@@ -138,7 +138,6 @@ export async function maybeGetHyperCorePermitSignature<N extends Network>(
   }
 
   try {
-    console.log(wallet);
     await wallet.switchChain(42161);
   } catch (e) {
     const reason = e instanceof Error ? `: ${e.message}` : '';

--- a/src/utils/hypercore.ts
+++ b/src/utils/hypercore.ts
@@ -63,18 +63,6 @@ export function validateHyperCoreTransfer<N extends Network>(
     };
   }
 
-  if (!(isEvmChain(fromChain.chain) || fromChain.chain === 'Sui')) {
-    // Uncomment and use this when we want to support HyperCore USDC deposits on SOL
-    // || fromChain.chain === 'Solana')
-    return {
-      valid: false,
-      params,
-      error: new routes.UnavailableError(
-        new Error('HyperCore only supports EVM or Sui source chains'),
-      ),
-    };
-  }
-
   return null;
 }
 
@@ -150,6 +138,7 @@ export async function maybeGetHyperCorePermitSignature<N extends Network>(
   }
 
   try {
+    console.log(wallet);
     await wallet.switchChain(42161);
   } catch (e) {
     const reason = e instanceof Error ? `: ${e.message}` : '';

--- a/src/utils/hypercore.ts
+++ b/src/utils/hypercore.ts
@@ -63,6 +63,22 @@ export function validateHyperCoreTransfer<N extends Network>(
     };
   }
 
+  if (
+    !(
+      isEvmChain(fromChain.chain) ||
+      fromChain.chain === 'Sui' ||
+      fromChain.chain === 'Solana'
+    )
+  ) {
+    return {
+      valid: false,
+      params,
+      error: new routes.UnavailableError(
+        new Error('HyperCore only supports EVM, Solana or Sui source chains'),
+      ),
+    };
+  }
+
   return null;
 }
 


### PR DESCRIPTION
### Changes

This PR enables  Solana -> HyperCore routes

List of changes: 
- Update Mayan SDK to 11.3.0
- Remove EVM restrictions 
- Detect and switch wallet destination wallet 
- Send USDC Permit signatures into Solana routes
