### PR TITLE
fix: Missing prop to calculate fee-offset for Mayan routes

### DIFF
--- a/src/routes/operator.ts
+++ b/src/routes/operator.ts
@@ -344,7 +344,6 @@ class QuoteMetadataCache {
         route,
         params.amount,
         params.sourceToken,
-        params.destChain,
         params.destToken,
       );
 

--- a/src/utils/fees.test.ts
+++ b/src/utils/fees.test.ts
@@ -103,7 +103,6 @@ describe('calculateFeeOffset', () => {
         'MayanSwapRoute',
         mockAmount,
         mockToken,
-        'Solana',
         mockToken,
       );
 
@@ -138,7 +137,6 @@ describe('calculateFeeOffset', () => {
         'MayanSwapRoute',
         mockAmount,
         mockToken,
-        'Solana',
         mockToken,
       );
       expect(result).toBeUndefined();
@@ -157,7 +155,6 @@ describe('calculateFeeOffset', () => {
         'MayanSwapRoute',
         mockAmount,
         mockToken,
-        'Solana',
         mockToken,
       );
       expect(result).toBeUndefined();

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -75,7 +75,7 @@ export function calculateFeeOffset(
   route: SDKv2Route | string | undefined,
   amount: sdkAmount.Amount | undefined,
   sourceToken: Token | undefined,
-  destToken: Token,
+  destToken?: Token,
 ): sdkAmount.Amount | undefined {
   if (!sourceToken || !amount || !route || sdkAmount.units(amount) === 0n) {
     return undefined;

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -68,7 +68,6 @@ export function applyOffsetFormula(
  * @param amount - The desired output amount (what user wants to receive)
  * @param routeName - The name of the route
  * @param sourceToken - The source token (required for token-specific fees)
- * @param destChain - Optional destination chain (for Mayan routes)
  * @param destToken - Optional destination token (for Mayan routes)
  * @returns The additional amount to add so that after fee deduction, user receives the desired amount
  */
@@ -76,8 +75,7 @@ export function calculateFeeOffset(
   route: SDKv2Route | string | undefined,
   amount: sdkAmount.Amount | undefined,
   sourceToken: Token | undefined,
-  destChain?: string,
-  destToken?: Token,
+  destToken: Token,
 ): sdkAmount.Amount | undefined {
   if (!sourceToken || !amount || !route || sdkAmount.units(amount) === 0n) {
     return undefined;
@@ -114,7 +112,7 @@ export function calculateFeeOffset(
         },
         destination: {
           id: destToken.tokenId || {
-            chain: destChain || destToken.chain,
+            chain: destToken.chain,
             address: destToken.address,
           },
           symbol: destToken.symbol,

--- a/src/views/v3/Bridge/AssetPicker/FeeOffset.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/FeeOffset.test.tsx
@@ -18,6 +18,14 @@ vi.mock('utils/fees', () => ({
   calculateFeeOffset: vi.fn(),
 }));
 
+// Mock the useGetTokens hook
+vi.mock('hooks/useGetTokens', () => ({
+  useGetTokens: vi.fn(() => ({
+    sourceToken: undefined,
+    destToken: undefined,
+  })),
+}));
+
 const mockToken = {
   key: 'USDC',
   symbol: 'USDC',
@@ -57,15 +65,21 @@ describe('FeeOffset', () => {
 
   it('renders fee offset with token symbol when valid amount is calculated', async () => {
     const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+    const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+
     const feeOffset = sdkAmount.fromBaseUnits(1000n, 6); // 0.001 USDC
     calculateFeeOffset.mockReturnValue(feeOffset);
+    useGetTokens.mockReturnValue({
+      sourceToken: mockToken,
+      destToken: undefined,
+    } as any);
 
     const store = createMockStore(
       sdkAmount.fromBaseUnits(100000n, 6),
       'TestRoute',
     );
 
-    render(<FeeOffset token={mockToken} />, {
+    render(<FeeOffset />, {
       wrapper: AppWrapper(store),
     });
 
@@ -74,15 +88,21 @@ describe('FeeOffset', () => {
 
   it('displays info icon with tooltip', async () => {
     const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+    const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+
     const feeOffset = sdkAmount.fromBaseUnits(1000n, 6);
     calculateFeeOffset.mockReturnValue(feeOffset);
+    useGetTokens.mockReturnValue({
+      sourceToken: mockToken,
+      destToken: undefined,
+    } as any);
 
     const store = createMockStore(
       sdkAmount.fromBaseUnits(100000n, 6),
       'TestRoute',
     );
 
-    render(<FeeOffset token={mockToken} />, {
+    render(<FeeOffset />, {
       wrapper: AppWrapper(store),
     });
 

--- a/src/views/v3/Bridge/AssetPicker/FeeOffset.tsx
+++ b/src/views/v3/Bridge/AssetPicker/FeeOffset.tsx
@@ -5,27 +5,26 @@ import InfoOutlineIcon from '@mui/icons-material/InfoOutline';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
 import type { RootState } from 'store';
-import type { Token } from 'config/tokens';
 import { calculateFeeOffset } from 'utils/fees';
-
-type Props = {
-  token?: Token;
-};
+import { useGetTokens } from 'hooks/useGetTokens';
 
 /**
  * Displays the fee offset amount that will be added to ensure users receive
  * exactly what they requested after protocol fees are deducted
  */
-function FeeOffset(props: Props) {
+function FeeOffset() {
   const theme: any = useTheme();
   const { amount, route: selectedRoute } = useSelector(
     (state: RootState) => state.transferInput,
   );
 
-  // Recalculate only when selectedRoute, amount or token changes
+  // Get both source and destination tokens from the store
+  const { sourceToken, destToken } = useGetTokens();
+
+  // Recalculate only when selectedRoute, amount or tokens change
   const feeOffsetAmount = useMemo(
-    () => calculateFeeOffset(selectedRoute, amount, props.token),
-    [selectedRoute, amount, props.token],
+    () => calculateFeeOffset(selectedRoute, amount, sourceToken, destToken),
+    [selectedRoute, amount, sourceToken, destToken],
   );
 
   const feeDisplay = useMemo(() => {
@@ -41,7 +40,7 @@ function FeeOffset(props: Props) {
           lineHeight="14px"
           height={'14px'}
         >
-          +{sdkAmount.display(feeOffsetAmount)} {props.token?.symbol}
+          +{sdkAmount.display(feeOffsetAmount)} {sourceToken?.symbol}
         </Typography>
         <Tooltip title="Portal's fee is added on top of your input amount. Slippage may still apply.">
           <InfoOutlineIcon
@@ -55,7 +54,7 @@ function FeeOffset(props: Props) {
         </Tooltip>
       </>
     );
-  }, [feeOffsetAmount, props.token?.symbol, theme.palette.text.secondary]);
+  }, [feeOffsetAmount, sourceToken?.symbol, theme.palette.text.secondary]);
 
   return (
     <Box

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -563,7 +563,7 @@ function AssetPicker(props: Props) {
             </Box>
           )}
         </Box>
-        {props.isSource && <FeeOffset token={props.token} />}
+        {props.isSource && <FeeOffset />}
         <Box
           sx={{
             height: '22px',


### PR DESCRIPTION
Destination token was missing in FeeOffset component when calculating the offset for Mayan routes.