### PR TITLE
fix: Destination token sorting

### DIFF
--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -47,6 +47,7 @@ export const useTokenList = ({
       selectedToken,
       balances,
       getTokenPrice,
+      sourceToken,
     );
 
     // Apply token whitelist filtering if configured

--- a/src/hooks/useTransactionHistoryLiFi.test.tsx
+++ b/src/hooks/useTransactionHistoryLiFi.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { createMockToken } from 'utils/testHelpers';
 
-const mockToken = {
-  key: 'USDC',
+const mockToken = createMockToken({
   chain: 'Ethereum',
-  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  addressString: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   decimals: 6,
   symbol: 'USDC',
   name: 'USD Coin',
-};
+});
 
 // Mock dependencies
 vi.mock('config', () => ({

--- a/src/hooks/useTransactionHistoryMayan.test.tsx
+++ b/src/hooks/useTransactionHistoryMayan.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { createMockToken } from 'utils/testHelpers';
 
-const mockToken = {
-  key: 'USDC',
+const mockToken = createMockToken({
   chain: 'Ethereum',
-  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  addressString: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   decimals: 6,
   symbol: 'USDC',
   name: 'USD Coin',
-};
+});
 
 // Mock dependencies
 vi.mock('config', () => ({

--- a/src/hooks/useTransactionHistoryWHScan.test.tsx
+++ b/src/hooks/useTransactionHistoryWHScan.test.tsx
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
+import { createMockToken } from 'utils/testHelpers';
 
-const mockToken = {
-  key: 'USDC',
+const mockToken = createMockToken({
   chain: 'Ethereum',
-  address: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  addressString: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
   decimals: 6,
   symbol: 'USDC',
   name: 'USD Coin',
-};
+});
 
 // Mock dependencies
 vi.mock('config', () => ({

--- a/src/utils/fees.test.ts
+++ b/src/utils/fees.test.ts
@@ -6,6 +6,7 @@ import {
   applyOffsetFormula,
 } from './fees';
 import config from 'config';
+import { createMockToken } from './testHelpers';
 
 // Mock the config module
 vi.mock('config', () => ({
@@ -18,29 +19,12 @@ vi.mock('config', () => ({
 
 describe('calculateFeeOffset', () => {
   const mockAmount = sdkAmount.fromBaseUnits(10000n, 6); // 0.01 with 6 decimals
-  const mockToken = {
-    key: 'Ethereum:0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
-    chain: 'Ethereum',
-    address: '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
+  const mockToken = createMockToken({
     addressString: '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
     symbol: 'USDC',
     name: 'USD Coin',
     decimals: 6,
-    tokenId: {
-      chain: 'Ethereum',
-      address: '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e',
-    },
-    display: 'USD Coin',
-    shortAddress: '0xa0b8...7e8e',
-    tuple: ['Ethereum', '0xa0b86a33e6776a1e5e0b3a6f6a1b6d6f7e7c7e8e'],
-    isNativeGasToken: false,
-    isTokenBridgeWrappedToken: false,
-    nativeChain: 'Ethereum',
-    icon: 'usdc.svg',
-    coinGeckoId: 'usd-coin',
-    equals: vi.fn(),
-    toJson: vi.fn(),
-  } as any;
+  }) as any;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/utils/testHelpers.ts
+++ b/src/utils/testHelpers.ts
@@ -1,0 +1,27 @@
+import type { Token } from 'config/tokens';
+
+/**
+ * Helper to create mock tokens for testing
+ */
+export const createMockToken = (overrides: Partial<Token> = {}): Token => {
+  const chain = overrides.chain || 'Ethereum';
+  const addressString = overrides.addressString || '0x1234567890abcdef';
+  const address = overrides.address || addressString;
+
+  return {
+    chain,
+    addressString,
+    address,
+    symbol: 'TEST',
+    name: 'Test Token',
+    decimals: 18,
+    isNativeGasToken: false,
+    isTokenBridgeWrappedToken: false,
+    isBuiltin: false,
+    tokenId: {
+      chain,
+      address,
+    },
+    ...overrides,
+  } as Token;
+};

--- a/src/utils/tokenListUtils.test.ts
+++ b/src/utils/tokenListUtils.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import {
+  getTokenPreferenceScore,
+  calculateTokenUSDBalance,
+  sortTokensByPreference,
+  applyCustomTokenSupport,
+  applyShittokenFilter,
+  filterTokensByBalance,
+} from './tokenListUtils';
+import type { Token } from 'config/tokens';
+import type { Balances } from './wallet/types';
+import { createMockToken } from './testHelpers';
+
+// Mock dependencies
+vi.mock('@wormhole-foundation/sdk', async () => {
+  const actual = await vi.importActual('@wormhole-foundation/sdk');
+  return {
+    ...actual,
+    circle: {
+      usdcContract: {
+        get: vi.fn((network: string, chain: string) => {
+          // Mock USDC addresses
+          if (chain === 'Ethereum' && network === 'Mainnet') {
+            return '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+          }
+          return undefined;
+        }),
+      },
+    },
+  };
+});
+
+vi.mock('config', () => ({
+  default: {
+    network: 'Mainnet',
+    tokenWhitelist: undefined,
+    isTokenSupportedHandler: undefined,
+    tokens: {
+      get: vi.fn(),
+      queryBySymbol: vi.fn(() => []),
+    },
+  },
+}));
+
+vi.mock('utils', () => ({
+  calculateUSDPriceRaw: vi.fn((getPrice: any, balance: any, token: any) => {
+    const price = typeof getPrice === 'function' ? getPrice(token) : getPrice;
+    if (!price || !balance) return undefined;
+    return 100 * price; // Simplified calculation
+  }),
+  isFrankensteinToken: vi.fn(() => false),
+}));
+
+vi.mock('./ntt', () => ({
+  isNttToken: vi.fn(() => false),
+}));
+
+vi.mock('config/tokens', () => ({
+  isSameToken: vi.fn((a: any, b: any) => {
+    return a.chain === b.chain && a.addressString === b.addressString;
+  }),
+  tokenKey: vi.fn((token: any) => `${token.chain}:${token.addressString}`),
+  isTokenTuple: vi.fn((item: any) => Array.isArray(item)),
+  tokenIdFromTuple: vi.fn((tuple: any) => ({
+    chain: tuple[0],
+    address: { toString: () => tuple[1] },
+  })),
+}));
+
+describe('tokenListUtils', () => {
+  describe('getTokenPreferenceScore', () => {
+    it('should return 5 for selected token', () => {
+      const token = createMockToken({ symbol: 'ETH' });
+      const score = getTokenPreferenceScore(token, token);
+      expect(score).toBe(5);
+    });
+
+    it('should return 4 for destination token matching source symbol', () => {
+      const sourceToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Ethereum',
+      });
+      const destToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Arbitrum',
+      });
+      const score = getTokenPreferenceScore(destToken, undefined, sourceToken);
+      expect(score).toBe(4);
+    });
+
+    it('should return 3 for native gas tokens', () => {
+      const nativeToken = createMockToken({
+        addressString: 'native',
+        isNativeGasToken: true,
+      });
+      const score = getTokenPreferenceScore(nativeToken);
+      expect(score).toBe(3);
+    });
+
+    it('should return 2 for USDC tokens', () => {
+      const usdcToken = createMockToken({
+        chain: 'Ethereum',
+        addressString: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+        symbol: 'USDC',
+      });
+      const score = getTokenPreferenceScore(usdcToken);
+      expect(score).toBe(2);
+    });
+
+    it('should return 1 for native non-wrapped tokens', () => {
+      const nativeToken = createMockToken({
+        isTokenBridgeWrappedToken: false,
+      });
+      const score = getTokenPreferenceScore(nativeToken);
+      expect(score).toBe(1);
+    });
+
+    it('should return 0 for wrapped tokens', () => {
+      const wrappedToken = createMockToken({
+        isTokenBridgeWrappedToken: true,
+      });
+      const score = getTokenPreferenceScore(wrappedToken);
+      expect(score).toBe(0);
+    });
+
+    it('should prioritize selected token over source symbol match', () => {
+      const selectedToken = createMockToken({ symbol: 'ETH' });
+      const sourceToken = createMockToken({ symbol: 'USDC' });
+
+      const scoreSelected = getTokenPreferenceScore(
+        selectedToken,
+        selectedToken,
+        sourceToken,
+      );
+      const scoreSourceMatch = getTokenPreferenceScore(
+        createMockToken({ symbol: 'USDC' }),
+        undefined,
+        sourceToken,
+      );
+
+      expect(scoreSelected).toBeGreaterThan(scoreSourceMatch);
+    });
+  });
+
+  describe('calculateTokenUSDBalance', () => {
+    const mockGetPrice = vi.fn((token: Token) => {
+      if (token.symbol === 'ETH') return 2000;
+      if (token.symbol === 'USDC') return 1;
+      return undefined;
+    });
+
+    beforeEach(() => {
+      mockGetPrice.mockClear();
+    });
+
+    it('should calculate USD balance correctly', () => {
+      const token = createMockToken({ symbol: 'ETH' });
+      const balances: Balances = {
+        'Ethereum:0x1234567890abcdef': {
+          lastUpdated: Date.now(),
+          balance: sdkAmount.fromBaseUnits(1000000000000000000n, 18), // 1 ETH
+        },
+      };
+
+      const usdBalance = calculateTokenUSDBalance(
+        token,
+        balances,
+        mockGetPrice,
+      );
+      expect(usdBalance).toBe(200000);
+      expect(mockGetPrice).toHaveBeenCalledWith(token);
+    });
+
+    it('should return 0 for missing balance', () => {
+      const token = createMockToken();
+      const balances: Balances = {};
+
+      const usdBalance = calculateTokenUSDBalance(
+        token,
+        balances,
+        mockGetPrice,
+      );
+      expect(usdBalance).toBe(0);
+    });
+
+    it('should return 0 for zero balance', () => {
+      const token = createMockToken();
+      const balances: Balances = {
+        'Ethereum:0x1234567890abcdef': {
+          lastUpdated: Date.now(),
+          balance: { amount: '0', decimals: 18 },
+        },
+      };
+
+      const usdBalance = calculateTokenUSDBalance(
+        token,
+        balances,
+        mockGetPrice,
+      );
+      expect(usdBalance).toBe(0);
+    });
+
+    it('should return 0 when price is unavailable', () => {
+      const token = createMockToken({ symbol: 'UNKNOWN' });
+      const balances: Balances = {
+        'Ethereum:0x1234567890abcdef': {
+          lastUpdated: Date.now(),
+          balance: sdkAmount.fromBaseUnits(1000000000000000000n, 18),
+        },
+      };
+
+      const usdBalance = calculateTokenUSDBalance(
+        token,
+        balances,
+        mockGetPrice,
+      );
+      expect(usdBalance).toBe(0);
+    });
+  });
+
+  describe('sortTokensByPreference', () => {
+    it('should sort by preference score first', () => {
+      const nativeToken = createMockToken({
+        symbol: 'ETH',
+        addressString: 'native',
+        isNativeGasToken: true,
+      });
+      const wrappedToken = createMockToken({
+        symbol: 'WETH',
+        isTokenBridgeWrappedToken: true,
+      });
+      const regularToken = createMockToken({
+        symbol: 'DAI',
+        isTokenBridgeWrappedToken: false,
+      });
+
+      const tokens = [wrappedToken, regularToken, nativeToken];
+      const balances: Balances = {};
+      const getPrice = () => undefined;
+
+      const sorted = sortTokensByPreference(
+        tokens,
+        undefined,
+        balances,
+        getPrice,
+      );
+
+      expect(sorted[0]).toBe(nativeToken); // Score 3
+      expect(sorted[1]).toBe(regularToken); // Score 1
+      expect(sorted[2]).toBe(wrappedToken); // Score 0
+    });
+
+    it('should sort by USD balance when scores are equal', () => {
+      const token1 = createMockToken({ symbol: 'AAA', addressString: '0x111' });
+      const token2 = createMockToken({ symbol: 'BBB', addressString: '0x222' });
+
+      const balances: Balances = {
+        'Ethereum:0x111': {
+          lastUpdated: Date.now(),
+          balance: sdkAmount.fromBaseUnits(1000000000000000000n, 18), // 1 token
+        },
+        'Ethereum:0x222': {
+          lastUpdated: Date.now(),
+          balance: sdkAmount.fromBaseUnits(2000000000000000000n, 18), // 2 tokens
+        },
+      };
+
+      const getPrice = (token: Token) => (token.symbol === 'AAA' ? 100 : 200);
+
+      const tokens = [token1, token2];
+      const sorted = sortTokensByPreference(
+        tokens,
+        undefined,
+        balances,
+        getPrice,
+      );
+
+      // token2 has higher USD balance (2 * 200 = 400) vs token1 (1 * 100 = 100)
+      expect(sorted[0].symbol).toBe('BBB');
+      expect(sorted[1].symbol).toBe('AAA');
+    });
+
+    it('should sort alphabetically by symbol when score and balance are equal', () => {
+      const tokenZ = createMockToken({ symbol: 'ZZZ' });
+      const tokenA = createMockToken({ symbol: 'AAA' });
+      const tokenM = createMockToken({ symbol: 'MMM' });
+
+      const tokens = [tokenZ, tokenA, tokenM];
+      const balances: Balances = {};
+      const getPrice = () => undefined;
+
+      const sorted = sortTokensByPreference(
+        tokens,
+        undefined,
+        balances,
+        getPrice,
+      );
+
+      expect(sorted[0].symbol).toBe('AAA');
+      expect(sorted[1].symbol).toBe('MMM');
+      expect(sorted[2].symbol).toBe('ZZZ');
+    });
+
+    it('should prioritize source symbol match in destination list', () => {
+      const sourceToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Ethereum',
+      });
+      const usdcArbitrum = createMockToken({
+        symbol: 'USDC',
+        chain: 'Arbitrum',
+      });
+      const ethArbitrum = createMockToken({
+        symbol: 'ETH',
+        chain: 'Arbitrum',
+        addressString: 'native',
+        isNativeGasToken: true,
+      });
+
+      const tokens = [ethArbitrum, usdcArbitrum];
+      const balances: Balances = {};
+      const getPrice = () => undefined;
+
+      const sorted = sortTokensByPreference(
+        tokens,
+        undefined,
+        balances,
+        getPrice,
+        sourceToken,
+      );
+
+      // USDC (score 4) should come before ETH native (score 3)
+      expect(sorted[0].symbol).toBe('USDC');
+      expect(sorted[1].symbol).toBe('ETH');
+    });
+  });
+
+  describe('applyShittokenFilter', () => {
+    it('should filter out unknown tokens', () => {
+      const unknownToken = createMockToken({
+        isNativeGasToken: false,
+        isBuiltin: false,
+        isTokenBridgeWrappedToken: false,
+      });
+      const tokens = [unknownToken];
+      const filtered = applyShittokenFilter(tokens);
+      expect(filtered).toHaveLength(0);
+    });
+
+    it('should filter mixed token list correctly', () => {
+      const nativeToken = createMockToken({
+        isNativeGasToken: true,
+        symbol: 'ETH',
+      });
+      const unknownToken = createMockToken({ symbol: 'SCAM' });
+      const verifiedToken = createMockToken({
+        symbol: 'USDC',
+        coingeckoWebId: 'usd-coin',
+      });
+
+      const tokens = [unknownToken, nativeToken, verifiedToken];
+      const filtered = applyShittokenFilter(tokens);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.find((t) => t.symbol === 'SCAM')).toBeUndefined();
+      expect(filtered.find((t) => t.symbol === 'ETH')).toBeDefined();
+      expect(filtered.find((t) => t.symbol === 'USDC')).toBeDefined();
+    });
+  });
+
+  describe('filterTokensByBalance', () => {
+    it('should return all tokens when no wallet connected', () => {
+      const tokens = [createMockToken(), createMockToken()];
+      const balances = {};
+      const filtered = filterTokensByBalance(tokens, balances, undefined);
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('should filter to tokens with non-zero balance', () => {
+      const token1 = createMockToken({ addressString: '0x111' });
+      const token2 = createMockToken({ addressString: '0x222' });
+      const token3 = createMockToken({ addressString: '0x333' });
+
+      const balances = {
+        'Ethereum:0x111': {
+          balance: sdkAmount.fromBaseUnits(1000000n, 6), // Non-zero
+        },
+        'Ethereum:0x222': {
+          balance: sdkAmount.fromBaseUnits(0n, 6), // Zero
+        },
+        'Ethereum:0x333': {
+          balance: sdkAmount.fromBaseUnits(5000000n, 6), // Non-zero
+        },
+      };
+
+      const tokens = [token1, token2, token3];
+      const filtered = filterTokensByBalance(tokens, balances, '0x123');
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.find((t) => t.addressString === '0x111')).toBeDefined();
+      expect(filtered.find((t) => t.addressString === '0x222')).toBeUndefined();
+      expect(filtered.find((t) => t.addressString === '0x333')).toBeDefined();
+    });
+  });
+
+  describe('applyCustomTokenSupport', () => {
+    it('should return all tokens when no custom handler set', () => {
+      const tokens = [createMockToken(), createMockToken()];
+      const filtered = applyCustomTokenSupport(tokens);
+      expect(filtered).toHaveLength(2);
+    });
+
+    it('should apply custom filter when handler is set', async () => {
+      const config = await import('config');
+      const token1 = createMockToken({ symbol: 'ALLOWED' });
+      const token2 = createMockToken({ symbol: 'BLOCKED' });
+
+      config.default.isTokenSupportedHandler = (token: Token) =>
+        token.symbol === 'ALLOWED';
+
+      const tokens = [token1, token2];
+      const filtered = applyCustomTokenSupport(tokens);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(token1);
+
+      // Cleanup
+      config.default.isTokenSupportedHandler = undefined;
+    });
+  });
+});

--- a/src/utils/tokenListUtils.test.ts
+++ b/src/utils/tokenListUtils.test.ts
@@ -76,17 +76,76 @@ describe('tokenListUtils', () => {
       expect(score).toBe(5);
     });
 
-    it('should return 4 for destination token matching source symbol', () => {
+    it('should return 4 for destination token matching source symbol (both native)', () => {
       const sourceToken = createMockToken({
         symbol: 'USDC',
         chain: 'Ethereum',
+        isTokenBridgeWrappedToken: false,
       });
       const destToken = createMockToken({
         symbol: 'USDC',
         chain: 'Arbitrum',
+        isTokenBridgeWrappedToken: false,
       });
       const score = getTokenPreferenceScore(destToken, undefined, sourceToken);
       expect(score).toBe(4);
+    });
+
+    it('should NOT prioritize wrapped destination when source is native', () => {
+      const sourceToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Ethereum',
+        isTokenBridgeWrappedToken: false,
+      });
+      const wrappedDestToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Arbitrum',
+        isTokenBridgeWrappedToken: true,
+      });
+      const score = getTokenPreferenceScore(
+        wrappedDestToken,
+        undefined,
+        sourceToken,
+      );
+      expect(score).toBe(0); // Falls through to wrapped token score
+    });
+
+    it('should prioritize native destination when source is wrapped', () => {
+      const wrappedSourceToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Ethereum',
+        isTokenBridgeWrappedToken: true,
+      });
+      const nativeDestToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Arbitrum',
+        isTokenBridgeWrappedToken: false,
+      });
+      const score = getTokenPreferenceScore(
+        nativeDestToken,
+        undefined,
+        wrappedSourceToken,
+      );
+      expect(score).toBe(4);
+    });
+
+    it('should NOT prioritize wrapped destination even when source is wrapped', () => {
+      const wrappedSourceToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Ethereum',
+        isTokenBridgeWrappedToken: true,
+      });
+      const wrappedDestToken = createMockToken({
+        symbol: 'USDC',
+        chain: 'Arbitrum',
+        isTokenBridgeWrappedToken: true,
+      });
+      const score = getTokenPreferenceScore(
+        wrappedDestToken,
+        undefined,
+        wrappedSourceToken,
+      );
+      expect(score).toBe(0); // Wrapped destinations are never prioritized
     });
 
     it('should return 3 for native gas tokens', () => {

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -19,9 +19,14 @@ import type { Balances } from './wallet/types';
 export const getTokenPreferenceScore = (
   token: Token,
   selectedToken?: Token,
+  sourceToken?: Token,
 ): number => {
   // Currently selected token should be shown first
   if (selectedToken && isSameToken(selectedToken, token)) {
+    return 5;
+  }
+  // For destination picker: prioritize tokens with same symbol as source token
+  if (sourceToken && token.symbol === sourceToken.symbol) {
     return 4;
   }
   // Native gas tokens are next
@@ -90,10 +95,11 @@ export const sortTokensByPreference = (
   selectedToken: Token | undefined,
   balances: Balances,
   getTokenPrice: (token: Token) => number | undefined,
+  sourceToken?: Token,
 ): Token[] => {
   return tokens.sort((a, b) => {
-    const scoreA = getTokenPreferenceScore(a, selectedToken);
-    const scoreB = getTokenPreferenceScore(b, selectedToken);
+    const scoreA = getTokenPreferenceScore(a, selectedToken, sourceToken);
+    const scoreB = getTokenPreferenceScore(b, selectedToken, sourceToken);
     if (scoreA > scoreB) return -1;
     if (scoreB > scoreA) return 1;
 

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -26,7 +26,12 @@ export const getTokenPreferenceScore = (
     return 5;
   }
   // For destination picker: prioritize tokens with same symbol as source token
-  if (sourceToken && token.symbol === sourceToken.symbol) {
+  // Only prioritize native (non-wrapped) destination tokens
+  if (
+    sourceToken &&
+    token.symbol === sourceToken.symbol &&
+    !token.isTokenBridgeWrappedToken
+  ) {
     return 4;
   }
   // Native gas tokens are next

--- a/src/views/v3/Bridge/AssetPicker/FeeOffset.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/FeeOffset.test.tsx
@@ -9,6 +9,7 @@ import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 import FeeOffset from './FeeOffset';
 import { dark } from 'theme';
 import config from 'config';
+import { createMockToken } from 'utils/testHelpers';
 
 const theme = createTheme({
   palette: dark as any,
@@ -38,18 +39,13 @@ vi.mock('config', () => ({
   },
 }));
 
-const mockToken = {
-  key: 'USDC',
+const mockToken = createMockToken({
   symbol: 'USDC',
   name: 'USD Coin',
   decimals: 6,
-  chain: 'Ethereum' as const,
-  address: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
-  tokenId: {
-    chain: 'Ethereum' as const,
-    address: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
-  },
-} as any;
+  chain: 'Ethereum',
+  addressString: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
+});
 
 const createMockStore = (amount?: any, route?: string) =>
   configureStore({

--- a/src/views/v3/Bridge/AssetPicker/TokenItem.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/TokenItem.test.tsx
@@ -5,9 +5,10 @@ import { ThemeProvider, createTheme } from '@mui/material';
 
 import TokenItem from './TokenItem';
 import { dark } from 'theme';
+import { createMockToken } from 'utils/testHelpers';
 
 const theme = createTheme({
-  palette: dark as any,
+  palette: dark,
 });
 
 vi.mock('utils', () => ({
@@ -22,36 +23,18 @@ vi.mock('components/TokenBalance', () => ({
   ),
 }));
 
-const mockToken = {
-  key: 'USDC',
+const mockToken = createMockToken({
   symbol: 'USDC',
   name: 'USD Coin',
   decimals: 6,
-  icon: 'usdc.svg',
   addressString: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
-  chain: 'Ethereum' as const,
-  address: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
-  tokenId: {
-    chain: 'Ethereum' as const,
-    address: '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e',
-  },
-  display: 'USD Coin',
-  shortAddress: '0xa0b...a6c6e',
-  tuple: ['Ethereum', '0xa0b86a33e6180d4c6d1cbe6c9e1f4a3d4b8a6c6e'] as [
-    'Ethereum',
-    string,
-  ],
-  isNativeGasToken: false,
-  isTokenBridgeWrappedToken: false,
-  nativeChain: 'Ethereum' as const,
-  equals: vi.fn(),
-  toJson: vi.fn(),
-} as any;
+  chain: 'Ethereum',
+});
 
 const mockBalance = {
   amount: '1000000000', // 1000 USDC
   decimals: 6,
-} as any;
+};
 
 const defaultProps = {
   token: mockToken,


### PR DESCRIPTION
Selected token's destination chain counterpart is not showing up at the top (e.g. Neiro on Ethereum selected as source, but Neiro not showing up at top when HL as destination is selected). This issue is related to the way we sort tokens by preference. This preference hasn't changed in the last 6 months maybe, but after we had more Mayan routes coming in and have a larger set of supported tokens as destination, the counterpart is pushed down the list. For instance if you have only DEFAULT_ROUTES (no Mayan) in Connect config and select Neiro as source, it'll show only Neiro as destination token. Here is the preferences order:
1. Currently selected token should be shown first
2. Native gas tokens are next
3. USDC preferred next
4. Finally, prefer native non-wrapped tokens over wrapped ones
5. The remaining ones with balance and the rest is same as far as preference (the order received from SDK)

In this PR we add a secondary check after selected token:
1. Currently selected token should be shown first
  a) For destination asset picker only => Destination equivalent of selected source token should be shown second.
2. Native gas tokens are next
...

Please see for details:
https://www.loom.com/share/743fff8b811041859ceabb35b2fe39fd

Fixes BRI-50