### PR TITLE
feat: include network in connect event meta

### DIFF
--- a/src/config/events.ts
+++ b/src/config/events.ts
@@ -5,8 +5,10 @@ import type {
   WormholeConnectEvent,
   TriggerEventHandler,
 } from 'telemetry/types';
+import type { Network } from '@wormhole-foundation/sdk';
 
 export function wrapEventHandler(
+  network: Network,
   integrationHandler?: WormholeConnectEventHandler,
 ): TriggerEventHandler {
   const host =
@@ -18,6 +20,7 @@ export function wrapEventHandler(
         version: CONNECT_VERSION,
         hash: CONNECT_GIT_HASH,
         host,
+        network,
       },
       ...event,
     };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -127,7 +127,7 @@ export function buildConfig(
     coingecko: customConfig.coingecko,
 
     // Callbacks
-    triggerEvent: wrapEventHandler(customConfig.eventHandler),
+    triggerEvent: wrapEventHandler(network, customConfig.eventHandler),
     validateTransfer: customConfig.validateTransferHandler,
     isChainSupportedHandler: customConfig.isChainSupportedHandler,
     isRouteSupportedHandler: customConfig.isRouteSupportedHandler,

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,4 +1,8 @@
-import type { Chain, amount as sdkAmount } from '@wormhole-foundation/sdk';
+import type {
+  Chain,
+  Network,
+  amount as sdkAmount,
+} from '@wormhole-foundation/sdk';
 import type { WormholeConnectConfig } from 'config/types';
 import type { Token } from 'config/tokens';
 import type { TransferWallet } from 'utils/wallet';
@@ -146,6 +150,7 @@ export interface WormholeConnectEventMeta {
     version: string;
     hash: string;
     host?: string;
+    network: Network;
   };
 }
 


### PR DESCRIPTION
Rationale: monadbridge.com will support both mainnet and testnet (there's a toggle to switch networks). I think we should include the active network (i.e. "Mainnet" | "Testnet") in Connect events so we can filter by network in Mixpanel