### PR TITLE
fix: Chain list single row layout for 5 or fewer chains

### DIFF
--- a/src/utils/fees.test.ts
+++ b/src/utils/fees.test.ts
@@ -22,6 +22,7 @@ describe('calculateFeeOffset', () => {
     key: 'Ethereum:0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
     chain: 'Ethereum',
     address: '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
+    addressString: '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
     symbol: 'USDC',
     name: 'USD Coin',
     decimals: 6,
@@ -236,10 +237,10 @@ describe('calculateFeeOffset', () => {
           config: {
             referrerFee: {
               feeDbps: 50n,
-            },
-            tokens: {
-              [mockToken.key]: {
-                referrerFeeDbps: 20n, // Token-specific override
+              perTokenOverrides: {
+                [mockToken.addressString]: {
+                  referrerFeeDbps: 20n, // Token-specific override
+                },
               },
             },
           },
@@ -292,7 +293,7 @@ describe('calculateFeeOffset', () => {
             referrerFee: {
               referrerFeeDbps: 100n,
               tokenFeeOverrides: {
-                [mockToken.key]: {
+                [mockToken.addressString]: {
                   referrerFeeDbps: 30n, // Token-specific override
                 },
               },

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -146,10 +146,14 @@ export function calculateFeeOffset(
     // NTT Executor route uses referrerFee.feeDbps
     else if (routeConfig.referrerFee?.feeDbps !== undefined) {
       // Check for token-specific override in NTT
-      if (routeConfig.tokens && sourceToken) {
-        const tokenConfig = routeConfig.tokens[sourceToken.key];
-        if (tokenConfig?.referrerFeeDbps !== undefined) {
-          feeDbps = tokenConfig.referrerFeeDbps;
+      if (
+        routeConfig.referrerFee.perTokenOverrides !== undefined &&
+        sourceToken
+      ) {
+        const override =
+          routeConfig.referrerFee.perTokenOverrides[sourceToken.addressString];
+        if (override?.referrerFeeDbps !== undefined) {
+          feeDbps = override.referrerFeeDbps;
         } else {
           feeDbps = routeConfig.referrerFee.feeDbps;
         }
@@ -162,7 +166,7 @@ export function calculateFeeOffset(
       // Check for token-specific override in Token Bridge Executor
       if (routeConfig.referrerFee.tokenFeeOverrides && sourceToken) {
         const tokenOverride =
-          routeConfig.referrerFee.tokenFeeOverrides[sourceToken.key];
+          routeConfig.referrerFee.tokenFeeOverrides[sourceToken.addressString];
         if (tokenOverride?.referrerFeeDbps !== undefined) {
           feeDbps = tokenOverride.referrerFeeDbps;
         } else {

--- a/src/views/v3/Bridge/AssetPicker/ChainShortList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainShortList.tsx
@@ -78,7 +78,11 @@ function ChainShortList({
   );
 
   const chainRows = useMemo(() => {
-    const chainsPerRow = Math.ceil(chains.length / 2);
+    // Only use 2 rows if we have 6 or more chains
+    const shouldUseTwoRows = chains.length >= 6;
+    const chainsPerRow = shouldUseTwoRows
+      ? Math.ceil(chains.length / 2)
+      : chains.length;
 
     const firstRowChains = chains.slice(0, chainsPerRow);
     const secondRowChains = chains.slice(chainsPerRow);
@@ -129,7 +133,12 @@ function ChainShortList({
   return (
     <Box sx={{ maxWidth: '420px' }}>
       {/* First row */}
-      <Box display="flex" flexDirection="row" gap="16px" marginBottom="16px">
+      <Box
+        display="flex"
+        flexDirection="row"
+        gap="16px"
+        marginBottom={chainRows.secondRowChains.length > 0 ? '16px' : '0'}
+      >
         {chainRows.firstRowChains.map((chain) => renderChainButton(chain))}
       </Box>
       {/* Second row */}


### PR DESCRIPTION
monad testnet only has 3 chains configured and caused 2 in first row and 1 in second

also fix ntt fee override dbps value reference