### PR TITLE
fix: use theme font family in chain list

### DIFF
--- a/src/views/v3/Bridge/AssetPicker/ChainList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainList.tsx
@@ -97,7 +97,7 @@ function ChainList(props: Props) {
       chainTileLabel: {
         color: theme.palette.text.secondary,
         fontSize: '9px',
-        fontFamily: 'IBM Plex Mono',
+        fontFamily: theme.typography.fontFamily,
         fontWeight: 400,
         lineHeight: '12px',
         marginTop: '8px',


### PR DESCRIPTION
This was causing the chain list font on monadbridge.com to look too small