### PR TITLE
feat: Creditcoin gas estimate buffer

### DIFF
--- a/src/utils/wallet/evm.test.ts
+++ b/src/utils/wallet/evm.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signAndSendTransaction } from './evm';
+import type { EvmUnsignedTransaction } from '@wormhole-foundation/sdk-evm';
+import type { Network } from '@wormhole-foundation/sdk';
+
+describe('signAndSendTransaction', () => {
+  const mockWallet = {
+    getSigner: vi.fn(),
+    switchChain: vi.fn(),
+  };
+
+  const mockSigner = {
+    provider: {
+      getNetwork: vi.fn(),
+    },
+    estimateGas: vi.fn(),
+    sendTransaction: vi.fn(),
+  };
+
+  const mockTx = {
+    wait: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call estimateGas and add 30% buffer for CreditCoin transactions', async () => {
+    const request = {
+      chain: 'CreditCoin',
+      transaction: {
+        chainId: 102031,
+        data: '0x',
+        to: '0x123',
+        value: 0n,
+      },
+    } as EvmUnsignedTransaction<Network, any>;
+
+    const expectedGasLimit = 100000n;
+    const expectedBufferedGasLimit = (expectedGasLimit * 130n) / 100n;
+
+    mockWallet.getSigner.mockResolvedValue(mockSigner);
+    mockSigner.provider.getNetwork.mockResolvedValue({ chainId: 102031n });
+    mockSigner.estimateGas.mockResolvedValue(expectedGasLimit);
+    mockSigner.sendTransaction.mockResolvedValue(mockTx);
+    mockTx.wait.mockResolvedValue({ hash: '0xabc123' });
+
+    const result = await signAndSendTransaction(
+      request,
+      mockWallet as any,
+      'CreditCoin',
+    );
+
+    expect(mockSigner.estimateGas).toHaveBeenCalledWith(request.transaction);
+    expect(mockSigner.sendTransaction).toHaveBeenCalledWith({
+      ...request.transaction,
+      gasLimit: expectedBufferedGasLimit,
+    });
+    expect(result).toBe('0xabc123');
+  });
+});

--- a/src/utils/wallet/evm.ts
+++ b/src/utils/wallet/evm.ts
@@ -143,6 +143,16 @@ export async function signAndSendTransaction(
     }
   }
 
+  if (request.chain === 'CreditCoin') {
+    // CreditCoin transactions often fail due to insufficient gas limit estimation
+    // due to it being a custom network and MetaMask (and possibly other wallets) not
+    // estimating gas limits correctly.
+    if (!request.transaction.gasLimit) {
+      const estimatedGas = await signer.estimateGas(request.transaction);
+      request.transaction.gasLimit = (estimatedGas * 30n) / 100n; // add 30% buffer
+    }
+  }
+
   const tx = await signer.sendTransaction(request.transaction);
   const result = await tx.wait();
 

--- a/src/utils/wallet/evm.ts
+++ b/src/utils/wallet/evm.ts
@@ -146,10 +146,10 @@ export async function signAndSendTransaction(
   if (request.chain === 'CreditCoin') {
     // CreditCoin transactions often fail due to insufficient gas limit estimation
     // due to it being a custom network and MetaMask (and possibly other wallets) not
-    // estimating gas limits correctly.
+    // adding an appropriate buffer.
     if (!request.transaction.gasLimit) {
       const estimatedGas = await signer.estimateGas(request.transaction);
-      request.transaction.gasLimit = (estimatedGas * 30n) / 100n; // add 30% buffer
+      request.transaction.gasLimit = (estimatedGas * 130n) / 100n; // add 30% buffer
     }
   }
 


### PR DESCRIPTION
add 30% buffer to CreditCoin gas limit since MetaMask does not estimate for custom chains correctly apparently (according to CC)