### PR TITLE
feat: add transaction history chain filtering

### DIFF
--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -60,6 +60,9 @@ export type UiConfig = {
 
   // When enabled hides the disconnect wallet option for desitnation wallets
   hideDestinationDisconnectWallet?: boolean;
+
+  // Filter transaction history by specific chains
+  transactionHistoryChains?: Chain[];
 };
 
 export type TestOptions = {

--- a/src/hooks/useTransactionHistory.ts
+++ b/src/hooks/useTransactionHistory.ts
@@ -5,6 +5,7 @@ import useTransactionHistoryWHScan from 'hooks/useTransactionHistoryWHScan';
 import useTransactionHistoryMayan from 'hooks/useTransactionHistoryMayan';
 import useTransactionHistoryLiFi from 'hooks/useTransactionHistoryLiFi';
 
+import config from 'config';
 import type { Transaction } from 'config/types';
 import type { RootState } from 'store';
 import { sortByTime } from 'utils/sort';
@@ -48,6 +49,7 @@ const useTransactionHistory = (
     address,
     page: whScanPage,
     pageSize,
+    chains: config.ui.transactionHistoryChains,
   });
 
   const {
@@ -59,6 +61,7 @@ const useTransactionHistory = (
     address,
     page: mayanPage,
     pageSize,
+    chains: config.ui.transactionHistoryChains,
   });
 
   const {
@@ -70,6 +73,7 @@ const useTransactionHistory = (
     address,
     page: lifiPage,
     pageSize,
+    chains: config.ui.transactionHistoryChains,
   });
 
   const appendTxs = useCallback(

--- a/src/hooks/useTransactionHistoryLiFi.test.tsx
+++ b/src/hooks/useTransactionHistoryLiFi.test.tsx
@@ -158,7 +158,7 @@ describe('useTransactionHistoryLiFi', () => {
     expect(tx?.recipient).toBe('0xuser2');
     expect(tx?.fromChain).toBe('Ethereum');
     expect(tx?.toChain).toBe('Polygon');
-    expect(tx?.explorerLink).toBe('https://etherscan.io/tx/0xabc123');
+    expect(tx?.explorerLink).toBe('https://scan.li.fi/tx/0xabc123');
     expect(tx?.inProgress).toBe(false);
   });
 

--- a/src/hooks/useTransactionHistoryLiFi.ts
+++ b/src/hooks/useTransactionHistoryLiFi.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import type { Chain } from '@wormhole-foundation/sdk';
 import type { ChainId as LifiChainId } from '@lifi/sdk';
 
 import config from 'config';
@@ -60,6 +61,7 @@ type Props = {
   address: string;
   page?: number;
   pageSize?: number;
+  chains?: Chain[];
 };
 
 const ONE_WEEK = 7 * 24 * 60 * 60; // 1 week per page in seconds
@@ -80,7 +82,7 @@ const useTransactionHistoryLiFi = (
   const [isFetching, setIsFetching] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  const { address, page = 0, pageSize = 30 } = props;
+  const { address, page = 0, pageSize = 30, chains } = props;
 
   const resetTransactions = () => {
     setTransactions((current) => (current?.length === 0 ? current : []));
@@ -167,9 +169,23 @@ const useTransactionHistoryLiFi = (
   };
 
   const parseTransactions = useCallback(
-    (allTxs: Array<LiFiTransaction>) =>
-      allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx), // Filter out unsupported transactions
-    [],
+    (allTxs: Array<LiFiTransaction>) => {
+      const parsed = allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx);
+
+      // TODO: ideally filtering should be done at the API level,
+      // but it would require multiple requests for different chains
+      // For now, we just filter on the client. This will result in
+      // fewer results per page when filters are applied.
+      if (chains && chains.length > 0) {
+        return parsed.filter((tx) => {
+          if (!tx) return false;
+          return chains.includes(tx.fromChain) || chains.includes(tx.toChain);
+        });
+      }
+
+      return parsed;
+    },
+    [chains],
   );
 
   useEffect(() => {
@@ -241,9 +257,9 @@ const useTransactionHistoryLiFi = (
           const resData = resPayload?.transfers || resPayload;
 
           if (Array.isArray(resData)) {
-            setTransactions((txs) => {
-              const parsedTxs = parseTransactions(resData);
+            const parsedTxs = parseTransactions(resData);
 
+            setTransactions((txs) => {
               if (txs && txs.length > 0) {
                 // We need to keep track of existing tx hashes to prevent duplicates
                 const existingTxs = new Set<string>();
@@ -263,8 +279,8 @@ const useTransactionHistoryLiFi = (
               return parsedTxs;
             });
 
-            // LiFi returns max 1000 results, if we get less than pageSize, no more data
-            if (resData.length < pageSize) {
+            // LiFi returns max 1000 results, check filtered count not raw response count
+            if (parsedTxs.length < pageSize) {
               setHasMore(false);
             }
           } else {

--- a/src/hooks/useTransactionHistoryLiFi.ts
+++ b/src/hooks/useTransactionHistoryLiFi.ts
@@ -161,7 +161,7 @@ const useTransactionHistoryLiFi = (
       toToken,
       senderTimestamp: senderTime.toISOString(),
       receiverTimestamp: receiverTime?.toISOString(),
-      explorerLink: sending.txLink,
+      explorerLink: `https://scan.li.fi/tx/${sending.txHash}`,
       inProgress: status === 'PENDING',
     };
 

--- a/src/hooks/useTransactionHistoryLiFi.ts
+++ b/src/hooks/useTransactionHistoryLiFi.ts
@@ -278,8 +278,12 @@ const useTransactionHistoryLiFi = (
               return parsedTxs;
             });
 
-            // LiFi returns max 1000 results, if we get less than pageSize, no more data
-            if (resData.length < pageSize) {
+            // If filtering by chain client-side, disable pagination since we can't
+            // reliably determine if there are more matching transactions
+            if (chains && chains.length > 0) {
+              setHasMore(false);
+            } else if (resData.length < pageSize) {
+              // LiFi returns max 1000 results, if we get less than pageSize, no more data
               setHasMore(false);
             }
           } else {
@@ -316,7 +320,7 @@ const useTransactionHistoryLiFi = (
     return () => {
       cancelled = true;
     };
-  }, [address, page, pageSize, parseTransactions, hasMore]);
+  }, [address, page, pageSize, chains, parseTransactions, hasMore]);
 
   return {
     transactions,

--- a/src/hooks/useTransactionHistoryLiFi.ts
+++ b/src/hooks/useTransactionHistoryLiFi.ts
@@ -172,10 +172,9 @@ const useTransactionHistoryLiFi = (
     (allTxs: Array<LiFiTransaction>) => {
       const parsed = allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx);
 
-      // TODO: ideally filtering should be done at the API level,
-      // but it would require multiple requests for different chains
-      // For now, we just filter on the client. This will result in
-      // fewer results per page when filters are applied.
+      // NOTE: Ideally, filtering would be done at the API level,
+      // but the LiFi API does not make this easy when multiple chains are involved.
+      // For simplicity, we filter on the client side here.
       if (chains && chains.length > 0) {
         return parsed.filter((tx) => {
           if (!tx) return false;
@@ -257,9 +256,9 @@ const useTransactionHistoryLiFi = (
           const resData = resPayload?.transfers || resPayload;
 
           if (Array.isArray(resData)) {
-            const parsedTxs = parseTransactions(resData);
-
             setTransactions((txs) => {
+              const parsedTxs = parseTransactions(resData);
+
               if (txs && txs.length > 0) {
                 // We need to keep track of existing tx hashes to prevent duplicates
                 const existingTxs = new Set<string>();
@@ -279,8 +278,8 @@ const useTransactionHistoryLiFi = (
               return parsedTxs;
             });
 
-            // LiFi returns max 1000 results, check filtered count not raw response count
-            if (parsedTxs.length < pageSize) {
+            // LiFi returns max 1000 results, if we get less than pageSize, no more data
+            if (resData.length < pageSize) {
               setHasMore(false);
             }
           } else {

--- a/src/hooks/useTransactionHistoryMayan.ts
+++ b/src/hooks/useTransactionHistoryMayan.ts
@@ -145,10 +145,8 @@ const useTransactionHistoryMayan = (
     (allTxs: Array<MayanTransaction>) => {
       const parsed = allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx);
 
-      // TODO: ideally filtering should be done at the API level,
-      // but the Mayan API does not currently support it.
-      // For now, we just filter on the client. This will result in
-      // fewer results per page when filters are applied.
+      // NOTE: The Mayan API doesn't appear to support filtering by multiple chains,
+      // so we filter client-side here.
       if (chains && chains.length > 0) {
         return parsed.filter((tx) => {
           if (!tx) return false;
@@ -186,9 +184,9 @@ const useTransactionHistoryMayan = (
             const resData = resPayload?.data;
 
             if (resData) {
-              const parsedTxs = parseTransactions(resData);
-
               setTransactions((txs) => {
+                const parsedTxs = parseTransactions(resData);
+
                 if (txs && txs.length > 0) {
                   // We need to keep track of existing tx hashes to prevent duplicates in the final list
                   const existingTxs = new Set<string>();
@@ -207,11 +205,10 @@ const useTransactionHistoryMayan = (
                 }
                 return parsedTxs;
               });
+            }
 
-              // Check filtered results count, not raw API response count
-              if (parsedTxs.length < limit) {
-                setHasMore(false);
-              }
+            if (resData?.length < limit) {
+              setHasMore(false);
             }
           }
         }

--- a/src/hooks/useTransactionHistoryMayan.ts
+++ b/src/hooks/useTransactionHistoryMayan.ts
@@ -33,6 +33,7 @@ type Props = {
   address: string;
   page?: number;
   pageSize?: number;
+  chains?: Chain[];
 };
 
 const useTransactionHistoryMayan = (
@@ -50,7 +51,7 @@ const useTransactionHistoryMayan = (
   const [isFetching, setIsFetching] = useState(false);
   const [hasMore, setHasMore] = useState(true);
 
-  const { address, page = 0, pageSize = 30 } = props;
+  const { address, page = 0, pageSize = 30, chains } = props;
 
   const parseSingleTx = (tx: MayanTransaction) => {
     const {
@@ -141,9 +142,23 @@ const useTransactionHistoryMayan = (
   };
 
   const parseTransactions = useCallback(
-    (allTxs: Array<MayanTransaction>) =>
-      allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx), // Filter out unsupported transactions
-    [],
+    (allTxs: Array<MayanTransaction>) => {
+      const parsed = allTxs.map((tx) => parseSingleTx(tx)).filter((tx) => !!tx);
+
+      // TODO: ideally filtering should be done at the API level,
+      // but the Mayan API does not currently support it.
+      // For now, we just filter on the client. This will result in
+      // fewer results per page when filters are applied.
+      if (chains && chains.length > 0) {
+        return parsed.filter((tx) => {
+          if (!tx) return false;
+          return chains.includes(tx.fromChain) || chains.includes(tx.toChain);
+        });
+      }
+
+      return parsed;
+    },
+    [chains],
   );
 
   useEffect(() => {
@@ -171,9 +186,9 @@ const useTransactionHistoryMayan = (
             const resData = resPayload?.data;
 
             if (resData) {
-              setTransactions((txs) => {
-                const parsedTxs = parseTransactions(resData);
+              const parsedTxs = parseTransactions(resData);
 
+              setTransactions((txs) => {
                 if (txs && txs.length > 0) {
                   // We need to keep track of existing tx hashes to prevent duplicates in the final list
                   const existingTxs = new Set<string>();
@@ -192,10 +207,11 @@ const useTransactionHistoryMayan = (
                 }
                 return parsedTxs;
               });
-            }
 
-            if (resData?.length < limit) {
-              setHasMore(false);
+              // Check filtered results count, not raw API response count
+              if (parsedTxs.length < limit) {
+                setHasMore(false);
+              }
             }
           }
         }

--- a/src/hooks/useTransactionHistoryMayan.ts
+++ b/src/hooks/useTransactionHistoryMayan.ts
@@ -207,7 +207,11 @@ const useTransactionHistoryMayan = (
               });
             }
 
-            if (resData?.length < limit) {
+            // If filtering by chain client-side, disable pagination since we can't
+            // reliably determine if there are more matching transactions
+            if (chains && chains.length > 0) {
+              setHasMore(false);
+            } else if (resData?.length < limit) {
               setHasMore(false);
             }
           }
@@ -227,7 +231,7 @@ const useTransactionHistoryMayan = (
     return () => {
       cancelled = true;
     };
-  }, [address, page, pageSize, parseTransactions]);
+  }, [address, page, pageSize, chains, parseTransactions]);
 
   return {
     transactions,

--- a/src/hooks/useTransactionHistoryWHScan.ts
+++ b/src/hooks/useTransactionHistoryWHScan.ts
@@ -449,10 +449,8 @@ const useTransactionHistoryWHScan = (
       setIsFetching(true);
 
       try {
-        // Build the API URL with optional chain filter
         let url = `${config.wormholeApi}api/v1/operations?address=${address}&page=${page}&pageSize=${pageSize}`;
         if (chainIds && chainIds.length > 0) {
-          // Add chain IDs as comma-separated values
           url += `&includesChain=${chainIds.join(',')}`;
         }
 

--- a/src/hooks/useTransactionHistoryWHScan.ts
+++ b/src/hooks/useTransactionHistoryWHScan.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   amount as sdkAmount,
   chainIdToChain,
+  chainToChainId,
   toNative,
   Wormhole,
 } from '@wormhole-foundation/sdk';
@@ -101,6 +102,7 @@ type Props = {
   address: string;
   page?: number;
   pageSize?: number;
+  chains?: Chain[];
 };
 
 // Number of decimals from WHScan API results are fixed to 8
@@ -122,7 +124,12 @@ const useTransactionHistoryWHScan = (
   const [hasMore, setHasMore] = useState(true);
   const { getOrFetchToken } = useTokens();
 
-  const { address, page = 0, pageSize = 30 } = props;
+  const { address, page = 0, pageSize = 30, chains } = props;
+
+  const chainIds = useMemo(() => {
+    if (!chains || chains.length === 0) return undefined;
+    return chains.map((chain) => chainToChainId(chain));
+  }, [chains]);
 
   // Common parsing logic for a single transaction from WHScan API.
   // IMPORTANT: Anything specific to a route, please use that route's parser:
@@ -442,10 +449,14 @@ const useTransactionHistoryWHScan = (
       setIsFetching(true);
 
       try {
-        const res = await fetch(
-          `${config.wormholeApi}api/v1/operations?address=${address}&page=${page}&pageSize=${pageSize}`,
-          { headers },
-        );
+        // Build the API URL with optional chain filter
+        let url = `${config.wormholeApi}api/v1/operations?address=${address}&page=${page}&pageSize=${pageSize}`;
+        if (chainIds && chainIds.length > 0) {
+          // Add chain IDs as comma-separated values
+          url += `&includesChain=${chainIds.join(',')}`;
+        }
+
+        const res = await fetch(url, { headers });
 
         // If the fetch was unsuccessful, return an empty set
         if (res.status !== 200) {
@@ -502,7 +513,7 @@ const useTransactionHistoryWHScan = (
     return () => {
       cancelled = true;
     };
-  }, [address, page, pageSize, parseTransactions]);
+  }, [address, page, pageSize, parseTransactions, chainIds]);
 
   return {
     transactions,


### PR DESCRIPTION
Add support for filtering transaction history by specific chains via the `transactionHistoryChains` UI config option.

Wormholescan supports filtering at the API level. For Mayan and LiFi, we filter at the client level for simplicity and, as a result, only support limited history which is fine for now.

Addresses BRI-122