### PR TITLE
fix: Remove invalid WebSearch setting

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,7 +35,6 @@
       "Grep(*)",
       "Glob(*)",
       "LS(*)",
-      "WebSearch(*)",
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:github.com)"
     ],


### PR DESCRIPTION
Claude says wildcards can't be used in WebSearch permissions and removing it will allow web searches to any domain without restrictions (same as `*` I guess).