### PR TITLE
fix: Filter frankenstein tokens in asset picker

### DIFF
--- a/src/hooks/useTokenListWithSearch.test.tsx
+++ b/src/hooks/useTokenListWithSearch.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTokenListWithSearch } from './useTokenListWithSearch';
+import { Token } from 'config/tokens';
+import { amount } from '@wormhole-foundation/sdk-connect';
+
+const ethereumUSDC = new Token({
+  chain: 'Ethereum',
+  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  decimals: 6,
+  symbol: 'USDC',
+});
+
+const arbitrumUSDC = new Token({
+  chain: 'Arbitrum',
+  address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+  decimals: 6,
+  symbol: 'USDC',
+});
+
+const arbitrumFrankensteinUSDC = new Token({
+  chain: 'Arbitrum',
+  address: '0xC96F2715E2a242d50D1b0bC923dbe1740b8eCf18',
+  decimals: 6,
+  symbol: 'USDC',
+  tokenBridgeOriginalTokenId: ethereumUSDC.tokenId,
+});
+
+const mockGetOrFetchToken = vi.fn().mockResolvedValue(null);
+const mockGetTokenPrices = vi.fn(() => new Map());
+
+vi.mock('contexts/TokensContext', () => ({
+  useTokens: () => ({
+    getOrFetchToken: mockGetOrFetchToken,
+    getTokenPrices: mockGetTokenPrices,
+  }),
+}));
+
+describe('useTokenListWithSearch', () => {
+  it('should filter out frankenstein tokens on destination chain', () => {
+    const { result } = renderHook(() =>
+      useTokenListWithSearch({
+        baseTokenList: [arbitrumUSDC, arbitrumFrankensteinUSDC],
+        searchQuery: '',
+        chain: 'Arbitrum',
+        isSource: false,
+        isSameChainSwap: false,
+        sourceToken: ethereumUSDC,
+      }),
+    );
+
+    // Should only have the native USDC token, frankenstein USDC filtered out
+    expect(result.current.sortedTokens).toHaveLength(1);
+    expect(result.current.sortedTokens[0].symbol).toBe('USDC');
+    expect(result.current.sortedTokens[0].nativeChain).toBe('Arbitrum');
+  });
+
+  it('should filter out frankenstein tokens on source chain if no balance', () => {
+    const { result } = renderHook(() =>
+      useTokenListWithSearch({
+        baseTokenList: [arbitrumUSDC, arbitrumFrankensteinUSDC],
+        searchQuery: '',
+        chain: 'Arbitrum',
+        isSource: true,
+        isSameChainSwap: false,
+        sourceToken: undefined,
+      }),
+    );
+
+    // Should only have the native USDC token, frankenstein USDC filtered out due to no balance
+    expect(result.current.sortedTokens).toHaveLength(1);
+    expect(result.current.sortedTokens[0].symbol).toBe('USDC');
+    expect(result.current.sortedTokens[0].nativeChain).toBe('Arbitrum');
+  });
+
+  it('should include frankenstein tokens on source chain if has balance', () => {
+    const { result } = renderHook(() =>
+      useTokenListWithSearch({
+        baseTokenList: [arbitrumUSDC, arbitrumFrankensteinUSDC],
+        searchQuery: '',
+        chain: 'Arbitrum',
+        isSource: true,
+        isSameChainSwap: false,
+        sourceToken: undefined,
+        balances: {
+          [arbitrumFrankensteinUSDC.key]: {
+            balance: amount.fromBaseUnits(1000000n, 6), // 1 token with 6 decimals
+            lastUpdated: Date.now(),
+          },
+        },
+      }),
+    );
+
+    // Should have both the native USDC token and frankenstein USDC since it has a balance
+    expect(result.current.sortedTokens).toHaveLength(2);
+    expect(result.current.sortedTokens[0].symbol).toBe('USDC');
+    expect(result.current.sortedTokens[0].nativeChain).toBe('Arbitrum');
+  });
+});

--- a/src/hooks/useTokenListWithSearch.ts
+++ b/src/hooks/useTokenListWithSearch.ts
@@ -6,16 +6,20 @@ import {
   useDeferredValue,
   startTransition,
 } from 'react';
-import { toNative } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount, toNative } from '@wormhole-foundation/sdk';
 import type { Chain } from '@wormhole-foundation/sdk';
 import type { Token } from 'config/tokens';
 import config from 'config';
 import { useTokens } from 'contexts/TokensContext';
-import { getTokenDisplaySymbolByTokenAddress } from 'utils';
+import {
+  getTokenDisplaySymbolByTokenAddress,
+  isFrankensteinToken,
+} from 'utils';
 import {
   getWrappedNativeToken,
   shouldFilterSameChainToken,
 } from 'utils/wrappedNativeTokens';
+import type { Balances } from 'utils/wallet/types';
 import { unionBy } from 'es-toolkit';
 
 interface UseTokenListWithSearchParams {
@@ -25,6 +29,7 @@ interface UseTokenListWithSearchParams {
   isSource: boolean;
   isSameChainSwap: boolean;
   sourceToken?: Token;
+  balances?: Balances;
   tokenPastingEnabled?: boolean;
 }
 
@@ -47,6 +52,7 @@ export const useTokenListWithSearch = ({
   isSource,
   isSameChainSwap,
   sourceToken,
+  balances,
   tokenPastingEnabled = true,
 }: UseTokenListWithSearchParams): UseTokenListWithSearchReturn => {
   const [searchedTokens, setSearchedTokens] = useState<Token[]>([]);
@@ -155,6 +161,30 @@ export const useTokenListWithSearch = ({
       );
     }
 
+    // Filter frankenstein tokens based on whether it's source or destination
+    if (chain) {
+      tokens = tokens.filter((token) => {
+        if (!isFrankensteinToken(token, chain)) {
+          return true;
+        }
+
+        // For destination tokens: always filter out frankenstein tokens
+        if (!isSource) {
+          return false;
+        }
+
+        // For source tokens: only show frankenstein tokens if they have a balance
+        if (balances) {
+          const balance = balances[token.key]?.balance;
+          const hasBalance = balance && sdkAmount.units(balance) > 0n;
+          return hasBalance;
+        }
+
+        // No balances available - don't show frankenstein tokens
+        return false;
+      });
+    }
+
     return tokens;
   }, [
     baseTokenList,
@@ -165,6 +195,8 @@ export const useTokenListWithSearch = ({
     isSameChainSwap,
     isSource,
     wrappedNativeAddr,
+    chain,
+    balances,
   ]);
 
   const tokenPrices = useMemo(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -343,10 +343,11 @@ export const getWalletExplorerUrl = (
     : appendPathToUrl(baseUrl, `address/${path}`);
 };
 
-// Frankenstein tokens are wormhole-wrapped tokens that are not native to the chain
-// and likely have no liquidity.
-// An example of a Frankenstein token is wormhole-wrapped Arbitrum WETH on Solana.
-// However wormhole-wrapped Ethereum WETH on Solana is not a Frankenstein token.
+// Frankenstein tokens are specific token bridge wrapped tokens (WTT) that likely have no liquidity.
+// An example of a Frankenstein token is token bridge wrapped Arbitrum WETH on Solana.
+// However token bridge wrapped Ethereum WETH on Solana is not a Frankenstein token.
+// This is not meant to be a perfect classification, but rather a heuristic to filter out
+// tokens that are likely to have no liquidity on DEXes.
 export const isFrankensteinToken = (token: Token, chain: Chain) => {
   if (!token.isTokenBridgeWrappedToken) {
     return false;
@@ -354,7 +355,7 @@ export const isFrankensteinToken = (token: Token, chain: Chain) => {
 
   const { nativeChain, symbol } = token;
 
-  if (symbol === 'USDC' && nativeChain === 'Ethereum' && chain === 'Fantom') {
+  if (symbol === 'USDC') {
     return true;
   }
 
@@ -363,7 +364,7 @@ export const isFrankensteinToken = (token: Token, chain: Chain) => {
   }
 
   return (
-    !(['Ethereum', 'Sepolia'] as Chain[]).includes(nativeChain) &&
+    nativeChain !== 'Ethereum' &&
     ['ETH', 'WETH', 'wstETH', 'USDT', 'USDC', 'USDC.e'].includes(symbol)
   );
 };

--- a/src/utils/isFrankensteinToken.test.ts
+++ b/src/utils/isFrankensteinToken.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { isFrankensteinToken } from './index';
+import { Token } from 'config/tokens';
+
+describe('isFrankensteinToken', () => {
+  it('should return false for non-wrapped tokens', () => {
+    const ethereumUSDC = new Token({
+      chain: 'Ethereum',
+      address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      decimals: 6,
+      symbol: 'USDC',
+      tokenBridgeOriginalTokenId: undefined,
+    });
+
+    expect(isFrankensteinToken(ethereumUSDC, 'Ethereum')).toBe(false);
+  });
+
+  it('should return true for Arbitrum wrapped USDC on Solana', () => {
+    const arbitrumUSDC = new Token({
+      chain: 'Arbitrum',
+      address: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      decimals: 6,
+      symbol: 'USDC',
+    });
+
+    const wrappedOnSolana = new Token({
+      chain: 'Solana',
+      address: '8wJakbZuv7WApfHmRo2sdkeQfu6hXqfEqjb7BYXDKpKe',
+      decimals: 6,
+      symbol: 'USDC',
+      tokenBridgeOriginalTokenId: arbitrumUSDC.tokenId,
+    });
+
+    expect(isFrankensteinToken(wrappedOnSolana, 'Solana')).toBe(true);
+  });
+
+  it('should return false for wrapped WETH on Solana', () => {
+    const ethereumWETH = new Token({
+      chain: 'Ethereum',
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      decimals: 18,
+      symbol: 'WETH',
+    });
+
+    const wrappedOnSolana = new Token({
+      chain: 'Solana',
+      address: '7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs',
+      decimals: 8,
+      symbol: 'WETH',
+      tokenBridgeOriginalTokenId: ethereumWETH.tokenId,
+    });
+
+    expect(isFrankensteinToken(wrappedOnSolana, 'Solana')).toBe(false);
+  });
+});

--- a/src/views/v3/Bridge/AssetPicker/TokenList.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenList.tsx
@@ -43,6 +43,7 @@ const TokenList = (props: Props) => {
     isSource: props.isSource,
     isSameChainSwap: props.isSameChainSwap,
     sourceToken: props.sourceToken,
+    balances: props.balances,
     tokenPastingEnabled: tokenPastingIsEnabled,
   });
 


### PR DESCRIPTION
The token picker was displaying "frankenstein tokens" - certain token bridge wrapped tokens that likely have no liquidity. For example, when a user selected Ethereum as the source chain, USDC as the source token, and Arbitrum as the destination chain, they would see both native Arbitrum USDC and token bridge wrapped Ethereum USDC (which has no liquidity on Arbitrum). This change updates `useTokenListWithSearch` to always hide frankenstein tokens on the destination chain and only show frankenstein tokens on the source chain if the user has a balance - if they already have them, they should be able to move them.