### PR TITLE
feat: upgrade npm publishing to OIDC authentication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,18 +11,21 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC authentication with npm
+      contents: read
 
     defaults:
       run:
         working-directory: './'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: '**/package-lock.json'
           registry-url: 'https://registry.npmjs.org'
@@ -34,6 +37,3 @@ jobs:
           npm run build:lib
           npm run build:hosted
           npm publish --tag $(echo $([ ${strarr[0]} == "production" ] && echo "latest" || echo ${strarr[0]})) --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry


### PR DESCRIPTION
## Summary

Migrate npm publishing from traditional NPM_TOKEN secret authentication to OpenID Connect (OIDC) trusted publishers for enhanced security and automatic provenance attestations.

## Changes

- ✅ Add OIDC permissions (`id-token: write`) to publish workflow
- ✅ Upgrade `actions/checkout@v3` → `v5`
- ✅ Upgrade `actions/setup-node@v4` → `v6`
- ✅ Upgrade Node.js 20 → 24 (includes npm 11.5.1+ for OIDC support)
- ✅ Remove `NPM_TOKEN` secret reference
- ✅ Configure trusted publisher on npm for `@wormhole-foundation/wormhole-connect`

## Benefits

- **No long-lived tokens**: No secrets to manage or rotate
- **Reduced attack surface**: Short-lived tokens issued per workflow run
- **Automatic provenance**: npm automatically generates provenance attestations
- **Better audit trail**: Authentication tied to specific workflow runs

## Testing

The trusted publisher has been configured on npm. To test:

1. Trigger the publish workflow manually from GitHub Actions
2. Use a test version tag (e.g., `1.0.0-beta.test`)
3. Verify publishing succeeds without NPM_TOKEN
4. Confirm provenance attestations are generated

## References

- [npm Trusted Publishers Documentation](https://docs.npmjs.com/trusted-publishers/)
- [npm Provenance Documentation](https://docs.npmjs.com/generating-provenance-statements/)
- [GitHub OIDC Documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)