### PR TITLE
feat: show amount in additional gas

### DIFF
--- a/src/views/v3/Redeem/TransactionDetails/index.tsx
+++ b/src/views/v3/Redeem/TransactionDetails/index.tsx
@@ -229,11 +229,23 @@ const TransactionDetails = () => {
       return <></>;
     }
 
+    const gasToken = config.tokens.getGasToken(destChainConfig.sdkName);
+
+    if (!gasToken) {
+      return <></>;
+    }
+
     const gasTokenPrice = calculateUSDPrice(
       getTokenPrice,
       receiveNativeAmount,
-      config.tokens.getGasToken(destChainConfig.sdkName),
+      gasToken,
     );
+
+    const gasTokenAmount = sdkAmount.display(
+      sdkAmount.truncate(receiveNativeAmount, 6),
+    );
+
+    const gasTokenPriceStr = gasTokenPrice ? ` (${gasTokenPrice})` : '';
 
     return (
       <Stack direction="row" justifyContent="space-between">
@@ -243,7 +255,9 @@ const TransactionDetails = () => {
         {isFetchingTokenPrices ? (
           <CircularProgress size={14} />
         ) : (
-          <Typography fontSize={14}>{gasTokenPrice}</Typography>
+          <Typography
+            fontSize={14}
+          >{`${gasTokenAmount} ${gasToken.symbol}${gasTokenPriceStr}`}</Typography>
         )}
       </Stack>
     );


### PR DESCRIPTION
Previously, when there was no price for the gas token (e.g. Fogo not on Coingecko yet), the Additional gas column would just be blank. Now we at least show the amount of gas token received when there's no price (and also the price if it's available). 
price: <img width="475" height="435" alt="Screenshot 2025-11-06 at 1 26 17 PM" src="https://github.com/user-attachments/assets/7aa45eac-5c1c-4d06-bc89-8a1210fc2ec8" />
no price: <img width="511" height="439" alt="Screenshot 2025-11-06 at 1 20 01 PM" src="https://github.com/user-attachments/assets/b2fb240c-63be-4fa7-bf69-3cc766aa25ac" />
