### PR TITLE
feat: Center asset picker modal vertically

### DIFF
--- a/src/views/v3/Bridge/AssetPicker/ChainList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/ChainList.tsx
@@ -59,7 +59,7 @@ function ChainList(props: Props) {
         justifyContent: 'center',
       },
       chainSearchList: {
-        maxHeight: '480px',
+        maxHeight: '516px',
         [theme.breakpoints.down('sm')]: {
           maxHeight: '640px',
         },

--- a/src/views/v3/Bridge/AssetPicker/PickerModal.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PickerModal.tsx
@@ -64,15 +64,7 @@ function AssetPickerPopover({
     <Popover
       {...bindPopover(popupState)}
       transitionDuration={200}
-      anchorEl={anchorEl}
-      anchorOrigin={{
-        vertical: 'top',
-        horizontal: 'center',
-      }}
-      transformOrigin={{
-        vertical: 'top',
-        horizontal: 'center',
-      }}
+      anchorReference="none"
       marginThreshold={4}
       slotProps={{
         paper: {
@@ -88,6 +80,9 @@ function AssetPickerPopover({
         },
         root: {
           sx: {
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
             backdropFilter: 'blur(4px)',
             WebkitBackdropFilter: 'blur(4px)', // Safari support
           },


### PR DESCRIPTION
Currently asset picker modal is anchored at the top position of the selected pickers trigger. After this change it'll always be centered vertically.

<img width="1451" height="931" alt="Screenshot 2025-10-11 at 11 15 08 PM" src="https://github.com/user-attachments/assets/fce897e2-959b-4fb0-b8b7-63b90fadf0b6" />

<img width="1245" height="799" alt="Screenshot 2025-10-11 at 11 15 34 PM" src="https://github.com/user-attachments/assets/049d9682-9d6b-4e43-bad6-9a04bed8e7fe" />
