### PR TITLE
feat: mayan monad support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@ledgerhq/hw-transport-webhid": "6.27.1",
         "@ledgerhq/logs": "6.12.0",
         "@lifi/sdk": "3.12.14",
-        "@mayanfinance/swap-sdk": "11.3.0",
+        "@mayanfinance/swap-sdk": "12.0.0",
         "@metaplex-foundation/mpl-token-metadata": "3.4.0",
         "@metaplex-foundation/umi": "0.9.2",
         "@metaplex-foundation/umi-bundle-defaults": "0.9.2",
@@ -5769,9 +5769,9 @@
       }
     },
     "node_modules/@mayanfinance/swap-sdk": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-11.3.0.tgz",
-      "integrity": "sha512-1pT7yUvO+JIl2Tgrxv6H5cG9mH7vOf6+xlj/ShD2DuiCDfGym3KJwJ3FGqAtBze/aqW5kpCGcfDK3uvVS2WPXw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@mayanfinance/swap-sdk/-/swap-sdk-12.0.0.tgz",
+      "integrity": "sha512-4NFBhQOSh6VQFd1Vc33faiS1vSpZGIBY/hG49b68fiD8XQOL2R0Vk/deh9rND9IojQWS7ZKAK0nr7uutAnNAzQ==",
       "license": "MIT",
       "dependencies": {
         "@mysten/sui": "^1.34.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ledgerhq/hw-transport-webhid": "6.27.1",
     "@ledgerhq/logs": "6.12.0",
     "@lifi/sdk": "3.12.14",
-    "@mayanfinance/swap-sdk": "11.3.0",
+    "@mayanfinance/swap-sdk": "12.0.0",
     "@metaplex-foundation/mpl-token-metadata": "3.4.0",
     "@metaplex-foundation/umi": "0.9.2",
     "@metaplex-foundation/umi-bundle-defaults": "0.9.2",

--- a/src/routes/mayan/MayanRouteBase.ts
+++ b/src/routes/mayan/MayanRouteBase.ts
@@ -872,7 +872,7 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
               undefined,
               undefined,
             )
-          : getSwapFromEvmTxPayload(
+          : await getSwapFromEvmTxPayload(
               quoteDetails,
               originAddress,
               destinationAddress,

--- a/src/routes/mayan/utils.ts
+++ b/src/routes/mayan/utils.ts
@@ -45,6 +45,7 @@ const defaultDeadlines: {
   Aptos: 50,
   Unichain: 96,
   Sui: 40,
+  Monad: 96,
 };
 
 // return the default deadline for a given chain in seconds
@@ -54,7 +55,7 @@ export function getDefaultDeadline(chain: Chain): number {
   return 60 * 60;
 }
 
-const chainNameMap = {
+const chainNameMap: Partial<Record<Chain, MayanChainName>> = {
   Solana: 'solana',
   Ethereum: 'ethereum',
   Bsc: 'bsc',
@@ -69,7 +70,8 @@ const chainNameMap = {
   HyperEVM: 'hyperevm',
   HyperCore: 'hypercore',
   Linea: 'linea',
-} as Record<Chain, MayanChainName>;
+  Monad: 'monad',
+};
 
 // Mapping of Wormhole chains to testnet Mayan chain names
 // Only Solana, Ethereum, Base, Sui, and Monad are supported on testnet


### PR DESCRIPTION
successful mctp txns to monad:
Arbitrum USDC -> Monad UDSC https://explorer.mayan.finance/tx/0x9d900461aa5c321fc04163890276ed522f3c418859ce610d41aeae471158502b
Arbitrum ETH -> Monad MON https://explorer.mayan.finance/tx/0xe48024a0afb99eecba2f7b1e42928d98a5a74177eec397937f93a0e656dd11bb
