### PR TITLE
feat: add ability to hide wallet actions in the wallet drop down

### DIFF
--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -48,6 +48,18 @@ export type UiConfig = {
 
   // When enabled hides the history button
   hideHistory?: boolean;
+
+  // When enabled hides the change wallet option for source wallets
+  hideSourceChangeWallet?: boolean;
+
+  // When enabled hides the disconnect wallet option for source wallets
+  hideSourceDisconnectWallet?: boolean;
+
+  // When enabled hides the change wallet option for desitnation wallets
+  hideDestinationChangeWallet?: boolean;
+
+  // When enabled hides the disconnect wallet option for desitnation wallets
+  hideDestinationDisconnectWallet?: boolean;
 };
 
 export type TestOptions = {

--- a/src/views/v3/Bridge/WalletConnector/Controller.tsx
+++ b/src/views/v3/Bridge/WalletConnector/Controller.tsx
@@ -65,9 +65,16 @@ const ConnectedWallet = (props: Props) => {
   );
 
   const wallet = useSelector((state: RootState) => state.wallet[props.type]);
+  const isSourceWallet = props.type === TransferWallet.SENDING;
+  const selectedChain = isSourceWallet ? fromChain : toChain;
 
-  const selectedChain =
-    props.type === TransferWallet.SENDING ? fromChain : toChain;
+  const isChangeWalletVisible = isSourceWallet
+    ? !config.ui.hideSourceChangeWallet
+    : !config.ui.hideDestinationChangeWallet;
+
+  const isDisconnectWalletVisible = isSourceWallet
+    ? !config.ui.hideSourceDisconnectWallet
+    : !config.ui.hideDestinationDisconnectWallet;
 
   const [isOpen, setIsOpen] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -155,12 +162,16 @@ const ConnectedWallet = (props: Props) => {
                   label={config.ui.explorer.label}
                 />
               ) : null}
-              <ListItemButton onClick={handleChangeWallet}>
-                <Typography fontSize={14}>Change wallet</Typography>
-              </ListItemButton>
-              <ListItemButton onClick={handleDisconnectWallet}>
-                <Typography fontSize={14}>Disconnect</Typography>
-              </ListItemButton>
+              {isChangeWalletVisible && (
+                <ListItemButton onClick={handleChangeWallet}>
+                  <Typography fontSize={14}>Change wallet</Typography>
+                </ListItemButton>
+              )}
+              {isDisconnectWalletVisible && (
+                <ListItemButton onClick={handleDisconnectWallet}>
+                  <Typography fontSize={14}>Disconnect</Typography>
+                </ListItemButton>
+              )}
             </List>
           </Popover>
         </>


### PR DESCRIPTION
Adds ui config to hide options in the source or destination wallet drop down

- hideSourceChangeWallet?: boolean;
- hideSourceDisconnectWallet?: boolean;
- hideDestinationChangeWallet?: boolean;
- hideDestinationDisconnectWallet?: boolean;