### PR TITLE
fix: Number formatting for intl locales

### DIFF
--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  formatWithCommas,
-  removeCommas,
-  isValidDecimalInput,
+  formatNumberIntl,
+  removeFormatting,
+  isValidDecimalNumber,
   formatMinAmount,
 } from './formatNumber';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
@@ -39,146 +39,144 @@ describe('formatNumber utilities', () => {
   });
 
   describe.each(localeConfigs)(
-    'formatWithCommas - $locale',
+    'formatNumberIntl - $locale',
     ({ locale, group, decimal }) => {
       beforeEach(() => {
         mockNavigatorLanguage(locale);
       });
 
       it('should format integers with grouping', () => {
-        expect(formatWithCommas('1234')).toBe(`1${group}234`);
-        expect(formatWithCommas('1234567')).toBe(`1${group}234${group}567`);
-        expect(formatWithCommas('1234567890')).toBe(
+        expect(formatNumberIntl('1234')).toBe(`1${group}234`);
+        expect(formatNumberIntl('1234567')).toBe(`1${group}234${group}567`);
+        expect(formatNumberIntl('1234567890')).toBe(
           `1${group}234${group}567${group}890`,
         );
       });
 
       it('should format decimals with grouping', () => {
-        expect(formatWithCommas('1234.56')).toBe(`1${group}234${decimal}56`);
-        expect(formatWithCommas('1234567.89')).toBe(
+        expect(formatNumberIntl('1234.56')).toBe(`1${group}234${decimal}56`);
+        expect(formatNumberIntl('1234567.89')).toBe(
           `1${group}234${group}567${decimal}89`,
         );
-        expect(formatWithCommas('1234.123456')).toBe(
+        expect(formatNumberIntl('1234.123456')).toBe(
           `1${group}234${decimal}123456`,
         );
       });
 
       it('should preserve trailing decimal point', () => {
-        expect(formatWithCommas('1234.')).toBe(`1${group}234${decimal}`);
-        expect(formatWithCommas('123.')).toBe(`123${decimal}`);
+        expect(formatNumberIntl('1234.')).toBe(`1${group}234${decimal}`);
+        expect(formatNumberIntl('123.')).toBe(`123${decimal}`);
       });
 
       it('should handle small numbers without grouping', () => {
-        expect(formatWithCommas('123')).toBe('123');
-        expect(formatWithCommas('12.34')).toBe(`12${decimal}34`);
-        expect(formatWithCommas('0.123')).toBe(`0${decimal}123`);
+        expect(formatNumberIntl('123')).toBe('123');
+        expect(formatNumberIntl('12.34')).toBe(`12${decimal}34`);
+        expect(formatNumberIntl('0.123')).toBe(`0${decimal}123`);
       });
 
       it('should handle zero', () => {
-        expect(formatWithCommas('0')).toBe('0');
-        expect(formatWithCommas('0.0')).toBe(`0${decimal}0`);
-        expect(formatWithCommas('0.00')).toBe(`0${decimal}00`);
+        expect(formatNumberIntl('0')).toBe('0');
+        expect(formatNumberIntl('0.0')).toBe(`0${decimal}0`);
+        expect(formatNumberIntl('0.00')).toBe(`0${decimal}00`);
       });
 
       it('should handle empty string', () => {
-        expect(formatWithCommas('')).toBe('');
+        expect(formatNumberIntl('')).toBe('');
       });
     },
   );
 
   describe.each(localeConfigs)(
-    'removeCommas - $locale',
+    'removeFormatting - $locale',
     ({ locale, group, decimal }) => {
       beforeEach(() => {
         mockNavigatorLanguage(locale);
       });
 
       it('should remove grouping separators', () => {
-        expect(removeCommas(`1${group}234`)).toBe('1234');
-        expect(removeCommas(`1${group}234${group}567`)).toBe('1234567');
-        expect(removeCommas(`1${group}234${group}567${group}890`)).toBe(
+        expect(removeFormatting(`1${group}234`)).toBe('1234');
+        expect(removeFormatting(`1${group}234${group}567`)).toBe('1234567');
+        expect(removeFormatting(`1${group}234${group}567${group}890`)).toBe(
           '1234567890',
         );
       });
 
       it('should preserve/convert decimal separator to dot', () => {
-        expect(removeCommas(`1${group}234${decimal}56`)).toBe('1234.56');
-        expect(removeCommas(`1${group}234${group}567${decimal}89`)).toBe(
+        expect(removeFormatting(`1${group}234${decimal}56`)).toBe('1234.56');
+        expect(removeFormatting(`1${group}234${group}567${decimal}89`)).toBe(
           '1234567.89',
         );
       });
 
       it('should handle strings without grouping', () => {
-        expect(removeCommas('123')).toBe('123');
-        expect(removeCommas(`123${decimal}45`)).toBe('123.45');
+        expect(removeFormatting('123')).toBe('123');
+        expect(removeFormatting(`123${decimal}45`)).toBe('123.45');
       });
 
       it('should handle empty string', () => {
-        expect(removeCommas('')).toBe('');
+        expect(removeFormatting('')).toBe('');
       });
     },
   );
 
   describe.each(localeConfigs)(
-    'isValidDecimalInput - $locale',
+    'isValidDecimalNumber - $locale',
     ({ locale, decimal }) => {
       beforeEach(() => {
         mockNavigatorLanguage(locale);
       });
 
       it('should accept valid decimal numbers', () => {
-        expect(isValidDecimalInput('123')).toBe(true);
-        expect(isValidDecimalInput(`123${decimal}456`)).toBe(true);
-        expect(isValidDecimalInput(`0${decimal}123`)).toBe(true);
-        expect(isValidDecimalInput('0')).toBe(true);
+        expect(isValidDecimalNumber('123')).toBe(true);
+        expect(isValidDecimalNumber(`123${decimal}456`)).toBe(true);
+        expect(isValidDecimalNumber(`0${decimal}123`)).toBe(true);
+        expect(isValidDecimalNumber('0')).toBe(true);
       });
 
       it('should accept empty string', () => {
-        expect(isValidDecimalInput('')).toBe(true);
+        expect(isValidDecimalNumber('')).toBe(true);
       });
 
       it('should accept just decimal separator', () => {
-        expect(isValidDecimalInput(decimal)).toBe(true);
+        // The function accepts the locale decimal and normalizes it
+        expect(isValidDecimalNumber(decimal)).toBe(true);
+        // Also accepts standard '.' regardless of locale
+        expect(isValidDecimalNumber('.')).toBe(true);
       });
 
       it('should accept trailing decimal separator', () => {
-        expect(isValidDecimalInput(`123${decimal}`)).toBe(true);
+        expect(isValidDecimalNumber(`123${decimal}`)).toBe(true);
       });
 
       it('should accept leading decimal separator', () => {
-        expect(isValidDecimalInput(`${decimal}123`)).toBe(true);
+        expect(isValidDecimalNumber(`${decimal}123`)).toBe(true);
       });
 
       it('should reject negative numbers', () => {
-        expect(isValidDecimalInput('-123')).toBe(false);
-        expect(isValidDecimalInput(`-0${decimal}5`)).toBe(false);
+        expect(isValidDecimalNumber('-123')).toBe(false);
+        expect(isValidDecimalNumber(`-0${decimal}5`)).toBe(false);
       });
 
       it('should reject multiple decimal separators', () => {
-        expect(isValidDecimalInput(`12${decimal}34${decimal}56`)).toBe(false);
-        expect(isValidDecimalInput(`1${decimal}${decimal}2`)).toBe(false);
+        expect(isValidDecimalNumber(`12${decimal}34${decimal}56`)).toBe(false);
+        expect(isValidDecimalNumber(`1${decimal}${decimal}2`)).toBe(false);
       });
 
       it('should reject non-numeric characters', () => {
-        expect(isValidDecimalInput('12a34')).toBe(false);
-        expect(isValidDecimalInput('abc')).toBe(false);
-      });
-
-      it('should reject wrong decimal separator for locale', () => {
-        const wrongDecimal = decimal === '.' ? ',' : '.';
-        expect(isValidDecimalInput(`12${wrongDecimal}34`)).toBe(false);
+        expect(isValidDecimalNumber('12a34')).toBe(false);
+        expect(isValidDecimalNumber('abc')).toBe(false);
       });
 
       it('should reject non-string input', () => {
-        expect(isValidDecimalInput(123 as any)).toBe(false);
-        expect(isValidDecimalInput(null as any)).toBe(false);
-        expect(isValidDecimalInput(undefined as any)).toBe(false);
+        expect(isValidDecimalNumber(123 as any)).toBe(false);
+        expect(isValidDecimalNumber(null as any)).toBe(false);
+        expect(isValidDecimalNumber(undefined as any)).toBe(false);
       });
     },
   );
 
   describe.each(localeConfigs)(
-    'formatWithCommas and removeCommas round-trip - $locale',
+    'formatNumberIntl and removeFormatting round-trip - $locale',
     ({ locale }) => {
       beforeEach(() => {
         mockNavigatorLanguage(locale);
@@ -187,8 +185,8 @@ describe('formatNumber utilities', () => {
       it('should round-trip correctly with various inputs', () => {
         const testCases = ['123', '1234', '123456.789', '0.123', '1234567.89'];
         testCases.forEach((value) => {
-          const formatted = formatWithCommas(value);
-          const restored = removeCommas(formatted);
+          const formatted = formatNumberIntl(value);
+          const restored = removeFormatting(formatted);
           expect(restored).toBe(value);
         });
       });

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   formatNumberIntl,
   removeFormatting,
-  isValidDecimalNumber,
+  isValidFormattedNumber,
   formatMinAmount,
 } from './formatNumber';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
@@ -10,7 +10,7 @@ import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 // Locale configuration for separators
 const localeConfigs = [
   { locale: 'en-US', group: ',', decimal: '.' },
-  { locale: 'ja-JP', group: ',', decimal: '.' },
+  { locale: 'pt-PT', group: '\u00A0', decimal: ',' }, // Non-breaking space (charCode 160)
   { locale: 'tr-TR', group: '.', decimal: ',' },
 ];
 
@@ -120,57 +120,64 @@ describe('formatNumber utilities', () => {
   );
 
   describe.each(localeConfigs)(
-    'isValidDecimalNumber - $locale',
-    ({ locale, decimal }) => {
+    'isValidFormattedNumber - $locale',
+    ({ locale, group, decimal }) => {
       beforeEach(() => {
         mockNavigatorLanguage(locale);
       });
 
       it('should accept valid decimal numbers', () => {
-        expect(isValidDecimalNumber('123')).toBe(true);
-        expect(isValidDecimalNumber(`123${decimal}456`)).toBe(true);
-        expect(isValidDecimalNumber(`0${decimal}123`)).toBe(true);
-        expect(isValidDecimalNumber('0')).toBe(true);
+        expect(isValidFormattedNumber('123')).toBe(true);
+        expect(isValidFormattedNumber(`123${decimal}456`)).toBe(true);
+        expect(isValidFormattedNumber(`0${decimal}123`)).toBe(true);
+        expect(isValidFormattedNumber('0')).toBe(true);
+      });
+
+      it('should accept numbers with both grouping and decimals', () => {
+        expect(isValidFormattedNumber(`10${group}000${decimal}99`)).toBe(true);
+        expect(isValidFormattedNumber(`1${group}234${decimal}56`)).toBe(true);
+        expect(
+          isValidFormattedNumber(`1${group}234${group}567${decimal}89`),
+        ).toBe(true);
       });
 
       it('should accept empty string', () => {
-        expect(isValidDecimalNumber('')).toBe(true);
+        expect(isValidFormattedNumber('')).toBe(true);
       });
 
       it('should accept just decimal separator', () => {
-        // The function accepts the locale decimal and normalizes it
-        expect(isValidDecimalNumber(decimal)).toBe(true);
-        // Also accepts standard '.' regardless of locale
-        expect(isValidDecimalNumber('.')).toBe(true);
+        expect(isValidFormattedNumber(decimal)).toBe(true);
       });
 
       it('should accept trailing decimal separator', () => {
-        expect(isValidDecimalNumber(`123${decimal}`)).toBe(true);
+        expect(isValidFormattedNumber(`123${decimal}`)).toBe(true);
       });
 
       it('should accept leading decimal separator', () => {
-        expect(isValidDecimalNumber(`${decimal}123`)).toBe(true);
+        expect(isValidFormattedNumber(`${decimal}123`)).toBe(true);
       });
 
       it('should reject negative numbers', () => {
-        expect(isValidDecimalNumber('-123')).toBe(false);
-        expect(isValidDecimalNumber(`-0${decimal}5`)).toBe(false);
+        expect(isValidFormattedNumber('-123')).toBe(false);
+        expect(isValidFormattedNumber(`-0${decimal}5`)).toBe(false);
       });
 
       it('should reject multiple decimal separators', () => {
-        expect(isValidDecimalNumber(`12${decimal}34${decimal}56`)).toBe(false);
-        expect(isValidDecimalNumber(`1${decimal}${decimal}2`)).toBe(false);
+        expect(isValidFormattedNumber(`12${decimal}34${decimal}56`)).toBe(
+          false,
+        );
+        expect(isValidFormattedNumber(`1${decimal}${decimal}2`)).toBe(false);
       });
 
       it('should reject non-numeric characters', () => {
-        expect(isValidDecimalNumber('12a34')).toBe(false);
-        expect(isValidDecimalNumber('abc')).toBe(false);
+        expect(isValidFormattedNumber('12a34')).toBe(false);
+        expect(isValidFormattedNumber('abc')).toBe(false);
       });
 
       it('should reject non-string input', () => {
-        expect(isValidDecimalNumber(123 as any)).toBe(false);
-        expect(isValidDecimalNumber(null as any)).toBe(false);
-        expect(isValidDecimalNumber(undefined as any)).toBe(false);
+        expect(isValidFormattedNumber(123 as any)).toBe(false);
+        expect(isValidFormattedNumber(null as any)).toBe(false);
+        expect(isValidFormattedNumber(undefined as any)).toBe(false);
       });
     },
   );

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -33,25 +33,29 @@ const getUserLocale = (): string =>
  * Format a numeric string with locale‑aware grouping, preserving any
  * fractional part (including a trailing dot).
  */
-export const formatWithCommas = (value: string): string => {
+export const formatNumberIntl = (value: string): string => {
   if (!value) {
     return '';
   }
 
-  const locale = getUserLocale();
-  const { decimal } = getSeparators(locale);
-
   const [integerPart, decimalPart] = value.split('.');
   const intNum = parseInt(integerPart, 10) || 0;
 
+  const locale = getUserLocale();
+  const { decimal } = getSeparators(locale);
+
+  // Format the integer part
+  // Intl.NumberFormat could be used to format the whole number,
+  // but we need to preserve trailing decimal points as user types.
+  // That's why we split and format only the integer part here.
   const formattedInt = new Intl.NumberFormat(locale, {
     useGrouping: true,
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(intNum);
 
-  // Append the locale decimal separator + any digits (or preserve trailing ".")
-  if (decimalPart !== undefined || value.endsWith('.')) {
+  // Append the locale decimal separator + any digits (or preserve trailing decimal separator)
+  if (decimalPart !== undefined || value.endsWith(decimal)) {
     return formattedInt + decimal + (decimalPart ?? '');
   }
 
@@ -59,10 +63,10 @@ export const formatWithCommas = (value: string): string => {
 };
 
 /**
- * Strip locale‑specific grouping separators and convert the decimal
- * separator to "." so Number() will parse correctly.
+ * Strip locale‑specific grouping separators and replace the decimal separator with "."
+ * Important: This is required for Number() to parse correctly
  */
-export const removeCommas = (value: string): string => {
+export const removeFormatting = (value: string): string => {
   if (!value) {
     return '';
   }
@@ -70,7 +74,9 @@ export const removeCommas = (value: string): string => {
   const locale = getUserLocale();
   const { group, decimal } = getSeparators(locale);
 
+  // Remove grouping separators
   const withoutGroups = value.split(group).join('');
+  // Replace locale decimal separator with standard "."
   return withoutGroups.replace(new RegExp(`\\${decimal}`, 'g'), '.');
 };
 
@@ -85,19 +91,20 @@ export const removeCommas = (value: string): string => {
  *  - non‑digit characters
  *  - leading/trailing non‑digit characters
  */
-export const isValidDecimalInput = (value: string): boolean => {
+export const isValidDecimalNumber = (value: string): boolean => {
   if (typeof value !== 'string') {
     return false;
   }
 
-  const locale = getUserLocale();
-  const { decimal } = getSeparators(locale);
+  // Remove any locale formatting for validation
+  // This includes removing grouping and replacing locale decimal separators
+  const nonIntlValue = removeFormatting(value);
 
-  if (value === '' || value === decimal) {
+  if (nonIntlValue === '' || nonIntlValue === '.') {
     return true;
   }
 
-  const parts = value.split(decimal);
+  const parts = nonIntlValue.split('.');
 
   // Reject more than one decimal separator
   if (parts.length > 2) {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -84,14 +84,14 @@ export const removeFormatting = (value: string): string => {
  * Validate raw input as a non‑negative decimal
  * Allows:
  *  - the empty string
- *  - just the locale’s decimal separator (for "0," or "0." beginnings)
+ *  - just the locale's decimal separator (for "0," or "0." beginnings)
  *  - any number of digits before/after a single separator
  * * Rejects:
  *  - multiple separators
  *  - non‑digit characters
  *  - leading/trailing non‑digit characters
  */
-export const isValidDecimalNumber = (value: string): boolean => {
+export const isValidFormattedNumber = (value: string): boolean => {
   if (typeof value !== 'string') {
     return false;
   }

--- a/src/views/v3/Bridge/AmountInput.tsx
+++ b/src/views/v3/Bridge/AmountInput.tsx
@@ -21,7 +21,7 @@ import type { RootState } from 'store';
 import { useGetTokens } from 'hooks/useGetTokens';
 import {
   formatNumberIntl,
-  isValidDecimalNumber,
+  isValidFormattedNumber,
   removeFormatting,
 } from 'utils/formatNumber';
 
@@ -48,7 +48,7 @@ const DebouncedTextField = memo(
     const onInnerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         // Run validation on the raw input value as it already strips formatting internally
-        if (!isValidDecimalNumber(e.target.value)) {
+        if (!isValidFormattedNumber(e.target.value)) {
           return;
         }
 

--- a/src/views/v3/Bridge/AmountInput.tsx
+++ b/src/views/v3/Bridge/AmountInput.tsx
@@ -20,9 +20,9 @@ import type { Token } from 'config/tokens';
 import type { RootState } from 'store';
 import { useGetTokens } from 'hooks/useGetTokens';
 import {
-  formatWithCommas,
-  removeCommas,
-  isValidDecimalInput,
+  formatNumberIntl,
+  isValidDecimalNumber,
+  removeFormatting,
 } from 'utils/formatNumber';
 
 const INPUT_DEBOUNCE = 500;
@@ -47,16 +47,18 @@ const DebouncedTextField = memo(
 
     const onInnerChange: ChangeEventHandler<HTMLInputElement> = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
-        if (!isValidDecimalInput(e.target.value)) {
+        // Run validation on the raw input value as it already strips formatting internally
+        if (!isValidDecimalNumber(e.target.value)) {
           return;
         }
 
-        const value = removeCommas(e.target.value);
-        const formattedValue = formatWithCommas(value);
-
-        setInnerValue(formattedValue);
+        // Remove any locale formatting before persisting the value
+        const value = removeFormatting(e.target.value);
         onChange(value);
         deferredOnChange(value);
+
+        // Make sure the displayed value is always formatted
+        setInnerValue(formatNumberIntl(value));
       },
       [deferredOnChange, onChange],
     );
@@ -65,7 +67,7 @@ const DebouncedTextField = memo(
     // The way we do this is by checking when the focus is not on the input component
     useEffect(() => {
       if (!isFocused) {
-        setInnerValue(formatWithCommas(value));
+        setInnerValue(formatNumberIntl(value));
       }
       // We should run this side-effect only when the value changes
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -28,7 +28,7 @@ import { OPACITY } from 'utils/style';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
 import { calculateUSDPrice, getTokenDisplaySymbolByTokenAddress } from 'utils';
-import { formatWithCommas } from 'utils/formatNumber';
+import { formatNumberIntl } from 'utils/formatNumber';
 import {
   handleTelemetryOnChainSelect,
   handleTelemetryOnTokenSelect,
@@ -635,7 +635,7 @@ function AssetPicker(props: Props) {
                   },
                 }}
                 variant="standard"
-                value={formatWithCommas(receiveAmountText)}
+                value={formatNumberIntl(receiveAmountText)}
               />
             </Box>
           )}


### PR DESCRIPTION
Number intl formatting between user display and stored values is a bit complicated. I've first renamed the util functions to better match their functionalities:
```
formatWithCommas() → formatNumberIntl()
removeCommas() → removeFormatting()
isValidDecimalInput() → isValidDecimalNumber()
```
- `formatNumberIntl` now formats a non-locale number string to locale number string.
- `isValidDecimalNumber` now makes sure to remove any formatting before validating. It can also work with both locale and non-locale numbers strings.
- We also make sure to use the validated value and re-format it before displaying.