### PR TITLE
fix: Addressing UX follow up items

### DIFF
--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -10,7 +10,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     symbol: 'ETH',
   },
   Bsc: {
-    displayName: 'BSC',
+    displayName: 'BNB',
     sdkName: 'Bsc',
     explorerUrl: 'https://bscscan.com/',
     explorerName: 'BscScan',

--- a/src/config/testnet/chains.ts
+++ b/src/config/testnet/chains.ts
@@ -2,7 +2,7 @@ import type { ChainsConfig } from '../types';
 
 export const TESTNET_CHAINS: ChainsConfig = {
   Bsc: {
-    displayName: 'BSC',
+    displayName: 'BNB',
     explorerUrl: 'https://testnet.bscscan.com/',
     explorerName: 'BscScan',
     icon: 'Bsc',

--- a/src/views/v3/Bridge/AssetPicker/ChainList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainList.tsx
@@ -178,7 +178,7 @@ function ChainList(props: Props) {
           <ChainShortList
             chains={topChains}
             selectedChain={selectedChainConfig}
-            showOtherButton={showMoreButton}
+            showMoreButton={showMoreButton}
             onChainSelect={onChainSelect}
             onShowMore={() => setShowSearch(true)}
           />

--- a/src/views/v3/Bridge/AssetPicker/ChainShortList.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainShortList.test.tsx
@@ -98,7 +98,7 @@ const mockSelectedChain = {
 const defaultProps = {
   chains: mockChainConfigs,
   selectedChain: undefined,
-  showOtherButton: false,
+  showMoreButton: false,
   onChainSelect: vi.fn(),
   onShowMore: vi.fn(),
 };
@@ -143,25 +143,25 @@ describe('ChainShortList', () => {
     expect(ethereumButton).toHaveClass('Mui-selected');
   });
 
-  it('shows other button when showOtherButton is true', () => {
-    const props = { ...defaultProps, showOtherButton: true };
+  it('shows More button when showMoreButton is true', () => {
+    const props = { ...defaultProps, showMoreButton: true };
     render(<ChainShortList {...props} />, { wrapper: AppWrapper });
 
-    expect(screen.getByText('other')).toBeInTheDocument();
+    expect(screen.getByText('More')).toBeInTheDocument();
   });
 
-  it('does not show other button when showOtherButton is false', () => {
+  it('does not show More button when showMoreButton is false', () => {
     render(<ChainShortList {...defaultProps} />, { wrapper: AppWrapper });
 
-    expect(screen.queryByText('other')).not.toBeInTheDocument();
+    expect(screen.queryByText('More')).not.toBeInTheDocument();
   });
 
-  it('calls onShowMore when other button is clicked', () => {
-    const props = { ...defaultProps, showOtherButton: true };
+  it('calls onShowMore when More button is clicked', () => {
+    const props = { ...defaultProps, showMoreButton: true };
     render(<ChainShortList {...props} />, { wrapper: AppWrapper });
 
-    const otherButton = screen.getByRole('button', { name: /other/i });
-    fireEvent.click(otherButton);
+    const moreButton = screen.getByRole('button', { name: /More/ });
+    fireEvent.click(moreButton);
 
     expect(defaultProps.onShowMore).toHaveBeenCalledTimes(1);
   });

--- a/src/views/v3/Bridge/AssetPicker/ChainShortList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainShortList.tsx
@@ -15,7 +15,7 @@ import { OPACITY } from 'utils/style';
 type ChainShortListProps = {
   chains: ChainConfig[];
   selectedChain?: ChainConfig;
-  showOtherButton: boolean;
+  showMoreButton: boolean;
   onChainSelect: (chain: Chain) => void;
   onShowMore: () => void;
 };
@@ -23,7 +23,7 @@ type ChainShortListProps = {
 function ChainShortList({
   chains,
   selectedChain,
-  showOtherButton,
+  showMoreButton,
   onChainSelect,
   onShowMore,
 }: ChainShortListProps) {
@@ -59,7 +59,7 @@ function ChainShortList({
       },
       chainTileLabel: {
         color: theme.palette.text.secondary,
-        fontSize: '9px',
+        fontSize: '10px',
         fontFamily: theme.typography.fontFamily,
         fontWeight: 400,
         lineHeight: '12px',
@@ -114,13 +114,17 @@ function ChainShortList({
     ],
   );
 
-  const otherButton = useMemo(
+  const moreButton = useMemo(
     () => (
-      <ListItemButton key="other" sx={styles.chainButton} onClick={onShowMore}>
+      <ListItemButton
+        key="moreButton"
+        sx={styles.chainButton}
+        onClick={onShowMore}
+      >
         <Box sx={styles.chainIcon}>
           <PlusIcon sx={{ height: '24px', width: '24px' }} />
         </Box>
-        <Typography sx={styles.chainTileLabel}>other</Typography>
+        <Typography sx={styles.chainTileLabel}>More</Typography>
       </ListItemButton>
     ),
     [onShowMore, styles.chainButton, styles.chainIcon, styles.chainTileLabel],
@@ -136,7 +140,7 @@ function ChainShortList({
       {chainRows.secondRowChains.length > 0 && (
         <Box display="flex" flexDirection="row" gap="16px">
           {chainRows.secondRowChains.map((chain) => renderChainButton(chain))}
-          {showOtherButton && otherButton}
+          {showMoreButton && moreButton}
         </Box>
       )}
     </Box>


### PR DESCRIPTION
Addressing below comments:
- "BSC" should be "BNB"
- "other" should be "More"
- Match the secondary text size used in the network label names and the asset labels shown in the token rows in the next section below.
  - This will increase the width of the network tiles, make them fill the width of the screen before breaking to the next line (mobile design coming shortly)