### PR TITLE
fix: handle coingecko 404 responses gracefully

### DIFF
--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -82,7 +82,15 @@ const coingeckoRequest = async (
     signal: params?.abort?.signal,
     headers,
   })
-    .then((resp) => resp.json())
+    .then((resp) => {
+      if (!resp.ok) {
+        console.error(
+          `Coingecko request failed with status ${resp.status}: ${path}`,
+        );
+        return null;
+      }
+      return resp.json();
+    })
     .catch((err) => {
       console.error('Error fetching from Coingecko', err);
       return null;
@@ -136,7 +144,13 @@ export const fetchTokenPrices = async (
         params,
       )
         .then((data) => {
-          if (data['error'] !== undefined || data['error_code'] !== undefined) {
+          if (data === null) {
+            // Request failed (e.g., 404, network error)
+            resolve([]);
+          } else if (
+            data['error'] !== undefined ||
+            data['error_code'] !== undefined
+          ) {
             reject(data['error']);
           } else {
             resolve(
@@ -186,24 +200,29 @@ export const fetchTokenPrices = async (
           `/api/v3/simple/price?ids=${ids.join(',')}&vs_currencies=usd`,
           params,
         )
-          .then((data) =>
-            resolve(
-              nativeTokens
-                .map((tokenId) => {
-                  const cgid = NATIVE_TOKEN_IDS[tokenId.chain];
-                  if (cgid) {
-                    const { usd } = data[cgid];
-                    return {
-                      tokenId,
-                      price: usd,
-                    };
-                  } else {
-                    return null;
-                  }
-                })
-                .filter((v) => !!v),
-            ),
-          )
+          .then((data) => {
+            if (data === null) {
+              // Request failed (e.g., 404, network error)
+              resolve([]);
+            } else {
+              resolve(
+                nativeTokens
+                  .map((tokenId) => {
+                    const cgid = NATIVE_TOKEN_IDS[tokenId.chain];
+                    if (cgid) {
+                      const { usd } = data[cgid];
+                      return {
+                        tokenId,
+                        price: usd,
+                      };
+                    } else {
+                      return null;
+                    }
+                  })
+                  .filter((v) => !!v),
+              );
+            }
+          })
           .catch(reject);
       }),
     );


### PR DESCRIPTION
fixes seeing errors in the console related to coins not being found on coingecko, e.g.:
```
hook.js:608 Coingecko error Error: string message has invalid length for format hex
    at 6900-4003b15ccf3279d5.js:7:431211
    at h.stringToUint8Array (6900-4003b15ccf3279d5.js:7:431502)
    at new h (6900-4003b15ccf3279d5.js:7:430597)
    at c (6900-4003b15ccf3279d5.js:467:47180)
    at b.parseAddress (6900-4003b15ccf3279d5.js:1479:25102)
    at b.chainAddress (6900-4003b15ccf3279d5.js:1479:25203)
    at b.tokenId (6900-4003b15ccf3279d5.js:1479:25277)
    at 6900-4003b15ccf3279d5.js:483:442697
    at Array.map (<anonymous>)
    at 6900-4003b15ccf3279d5.js:483:442675
    ```