### PR TITLE
feat: Monad mainnet support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@wormhole-foundation/sdk-sui-cctp": "3.11.0",
         "@wormhole-foundation/sdk-sui-core": "3.11.0",
         "@wormhole-foundation/sdk-sui-ntt": "4.0.4",
-        "@wormhole-labs/cctp-executor-route": "0.19.0",
+        "@wormhole-labs/cctp-executor-route": "0.20.0",
         "@wormhole-labs/wallet-aggregator-aptos": "1.3.1",
         "@wormhole-labs/wallet-aggregator-core": "1.3.1",
         "@wormhole-labs/wallet-aggregator-evm": "1.3.1",
@@ -18816,9 +18816,9 @@
       }
     },
     "node_modules/@wormhole-labs/cctp-executor-route": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.19.0.tgz",
-      "integrity": "sha512-VBfOUVBlSVxlIfJgV7OCldXRVXEn8pohcRpBx6oVQ93qQNBrQy+RdaEwrSjde7mceQ9WHmLroY94dJmBQoiY+g==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@wormhole-labs/cctp-executor-route/-/cctp-executor-route-0.20.0.tgz",
+      "integrity": "sha512-bM/cmKWb2B4FjAj1V25GHe6uNVn8ZnArwYFVsC8A9VZHgM6F3jFGYhPymrTz6PCfmVLaXPlyyz1oJZtA1ryNNg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aptos-labs/ts-sdk": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@wormhole-foundation/sdk-sui-cctp": "3.11.0",
     "@wormhole-foundation/sdk-sui-core": "3.11.0",
     "@wormhole-foundation/sdk-sui-ntt": "4.0.4",
-    "@wormhole-labs/cctp-executor-route": "0.19.0",
+    "@wormhole-labs/cctp-executor-route": "0.20.0",
     "@wormhole-labs/wallet-aggregator-aptos": "1.3.1",
     "@wormhole-labs/wallet-aggregator-core": "1.3.1",
     "@wormhole-labs/wallet-aggregator-evm": "1.3.1",

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -28,6 +28,7 @@ export const CHAIN_ORDER: Chain[] = [
   'Berachain',
   'Mezo',
   'Fogo',
+  'Monad',
   'HyperCore',
   'Fantom',
 ];

--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -249,4 +249,12 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Fogo',
     symbol: 'FOGO',
   },
+  Monad: {
+    displayName: 'Monad',
+    sdkName: 'Monad',
+    explorerUrl: 'https://monadexplorer.com/',
+    explorerName: 'Monad Explorer',
+    icon: 'Monad',
+    symbol: 'MON',
+  },
 };

--- a/src/config/mainnet/rpcs.ts
+++ b/src/config/mainnet/rpcs.ts
@@ -31,6 +31,7 @@ const {
   REACT_APP_HYPERCORE_RPC,
   REACT_APP_CREDITCOIN_RPC,
   REACT_APP_FOGO_RPC,
+  REACT_APP_MONAD_RPC,
 } = import.meta.env;
 
 export const MAINNET_RPC_MAPPING = {
@@ -65,4 +66,5 @@ export const MAINNET_RPC_MAPPING = {
   ...populateRpcField('HyperCore', REACT_APP_HYPERCORE_RPC),
   ...populateRpcField('CreditCoin', REACT_APP_CREDITCOIN_RPC),
   ...populateRpcField('Fogo', REACT_APP_FOGO_RPC),
+  ...populateRpcField('Monad', REACT_APP_MONAD_RPC),
 };

--- a/src/config/mainnet/tokens.ts
+++ b/src/config/mainnet/tokens.ts
@@ -18,6 +18,15 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     },
   },
   {
+    symbol: 'WMON',
+    decimals: 18,
+    icon: TokenIcon.MONAD,
+    tokenId: {
+      chain: 'Ethereum',
+      address: '0x6917037f8944201b2648198a89906edf863b9517',
+    },
+  },
+  {
     symbol: 'USDC',
     decimals: 6,
     icon: TokenIcon.USDC,
@@ -801,6 +810,39 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     tokenId: {
       chain: 'Fogo',
       address: 'So11111111111111111111111111111111111111112',
+    },
+  },
+  {
+    symbol: 'MON',
+    icon: TokenIcon.MONAD,
+    decimals: 18,
+    tokenId: { chain: 'Monad', address: 'native' },
+  },
+  {
+    symbol: 'WMON',
+    icon: TokenIcon.MONAD,
+    decimals: 18,
+    tokenId: {
+      chain: 'Monad',
+      address: '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A',
+    },
+  },
+  {
+    symbol: 'WETH',
+    icon: TokenIcon.ETH,
+    decimals: 18,
+    tokenId: {
+      chain: 'Monad',
+      address: '0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242',
+    },
+  },
+  {
+    symbol: 'USDC',
+    icon: TokenIcon.USDC,
+    decimals: 6,
+    tokenId: {
+      chain: 'Monad',
+      address: '0x754704Bc059F8C67012fEd69BC8A327a5aafb603',
     },
   },
 ];

--- a/src/config/mainnet/wrappedTokens.ts
+++ b/src/config/mainnet/wrappedTokens.ts
@@ -367,6 +367,7 @@ export const MAINNET_WRAPPED_TOKENS = {
       Worldchain: '0xEfae32D1c15EDBaEA3ebdDe1e2C51003AED04d30',
       Unichain: '0xbdE8A5331E8Ac4831cf8ea9e42e229219EafaB97',
       Fogo: 'HLc5hqihQGFU68488j7HkdyF6rywyJfV46BN6Dn8W5ug',
+      Monad: '0xea17E5a9efEBf1477dB45082d67010E2245217f1',
     },
     EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: {
       Ethereum: '0x41f7B8b9b897276b7AAE926a9016935280b44E97',

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -31,6 +31,15 @@ interface ImportMetaEnv {
   REACT_APP_MEZO_RPC: string;
   REACT_APP_PLUME_RPC: string;
   REACT_APP_XRPL_RPC: string;
+  REACT_APP_INK_RPC: string;
+  REACT_APP_LINEA_RPC: string;
+  REACT_APP_SONIC_RPC: string;
+  REACT_APP_SEIEVM_RPC: string;
+  REACT_APP_HYPEREVM_RPC: string;
+  REACT_APP_HYPERCORE_RPC: string;
+  REACT_APP_CREDITCOIN_RPC: string;
+  REACT_APP_FOGO_RPC: string;
+  REACT_APP_MONAD_RPC: string;
 
   // testnet
   REACT_APP_SEPOLIA_RPC: string;
@@ -56,6 +65,7 @@ interface ImportMetaEnv {
   REACT_APP_SEIEVM_TESTNET_RPC: string;
   REACT_APP_PLUME_TESTNET_RPC: string;
   REACT_APP_XRPLEVM_TESTNET_RPC: string;
+  REACT_APP_MONAD_TESTNET_RPC: string;
 
   // devnet
   REACT_APP_ETHEREUM_DEVNET_RPC: string;

--- a/src/routes/monad/consts.ts
+++ b/src/routes/monad/consts.ts
@@ -13,8 +13,34 @@ export const TOKEN_DENY_LIST: Partial<Record<Network, TokenId[]>> = {
   ],
 };
 
+// Mainnet-only allowlist - only tokens in this list can be bridged on mainnet
+// Testnet does not use an allowlist, only the deny list above
+export const TOKEN_ALLOW_LIST: Partial<Record<Network, TokenId[]>> = {
+  Mainnet: [
+    // Monad tokens
+    Wormhole.tokenId('Monad', 'native'), // MON
+    Wormhole.tokenId('Monad', '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A'), // WMON
+    Wormhole.tokenId('Monad', '0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242'), // WETH (NTT Token on Monad)
+    // Ethereum tokens
+    Wormhole.tokenId('Ethereum', 'native'), // ETH
+    Wormhole.tokenId('Ethereum', '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2'), // WETH
+    Wormhole.tokenId('Ethereum', '0x6917037F8944201b2648198a89906Edf863B9517'), // WMON (NTT Token on Ethereum)
+  ],
+};
+
 export const CONTRACTS: Partial<Record<Network, MultiTokenNtt.Contracts[]>> = {
-  Mainnet: [],
+  Mainnet: [
+    {
+      chain: 'Ethereum',
+      manager: '0x556790e948b9920A8868bCAFcC87D25e82e8a075',
+      gmpManager: '0xc6793a32761a11e96c97A3D18fC6545ea931F0E9',
+    },
+    {
+      chain: 'Monad',
+      manager: '0x36878C6FCa7e0E8a88F90dc410CfBBcA5B695C95',
+      gmpManager: '0x92957b3D0CaB3eA7110fEd1ccc4eF564981a59Fc',
+    },
+  ],
   Testnet: [
     {
       chain: 'Sepolia',

--- a/src/routes/monad/monad.test.ts
+++ b/src/routes/monad/monad.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+
+import '@wormhole-foundation/sdk-evm';
+
+import { Wormhole } from '@wormhole-foundation/sdk-connect';
+import { isTokenSupported } from './utils';
+
+describe('Monad Bridge - isTokenSupported', () => {
+  describe('Mainnet Allowlist - Supported Tokens', () => {
+    it('should support ETH from Ethereum', () => {
+      const sourceToken = Wormhole.tokenId('Ethereum', 'native'); // ETH
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+
+    it('should support WETH from Ethereum', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Ethereum',
+        '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      ); // WETH
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+
+    it('should support WMON from Ethereum', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Ethereum',
+        '0x6917037F8944201b2648198a89906Edf863B9517',
+      ); // WMON on Ethereum
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+
+    it('should support MON (native) from Monad', () => {
+      const sourceToken = Wormhole.tokenId('Monad', 'native'); // MON
+      const mockFromChain = {
+        chain: 'Monad',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+
+    it('should support WMON from Monad', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Monad',
+        '0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A',
+      ); // WMON on Monad
+      const mockFromChain = {
+        chain: 'Monad',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+
+    it('should support WETH from Monad', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Monad',
+        '0xEE8c0E9f1BFFb4Eb878d8f15f368A02a35481242',
+      ); // WETH on Monad (NTT Token)
+      const mockFromChain = {
+        chain: 'Monad',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('Mainnet Allowlist - Unsupported Tokens', () => {
+    it('should NOT support USDC from Ethereum (not in allowlist)', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Ethereum',
+        '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+      ); // USDC
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should NOT support USDT from Ethereum (not in allowlist)', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Ethereum',
+        '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+      ); // USDT
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should NOT support random token from Ethereum (not in allowlist)', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Ethereum',
+        '0x1234567890123456789012345678901234567890',
+      );
+      const mockFromChain = {
+        chain: 'Ethereum',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(false);
+    });
+
+    it('should NOT support random token from Monad (not in allowlist)', () => {
+      const sourceToken = Wormhole.tokenId(
+        'Monad',
+        '0x1234567890123456789012345678901234567890',
+      );
+      const mockFromChain = {
+        chain: 'Monad',
+        network: 'Mainnet' as const,
+      };
+
+      const result = isTokenSupported(sourceToken, mockFromChain as any);
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/routes/monad/utils.ts
+++ b/src/routes/monad/utils.ts
@@ -3,13 +3,25 @@ import type {
   ChainContext,
 } from '@wormhole-foundation/sdk-definitions';
 import { isSameToken } from '@wormhole-foundation/sdk-definitions';
-import { CONTRACTS, TOKEN_DENY_LIST } from './consts';
+import { CONTRACTS, TOKEN_DENY_LIST, TOKEN_ALLOW_LIST } from './consts';
 import type { Network } from '@wormhole-foundation/sdk-connect';
 
 export function isTokenSupported<N extends Network>(
   sourceToken: TokenId,
   fromChain: ChainContext<N>,
 ): boolean {
+  // For Mainnet, use allowlist - only allow tokens explicitly in the list
+  if (fromChain.network === 'Mainnet') {
+    const allowList = TOKEN_ALLOW_LIST[fromChain.network] || [];
+    // If allowlist is empty, no tokens are supported on mainnet
+    if (allowList.length === 0) {
+      return false;
+    }
+    // Check if token is in the allowlist
+    return allowList.some((t) => isSameToken(t, sourceToken));
+  }
+
+  // For other networks (e.g., Testnet), use the deny list
   const denyList = TOKEN_DENY_LIST[fromChain.network] || [];
   if (denyList.some((t) => isSameToken(t, sourceToken))) {
     return false;

--- a/src/sdklegacy/config/MAINNET.ts
+++ b/src/sdklegacy/config/MAINNET.ts
@@ -37,6 +37,7 @@ const MAINNET_CONFIG: WormholeConfig = {
     Ink: 'https://ink.drpc.org',
     CreditCoin: 'https://mainnet3.creditcoin.network',
     Fogo: 'https://mainnet.fogo.io',
+    Monad: 'https://rpc.monad.xyz',
   },
 };
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -36,13 +36,21 @@ export const AMOUNT_IN_TOO_SMALL = new RegExp('AmountInTooSmall', 'm');
 // Insufficient funds patterns
 export const INSUFFICIENT_FUNDS_FOR_GAS_REGEX =
   /insufficient funds for gas|insufficient.*gas/gim;
-export const INSUFFICIENT_FUNDS_REGEX = /insufficient funds/gim;
+export const INSUFFICIENT_FUNDS_REGEX = /insufficient (funds|balance)/gim;
 
 // Error messages
 const INSUFFICIENT_FUNDS_FOR_GAS_ERROR =
   'Insufficient funds for network fees. Please add more funds and try again';
 const INSUFFICIENT_FUNDS_ERROR =
   'Insufficient funds for this transfer. Please add more funds and try again';
+
+// Helper function to check if a regex matches in various nested error locations
+// Different wallets and libraries nest error messages in different places:
+// - e.message (most common)
+// - e.info?.error?.data?.message (ethers.js wrapping MetaMask errors)
+function errorMessageMatches(e: any, regex: RegExp): boolean {
+  return regex.test(e?.message) || regex.test(e?.info?.error?.data?.message);
+}
 
 export function interpretTransferError(
   e: any,
@@ -56,7 +64,7 @@ export function interpretTransferError(
     if (e instanceof routes.RelayFailedError) {
       uiErrorMessage = e.message;
       internalErrorCode = ERR_RELAY_FAILED;
-    } else if (INSUFFICIENT_ALLOWANCE_REGEX.test(e?.message)) {
+    } else if (errorMessageMatches(e, INSUFFICIENT_ALLOWANCE_REGEX)) {
       uiErrorMessage = 'Error with transfer, please try again';
       internalErrorCode = ERR_INSUFFICIENT_ALLOWANCE;
     } else if (
@@ -66,18 +74,18 @@ export function interpretTransferError(
       // Solana timeout
       uiErrorMessage = 'Transfer timed out, please try again';
       internalErrorCode = ERR_TIMEOUT;
-    } else if (INSUFFICIENT_FUNDS_FOR_GAS_REGEX.test(e?.message)) {
+    } else if (errorMessageMatches(e, INSUFFICIENT_FUNDS_FOR_GAS_REGEX)) {
       uiErrorMessage = INSUFFICIENT_FUNDS_FOR_GAS_ERROR;
       internalErrorCode = ERR_INSUFFICIENT_GAS;
-    } else if (INSUFFICIENT_FUNDS_REGEX.test(e?.message)) {
+    } else if (errorMessageMatches(e, INSUFFICIENT_FUNDS_REGEX)) {
       // IMPORTANT: This check must come after INSUFFICIENT_FUNDS_FOR_GAS_REGEX
       // because "insufficient funds for gas" contains "insufficient funds"
       uiErrorMessage = INSUFFICIENT_FUNDS_ERROR;
       internalErrorCode = ERR_INSUFFICIENT_GAS;
-    } else if (USER_REJECTED_REGEX.test(e?.message)) {
+    } else if (errorMessageMatches(e, USER_REJECTED_REGEX)) {
       uiErrorMessage = 'Wallet request declined. Transfer not started.';
       internalErrorCode = ERR_USER_REJECTED;
-    } else if (AMOUNT_IN_TOO_SMALL.test(e?.message)) {
+    } else if (errorMessageMatches(e, AMOUNT_IN_TOO_SMALL)) {
       uiErrorMessage = 'Amount is too small for the selected route';
       internalErrorCode = ERR_AMOUNT_TOO_SMALL;
     } else if (
@@ -97,8 +105,8 @@ export function interpretTransferError(
       uiErrorMessage = `Amount exceeds Circle limit${limitString}. Please reduce transfer amount.`;
       internalErrorCode = ERR_AMOUNT_TOO_LARGE;
     } else if (
-      SIMULATION_ACCOUNT_NOT_FOUND_REGEX.test(e?.message) ||
-      INSUFFICIENT_LAMPORTS_REGEX.test(e?.message)
+      errorMessageMatches(e, SIMULATION_ACCOUNT_NOT_FOUND_REGEX) ||
+      errorMessageMatches(e, INSUFFICIENT_LAMPORTS_REGEX)
     ) {
       const gasChain = transferDetails.fromChain;
       try {


### PR DESCRIPTION
The Monad Bridge route supports ETH and MON transfers between Ethereum and Monad via a frontend allowlist.