### PR TITLE
feat: Deduct a fixed amount for gas token on Max button click

### DIFF
--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -8,6 +8,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Etherscan',
     icon: 'Ethereum',
     symbol: 'ETH',
+    gasReserve: '0.01',
   },
   Bsc: {
     displayName: 'BNB',
@@ -16,6 +17,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'BscScan',
     icon: 'Bsc',
     symbol: 'BSC',
+    gasReserve: '0.01',
   },
   Polygon: {
     displayName: 'Polygon',
@@ -24,6 +26,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'PolygonScan',
     icon: 'Polygon',
     symbol: 'POL',
+    gasReserve: '0.01',
   },
   Avalanche: {
     displayName: 'Avalanche',
@@ -32,6 +35,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Snowtrace',
     icon: 'Avalanche',
     symbol: 'AVAX',
+    gasReserve: '0.01',
   },
   Fantom: {
     displayName: 'Fantom',
@@ -48,6 +52,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Celo Explorer',
     icon: 'Celo',
     symbol: 'CELO',
+    gasReserve: '0.01',
   },
   Moonbeam: {
     displayName: 'Moonbeam',
@@ -56,6 +61,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Moonscan',
     icon: 'Moonbeam',
     symbol: 'GLMR',
+    gasReserve: '0.01',
   },
   Solana: {
     displayName: 'Solana',
@@ -64,6 +70,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Solana Explorer',
     icon: 'Solana',
     symbol: 'SOL',
+    gasReserve: '0.01',
   },
   Sui: {
     displayName: 'Sui',
@@ -72,6 +79,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Suiscan',
     icon: 'Sui',
     symbol: 'SUI',
+    gasReserve: '0.01',
   },
   Aptos: {
     displayName: 'Aptos',
@@ -80,6 +88,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Aptos Explorer',
     icon: 'Aptos',
     symbol: 'APT',
+    gasReserve: '0.01',
   },
   Base: {
     displayName: 'Base',
@@ -88,6 +97,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'BaseScan',
     icon: 'Base',
     symbol: 'BASE',
+    gasReserve: '0.001',
   },
   Arbitrum: {
     displayName: 'Arbitrum',
@@ -96,6 +106,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Arbitrum Explorer',
     icon: 'Arbitrum',
     symbol: 'ARB',
+    gasReserve: '0.001',
   },
   Optimism: {
     displayName: 'Optimism',
@@ -104,6 +115,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Optimistic Etherscan',
     icon: 'Optimism',
     symbol: 'OP',
+    gasReserve: '0.001',
   },
   Klaytn: {
     displayName: 'Kaia',
@@ -256,5 +268,6 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'MonadVision',
     icon: 'Monad',
     symbol: 'MON',
+    gasReserve: '0.01',
   },
 };

--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -61,7 +61,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Moonscan',
     icon: 'Moonbeam',
     symbol: 'GLMR',
-    gasReserve: '0.01',
+    gasReserve: '0.03',
   },
   Solana: {
     displayName: 'Solana',

--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -124,6 +124,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'KaiaScan',
     icon: 'Klaytn',
     symbol: 'KAIA',
+    gasReserve: '0.01',
   },
   Scroll: {
     displayName: 'Scroll',
@@ -132,6 +133,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Scrollscan',
     icon: 'Scroll',
     symbol: 'SCR',
+    gasReserve: '0.001',
   },
   Xlayer: {
     displayName: 'X Layer',
@@ -140,6 +142,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'OKX Explorer',
     icon: 'Xlayer',
     symbol: 'OKX',
+    gasReserve: '0.001',
   },
   Mantle: {
     displayName: 'Mantle',
@@ -148,6 +151,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Mantle Explorer',
     icon: 'Mantle',
     symbol: 'MNT',
+    gasReserve: '0.001',
   },
   Worldchain: {
     displayName: 'World Chain',
@@ -244,6 +248,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'XRPL EVM Explorer',
     icon: 'XRPLEVM',
     symbol: 'XRP',
+    gasReserve: '0.01',
   },
   CreditCoin: {
     displayName: 'Creditcoin',
@@ -260,6 +265,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Fogo Explorer',
     icon: 'Fogo',
     symbol: 'FOGO',
+    gasReserve: '0.01',
   },
   Monad: {
     displayName: 'Monad',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -233,6 +233,18 @@ export interface ChainConfig {
   explorerName: string;
   icon: Chain;
   symbol?: string;
+  /**
+   * Gas reserve amount to keep for the chain's native token.
+   * This ensures users have enough gas to complete transactions.
+   * Format: decimal string (e.g., '0.01' for 0.01 of the native token)
+   *
+   * Typical values:
+   * - Ethereum: '0.01' ($30 notional)
+   * - L2s (Base, Op, Arb): '0.001' ($3 notional)
+   * - Other EVM L1s: '0.01'
+   * - Solana: '0.01' ($1.3 notional)
+   */
+  gasReserve?: string;
 }
 
 export type ChainsConfig = {

--- a/src/utils/gasReserve.test.ts
+++ b/src/utils/gasReserve.test.ts
@@ -4,8 +4,8 @@ import { getGasReserve } from './gasReserve';
 
 describe('getGasReserve', () => {
   describe('Ethereum mainnet', () => {
-    it('returns 0.01 ETH for Ethereum with 18 decimals', () => {
-      const reserve = getGasReserve('Ethereum', 18);
+    it('returns 0.01 ETH for Ethereum', () => {
+      const reserve = getGasReserve('Ethereum');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
@@ -14,24 +14,24 @@ describe('getGasReserve', () => {
   });
 
   describe('L2 chains', () => {
-    it('returns 0.001 ETH for Base with 18 decimals', () => {
-      const reserve = getGasReserve('Base', 18);
+    it('returns 0.001 ETH for Base', () => {
+      const reserve = getGasReserve('Base');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.001');
       expect(sdkAmount.units(reserve!)).toBe(1000000000000000n); // 0.001 * 10^18
     });
 
-    it('returns 0.001 ETH for Optimism with 18 decimals', () => {
-      const reserve = getGasReserve('Optimism', 18);
+    it('returns 0.001 ETH for Optimism', () => {
+      const reserve = getGasReserve('Optimism');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.001');
       expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
     });
 
-    it('returns 0.001 ETH for Arbitrum with 18 decimals', () => {
-      const reserve = getGasReserve('Arbitrum', 18);
+    it('returns 0.001 ETH for Arbitrum', () => {
+      const reserve = getGasReserve('Arbitrum');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.001');
@@ -40,8 +40,8 @@ describe('getGasReserve', () => {
   });
 
   describe('Solana', () => {
-    it('returns 0.01 SOL for Solana with 9 decimals', () => {
-      const reserve = getGasReserve('Solana', 9);
+    it('returns 0.01 SOL for Solana', () => {
+      const reserve = getGasReserve('Solana');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
@@ -50,48 +50,47 @@ describe('getGasReserve', () => {
   });
 
   describe('Other EVM L1 chains', () => {
-    it('returns 0.01 for Bsc with 18 decimals', () => {
-      const reserve = getGasReserve('Bsc', 18);
+    it('returns 0.01 for Bsc', () => {
+      const reserve = getGasReserve('Bsc');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
 
-    it('returns 0.01 for Avalanche with 18 decimals', () => {
-      const reserve = getGasReserve('Avalanche', 18);
+    it('returns 0.01 for Avalanche', () => {
+      const reserve = getGasReserve('Avalanche');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
 
-    it('returns 0.01 for Polygon with 18 decimals', () => {
-      const reserve = getGasReserve('Polygon', 18);
+    it('returns 0.01 for Polygon', () => {
+      const reserve = getGasReserve('Polygon');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
 
-    it('returns 0.01 for Fantom with 18 decimals', () => {
-      const reserve = getGasReserve('Fantom', 18);
+    it('returns undefined for Fantom (gas token not configured)', () => {
+      const reserve = getGasReserve('Fantom');
+
+      // Fantom has a reserve configured but no gas token in config, so should return undefined
+      expect(reserve).toBeUndefined();
+    });
+
+    it('returns 0.01 for Celo', () => {
+      const reserve = getGasReserve('Celo');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
 
-    it('returns 0.01 for Celo with 18 decimals', () => {
-      const reserve = getGasReserve('Celo', 18);
-
-      expect(reserve).toBeDefined();
-      expect(sdkAmount.display(reserve!)).toBe('0.01');
-      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
-    });
-
-    it('returns 0.01 for Moonbeam with 18 decimals', () => {
-      const reserve = getGasReserve('Moonbeam', 18);
+    it('returns 0.01 for Moonbeam', () => {
+      const reserve = getGasReserve('Moonbeam');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
@@ -100,16 +99,16 @@ describe('getGasReserve', () => {
   });
 
   describe('Move chains', () => {
-    it('returns 0.01 for Sui with 9 decimals', () => {
-      const reserve = getGasReserve('Sui', 9);
+    it('returns 0.01 for Sui', () => {
+      const reserve = getGasReserve('Sui');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000n); // 0.01 * 10^9
     });
 
-    it('returns 0.01 for Aptos with 8 decimals', () => {
-      const reserve = getGasReserve('Aptos', 8);
+    it('returns 0.01 for Aptos', () => {
+      const reserve = getGasReserve('Aptos');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');
@@ -119,56 +118,21 @@ describe('getGasReserve', () => {
 
   describe('Chains without configured reserves', () => {
     it('returns undefined for Cosmoshub', () => {
-      const reserve = getGasReserve('Cosmoshub', 6);
+      const reserve = getGasReserve('Cosmoshub');
 
       expect(reserve).toBeUndefined();
     });
 
     it('returns undefined for Wormchain', () => {
-      const reserve = getGasReserve('Wormchain', 6);
+      const reserve = getGasReserve('Wormchain');
 
       expect(reserve).toBeUndefined();
     });
 
     it('returns undefined for Osmosis', () => {
-      const reserve = getGasReserve('Osmosis', 6);
+      const reserve = getGasReserve('Osmosis');
 
       expect(reserve).toBeUndefined();
-    });
-  });
-
-  describe('Decimal precision', () => {
-    it('correctly handles different decimal precision for same reserve value', () => {
-      const reserve18 = getGasReserve('Ethereum', 18);
-      const reserve6 = getGasReserve('Ethereum', 6);
-
-      // Both should display as 0.01, but have different base units
-      expect(sdkAmount.display(reserve18!)).toBe('0.01');
-      expect(sdkAmount.display(reserve6!)).toBe('0.01');
-
-      // Base units should differ by 10^12
-      expect(sdkAmount.units(reserve18!)).toBe(10000000000000000n); // 0.01 * 10^18
-      expect(sdkAmount.units(reserve6!)).toBe(10000n); // 0.01 * 10^6
-    });
-
-    it('handles 8-decimal precision (Aptos)', () => {
-      const reserve = getGasReserve('Aptos', 8);
-
-      expect(reserve).toBeDefined();
-      expect(sdkAmount.display(reserve!)).toBe('0.01');
-      expect(sdkAmount.units(reserve!)).toBe(1000000n); // 0.01 * 10^8
-    });
-
-    it('handles 9-decimal precision (Solana, Sui)', () => {
-      const reserveSolana = getGasReserve('Solana', 9);
-      const reserveSui = getGasReserve('Sui', 9);
-
-      expect(reserveSolana).toBeDefined();
-      expect(reserveSui).toBeDefined();
-      expect(sdkAmount.display(reserveSolana!)).toBe('0.01');
-      expect(sdkAmount.display(reserveSui!)).toBe('0.01');
-      expect(sdkAmount.units(reserveSolana!)).toBe(10000000n); // 0.01 * 10^9
-      expect(sdkAmount.units(reserveSui!)).toBe(10000000n);
     });
   });
 });

--- a/src/utils/gasReserve.test.ts
+++ b/src/utils/gasReserve.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import { getGasReserve } from './gasReserve';
+
+describe('getGasReserve', () => {
+  describe('Ethereum mainnet', () => {
+    it('returns 0.01 ETH for Ethereum with 18 decimals', () => {
+      const reserve = getGasReserve('Ethereum', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n); // 0.01 * 10^18
+    });
+  });
+
+  describe('L2 chains', () => {
+    it('returns 0.001 ETH for Base with 18 decimals', () => {
+      const reserve = getGasReserve('Base', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n); // 0.001 * 10^18
+    });
+
+    it('returns 0.001 ETH for Optimism with 18 decimals', () => {
+      const reserve = getGasReserve('Optimism', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
+    });
+
+    it('returns 0.001 ETH for Arbitrum with 18 decimals', () => {
+      const reserve = getGasReserve('Arbitrum', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
+    });
+  });
+
+  describe('Solana', () => {
+    it('returns 0.01 SOL for Solana with 9 decimals', () => {
+      const reserve = getGasReserve('Solana', 9);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000n); // 0.01 * 10^9
+    });
+  });
+
+  describe('Other EVM L1 chains', () => {
+    it('returns 0.01 for Bsc with 18 decimals', () => {
+      const reserve = getGasReserve('Bsc', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Avalanche with 18 decimals', () => {
+      const reserve = getGasReserve('Avalanche', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Polygon with 18 decimals', () => {
+      const reserve = getGasReserve('Polygon', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Fantom with 18 decimals', () => {
+      const reserve = getGasReserve('Fantom', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Celo with 18 decimals', () => {
+      const reserve = getGasReserve('Celo', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Moonbeam with 18 decimals', () => {
+      const reserve = getGasReserve('Moonbeam', 18);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+  });
+
+  describe('Move chains', () => {
+    it('returns 0.01 for Sui with 9 decimals', () => {
+      const reserve = getGasReserve('Sui', 9);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000n); // 0.01 * 10^9
+    });
+
+    it('returns 0.01 for Aptos with 8 decimals', () => {
+      const reserve = getGasReserve('Aptos', 8);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(1000000n); // 0.01 * 10^8
+    });
+  });
+
+  describe('Chains without configured reserves', () => {
+    it('returns undefined for Cosmoshub', () => {
+      const reserve = getGasReserve('Cosmoshub', 6);
+
+      expect(reserve).toBeUndefined();
+    });
+
+    it('returns undefined for Wormchain', () => {
+      const reserve = getGasReserve('Wormchain', 6);
+
+      expect(reserve).toBeUndefined();
+    });
+
+    it('returns undefined for Osmosis', () => {
+      const reserve = getGasReserve('Osmosis', 6);
+
+      expect(reserve).toBeUndefined();
+    });
+  });
+
+  describe('Decimal precision', () => {
+    it('correctly handles different decimal precision for same reserve value', () => {
+      const reserve18 = getGasReserve('Ethereum', 18);
+      const reserve6 = getGasReserve('Ethereum', 6);
+
+      // Both should display as 0.01, but have different base units
+      expect(sdkAmount.display(reserve18!)).toBe('0.01');
+      expect(sdkAmount.display(reserve6!)).toBe('0.01');
+
+      // Base units should differ by 10^12
+      expect(sdkAmount.units(reserve18!)).toBe(10000000000000000n); // 0.01 * 10^18
+      expect(sdkAmount.units(reserve6!)).toBe(10000n); // 0.01 * 10^6
+    });
+
+    it('handles 8-decimal precision (Aptos)', () => {
+      const reserve = getGasReserve('Aptos', 8);
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(1000000n); // 0.01 * 10^8
+    });
+
+    it('handles 9-decimal precision (Solana, Sui)', () => {
+      const reserveSolana = getGasReserve('Solana', 9);
+      const reserveSui = getGasReserve('Sui', 9);
+
+      expect(reserveSolana).toBeDefined();
+      expect(reserveSui).toBeDefined();
+      expect(sdkAmount.display(reserveSolana!)).toBe('0.01');
+      expect(sdkAmount.display(reserveSui!)).toBe('0.01');
+      expect(sdkAmount.units(reserveSolana!)).toBe(10000000n); // 0.01 * 10^9
+      expect(sdkAmount.units(reserveSui!)).toBe(10000000n);
+    });
+  });
+});

--- a/src/utils/gasReserve.test.ts
+++ b/src/utils/gasReserve.test.ts
@@ -37,6 +37,30 @@ describe('getGasReserve', () => {
       expect(sdkAmount.display(reserve!)).toBe('0.001');
       expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
     });
+
+    it('returns 0.001 for Scroll', () => {
+      const reserve = getGasReserve('Scroll');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
+    });
+
+    it('returns 0.001 for Xlayer', () => {
+      const reserve = getGasReserve('Xlayer');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
+    });
+
+    it('returns 0.001 for Mantle', () => {
+      const reserve = getGasReserve('Mantle');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.001');
+      expect(sdkAmount.units(reserve!)).toBe(1000000000000000n);
+    });
   });
 
   describe('Solana', () => {
@@ -99,6 +123,30 @@ describe('getGasReserve', () => {
 
     it('returns 0.01 for Monad', () => {
       const reserve = getGasReserve('Monad');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Klaytn', () => {
+      const reserve = getGasReserve('Klaytn');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
+
+    it('returns 0.01 for Fogo', () => {
+      const reserve = getGasReserve('Fogo');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000n); // 0.01 * 10^9
+    });
+
+    it('returns 0.01 for XRPLEVM', () => {
+      const reserve = getGasReserve('XRPLEVM');
 
       expect(reserve).toBeDefined();
       expect(sdkAmount.display(reserve!)).toBe('0.01');

--- a/src/utils/gasReserve.test.ts
+++ b/src/utils/gasReserve.test.ts
@@ -96,6 +96,14 @@ describe('getGasReserve', () => {
       expect(sdkAmount.display(reserve!)).toBe('0.01');
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
+
+    it('returns 0.01 for Monad', () => {
+      const reserve = getGasReserve('Monad');
+
+      expect(reserve).toBeDefined();
+      expect(sdkAmount.display(reserve!)).toBe('0.01');
+      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+    });
   });
 
   describe('Move chains', () => {

--- a/src/utils/gasReserve.test.ts
+++ b/src/utils/gasReserve.test.ts
@@ -113,12 +113,12 @@ describe('getGasReserve', () => {
       expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
     });
 
-    it('returns 0.01 for Moonbeam', () => {
+    it('returns 0.03 for Moonbeam', () => {
       const reserve = getGasReserve('Moonbeam');
 
       expect(reserve).toBeDefined();
-      expect(sdkAmount.display(reserve!)).toBe('0.01');
-      expect(sdkAmount.units(reserve!)).toBe(10000000000000000n);
+      expect(sdkAmount.display(reserve!)).toBe('0.03');
+      expect(sdkAmount.units(reserve!)).toBe(30000000000000000n);
     });
 
     it('returns 0.01 for Monad', () => {

--- a/src/utils/gasReserve.ts
+++ b/src/utils/gasReserve.ts
@@ -1,43 +1,8 @@
 import type { Chain } from '@wormhole-foundation/sdk';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
+import config from 'config';
 import { getGasToken } from 'utils';
-
-/**
- * Gas reserve amounts to keep when clicking "Max" on gas tokens.
- * These reserves ensure users have enough gas to complete transactions.
- *
- * Values provided by team based on typical transaction costs:
- * - Ethereum: 0.01 ETH ($30 notional)
- * - L2s (Base, Op, Arb): 0.001 ETH ($3 notional)
- * - Other EVM L1s or cheap Move L1s: 0.01 native token
- * - Solana: 0.01 SOL ($1.3 notional)
- */
-const GAS_RESERVES: Partial<Record<Chain, string>> = {
-  // Ethereum mainnet - higher reserve due to higher gas costs
-  Ethereum: '0.01',
-
-  // L2s - lower reserve due to cheaper gas
-  Base: '0.001',
-  Optimism: '0.001',
-  Arbitrum: '0.001',
-
-  // Other EVM L1s - standard reserve
-  Bsc: '0.01',
-  Avalanche: '0.01',
-  Polygon: '0.01',
-  Fantom: '0.01',
-  Celo: '0.01',
-  Moonbeam: '0.01',
-  Monad: '0.01',
-
-  // Solana
-  Solana: '0.01',
-
-  // Move chains
-  Sui: '0.01',
-  Aptos: '0.01',
-};
 
 /**
  * Get the gas reserve amount for a given chain.
@@ -47,7 +12,9 @@ const GAS_RESERVES: Partial<Record<Chain, string>> = {
  * @returns The amount to reserve, or undefined if no reserve configured
  */
 export function getGasReserve(chain: Chain): sdkAmount.Amount | undefined {
-  const reserve = GAS_RESERVES[chain];
+  const chainConfig = config.chains[chain];
+  const reserve = chainConfig?.gasReserve;
+
   if (!reserve) {
     return undefined;
   }

--- a/src/utils/gasReserve.ts
+++ b/src/utils/gasReserve.ts
@@ -29,6 +29,7 @@ const GAS_RESERVES: Partial<Record<Chain, string>> = {
   Fantom: '0.01',
   Celo: '0.01',
   Moonbeam: '0.01',
+  Monad: '0.01',
 
   // Solana
   Solana: '0.01',

--- a/src/utils/gasReserve.ts
+++ b/src/utils/gasReserve.ts
@@ -1,0 +1,57 @@
+import type { Chain } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+
+/**
+ * Gas reserve amounts to keep when clicking "Max" on gas tokens.
+ * These reserves ensure users have enough gas to complete transactions.
+ *
+ * Values provided by team based on typical transaction costs:
+ * - Ethereum: 0.01 ETH ($30 notional)
+ * - L2s (Base, Op, Arb): 0.001 ETH ($3 notional)
+ * - Other EVM L1s or cheap Move L1s: 0.01 native token
+ * - Solana: 0.01 SOL ($1.3 notional)
+ */
+const GAS_RESERVES: Partial<Record<Chain, string>> = {
+  // Ethereum mainnet - higher reserve due to higher gas costs
+  Ethereum: '0.01',
+
+  // L2s - lower reserve due to cheaper gas
+  Base: '0.001',
+  Optimism: '0.001',
+  Arbitrum: '0.001',
+
+  // Other EVM L1s - standard reserve
+  Bsc: '0.01',
+  Avalanche: '0.01',
+  Polygon: '0.01',
+  Fantom: '0.01',
+  Celo: '0.01',
+  Moonbeam: '0.01',
+
+  // Solana
+  Solana: '0.01',
+
+  // Move chains
+  Sui: '0.01',
+  Aptos: '0.01',
+};
+
+/**
+ * Get the gas reserve amount for a given chain.
+ * Returns undefined if no reserve is configured for the chain.
+ *
+ * @param chain - The source chain
+ * @param decimals - The token decimals
+ * @returns The amount to reserve, or undefined if no reserve configured
+ */
+export function getGasReserve(
+  chain: Chain,
+  decimals: number,
+): sdkAmount.Amount | undefined {
+  const reserve = GAS_RESERVES[chain];
+  if (!reserve) {
+    return undefined;
+  }
+
+  return sdkAmount.parse(reserve, decimals);
+}

--- a/src/utils/gasReserve.ts
+++ b/src/utils/gasReserve.ts
@@ -1,6 +1,8 @@
 import type { Chain } from '@wormhole-foundation/sdk';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
+import { getGasToken } from 'utils';
+
 /**
  * Gas reserve amounts to keep when clicking "Max" on gas tokens.
  * These reserves ensure users have enough gas to complete transactions.
@@ -41,17 +43,19 @@ const GAS_RESERVES: Partial<Record<Chain, string>> = {
  * Returns undefined if no reserve is configured for the chain.
  *
  * @param chain - The source chain
- * @param decimals - The token decimals
  * @returns The amount to reserve, or undefined if no reserve configured
  */
-export function getGasReserve(
-  chain: Chain,
-  decimals: number,
-): sdkAmount.Amount | undefined {
+export function getGasReserve(chain: Chain): sdkAmount.Amount | undefined {
   const reserve = GAS_RESERVES[chain];
   if (!reserve) {
     return undefined;
   }
 
-  return sdkAmount.parse(reserve, decimals);
+  try {
+    const gasToken = getGasToken(chain);
+    return sdkAmount.parse(reserve, gasToken.decimals);
+  } catch {
+    // If gas token is not configured for this chain, return undefined
+    return undefined;
+  }
 }

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
@@ -269,7 +269,7 @@ describe('PercentButtons', () => {
   });
 
   describe('Insufficient balance handling', () => {
-    it('does not set amount when balance is less than gas reserve', async () => {
+    it('shows tooltip on click when balance is less than or equal to gas reserve', async () => {
       const store = createMockStore();
       const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
       const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
@@ -291,20 +291,128 @@ describe('PercentButtons', () => {
 
       const propsWithLowBalance = {
         ...defaultProps,
-        tokenBalance: sdkAmount.fromBaseUnits(10000000000000000n, 18), // 0.01 ETH
+        tokenBalance: sdkAmount.fromBaseUnits(10000000000000000n, 18), // 0.01 ETH (less than 0.02 reserve)
       };
 
       render(<PercentButtons {...propsWithLowBalance} />, {
         wrapper: AppWrapper(store),
       });
 
-      const buttonMax = screen.getByText('Max');
-      fireEvent.click(buttonMax);
+      const buttonMax = screen.getByText('Max').closest('button');
 
-      // Should NOT call amount change handlers when balance is insufficient
+      // Max button should NOT be disabled
+      expect(buttonMax).not.toBeDisabled();
+
+      // Click the button
+      fireEvent.click(buttonMax!);
+
+      // Should NOT call amount change handlers when insufficient balance
       expect(mockOnAmountChange).not.toHaveBeenCalled();
       expect(mockOnDebouncedAmountChange).not.toHaveBeenCalled();
       expect(mockOnPercentSelect).not.toHaveBeenCalled();
+
+      // Should show error tooltip (check for visible tooltip content)
+      expect(
+        screen.getByRole('tooltip', {
+          name: /You don't have enough funds in your wallet to cover both this amount and the gas cost of the transfer/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('shows tooltip only for the specific button clicked', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const gasReserve = sdkAmount.fromBaseUnits(20000000000000000n, 18); // 0.02 ETH
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(gasReserve);
+      getGasToken.mockReturnValue(mockToken);
+      isSameToken.mockReturnValue(true);
+      useGetTokens.mockReturnValue({
+        sourceToken: mockToken,
+        destToken: undefined,
+      } as any);
+
+      const propsWithLowBalance = {
+        ...defaultProps,
+        tokenBalance: sdkAmount.fromBaseUnits(10000000000000000n, 18), // 0.01 ETH (less than 0.02 reserve)
+      };
+
+      render(<PercentButtons {...propsWithLowBalance} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const button50 = screen.getByText('50%').closest('button');
+
+      // Click the 50% button
+      fireEvent.click(button50!);
+
+      // Only the 50% button should have the error tooltip (check for visible tooltip with role="tooltip")
+      const tooltips = screen.queryAllByRole('tooltip', {
+        name: /You don't have enough funds in your wallet to cover both this amount and the gas cost of the transfer/i,
+      });
+      expect(tooltips).toHaveLength(1);
+    });
+
+    it('does not show error tooltip for non-gas tokens with insufficient balance', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const usdcToken = createMockToken({
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        chain: 'Ethereum',
+        addressString: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      });
+
+      const gasReserve = sdkAmount.fromBaseUnits(20000000000000000n, 18); // 0.02 ETH
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(gasReserve);
+      getGasToken.mockReturnValue(mockToken); // ETH
+      isSameToken.mockReturnValue(false); // USDC !== ETH
+      useGetTokens.mockReturnValue({
+        sourceToken: usdcToken,
+        destToken: undefined,
+      } as any);
+
+      const propsWithLowBalance = {
+        ...defaultProps,
+        tokenBalance: sdkAmount.fromBaseUnits(1000n, 6), // 0.001 USDC (very low balance)
+      };
+
+      render(<PercentButtons {...propsWithLowBalance} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max').closest('button');
+
+      // Click the button
+      fireEvent.click(buttonMax!);
+
+      // Should call amount change handlers (no error tooltip for non-gas tokens)
+      expect(mockOnAmountChange).toHaveBeenCalled();
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalled();
+      expect(mockOnPercentSelect).toHaveBeenCalled();
+
+      // Should NOT show error tooltip
+      expect(
+        screen.queryByRole('tooltip', {
+          name: /You don't have enough funds in your wallet to cover both this amount and the gas cost of the transfer/i,
+        }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
@@ -1,0 +1,386 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { configureStore } from '@reduxjs/toolkit';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+
+import PercentButtons from './PercentButtons';
+import { dark } from 'theme';
+import { createMockToken } from 'utils/testHelpers';
+
+const theme = createTheme({
+  palette: dark as any,
+});
+
+// Mock the hooks and utilities
+vi.mock('hooks/useGetTokens', () => ({
+  useGetTokens: vi.fn(() => ({
+    sourceToken: undefined,
+    destToken: undefined,
+  })),
+}));
+
+vi.mock('utils/fees', () => ({
+  calculateFeeOffset: vi.fn(),
+}));
+
+vi.mock('utils/gasReserve', () => ({
+  getGasReserve: vi.fn(),
+}));
+
+vi.mock('utils', () => ({
+  getGasToken: vi.fn(),
+  getTokenDisplaySymbolByTokenAddress: vi.fn((token) => token.symbol),
+}));
+
+vi.mock('@wormhole-foundation/sdk', async () => {
+  const actual = await vi.importActual('@wormhole-foundation/sdk');
+  return {
+    ...actual,
+    isSameToken: vi.fn(),
+  };
+});
+
+vi.mock('config', () => ({
+  default: {
+    routes: {
+      get: vi.fn(),
+    },
+  },
+}));
+
+const mockToken = createMockToken({
+  symbol: 'ETH',
+  name: 'Ethereum',
+  decimals: 18,
+  chain: 'Ethereum',
+  addressString: '0x0000000000000000000000000000000000000000',
+});
+
+const createMockStore = (route?: string) =>
+  configureStore({
+    reducer: {
+      transferInput: () => ({
+        route,
+      }),
+    },
+  });
+
+const AppWrapper =
+  (store: any) =>
+  ({ children }: { children: React.ReactNode }) =>
+    (
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>{children}</ThemeProvider>
+      </Provider>
+    );
+
+describe('PercentButtons', () => {
+  const mockOnAmountChange = vi.fn();
+  const mockOnDebouncedAmountChange = vi.fn();
+  const mockOnPercentSelect = vi.fn();
+
+  const defaultProps = {
+    tokenBalance: sdkAmount.fromBaseUnits(1000000000000000000n, 18), // 1 ETH
+    chain: 'Ethereum' as const,
+    isTransactionInProgress: false,
+    selectedPercent: 0,
+    onAmountChange: mockOnAmountChange,
+    onDebouncedAmountChange: mockOnDebouncedAmountChange,
+    onPercentSelect: mockOnPercentSelect,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders 25%, 50%, and Max buttons', () => {
+      const store = createMockStore();
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      expect(screen.getByText('25%')).toBeInTheDocument();
+      expect(screen.getByText('50%')).toBeInTheDocument();
+      expect(screen.getByText('Max')).toBeInTheDocument();
+    });
+  });
+
+  describe('Basic percentage calculation', () => {
+    it('calculates 25% of balance when clicking 25% button', async () => {
+      const store = createMockStore();
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const button25 = screen.getByText('25%');
+      fireEvent.click(button25);
+
+      expect(mockOnAmountChange).toHaveBeenCalledWith('0.25');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.25');
+      expect(mockOnPercentSelect).toHaveBeenCalledWith(25);
+    });
+
+    it('calculates 50% of balance when clicking 50% button', () => {
+      const store = createMockStore();
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const button50 = screen.getByText('50%');
+      fireEvent.click(button50);
+
+      expect(mockOnAmountChange).toHaveBeenCalledWith('0.5');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.5');
+      expect(mockOnPercentSelect).toHaveBeenCalledWith(50);
+    });
+
+    it('calculates 100% of balance when clicking Max button without offsets', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(undefined);
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      expect(mockOnAmountChange).toHaveBeenCalledWith('1');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('1');
+      expect(mockOnPercentSelect).toHaveBeenCalledWith(100);
+    });
+  });
+
+  describe('Fee offset subtraction', () => {
+    it('subtracts fee offset from Max amount when route has fees', async () => {
+      const store = createMockStore('MayanRoute');
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+
+      const feeOffset = sdkAmount.fromBaseUnits(10000000000000000n, 18); // 0.01 ETH
+      calculateFeeOffset.mockReturnValue(feeOffset);
+      getGasReserve.mockReturnValue(undefined);
+      useGetTokens.mockReturnValue({
+        sourceToken: mockToken,
+        destToken: mockToken,
+      } as any);
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      // 1 ETH - 0.01 ETH fee = 0.99 ETH
+      expect(mockOnAmountChange).toHaveBeenCalledWith('0.99');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.99');
+    });
+  });
+
+  describe('Gas reserve subtraction', () => {
+    it('subtracts gas reserve from Max amount for gas tokens', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const gasReserve = sdkAmount.fromBaseUnits(10000000000000000n, 18); // 0.01 ETH
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(gasReserve);
+      getGasToken.mockReturnValue(mockToken);
+      isSameToken.mockReturnValue(true);
+      useGetTokens.mockReturnValue({
+        sourceToken: mockToken,
+        destToken: undefined,
+      } as any);
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      // 1 ETH - 0.01 ETH gas reserve = 0.99 ETH
+      expect(mockOnAmountChange).toHaveBeenCalledWith('0.99');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.99');
+    });
+
+    it('does not subtract gas reserve for non-gas tokens', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const usdcToken = createMockToken({
+        symbol: 'USDC',
+        name: 'USD Coin',
+        decimals: 6,
+        chain: 'Ethereum',
+        addressString: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      });
+
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(sdkAmount.fromBaseUnits(10000n, 6)); // 0.01 USDC
+      getGasToken.mockReturnValue(mockToken); // ETH
+      isSameToken.mockReturnValue(false); // USDC !== ETH
+      useGetTokens.mockReturnValue({
+        sourceToken: usdcToken,
+        destToken: undefined,
+      } as any);
+
+      const propsWithUSDC = {
+        ...defaultProps,
+        tokenBalance: sdkAmount.fromBaseUnits(1000000n, 6), // 1 USDC
+      };
+
+      render(<PercentButtons {...propsWithUSDC} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      // Full balance, no gas reserve deducted
+      expect(mockOnAmountChange).toHaveBeenCalledWith('1');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('1');
+    });
+  });
+
+  describe('Insufficient balance handling', () => {
+    it('does not set amount when balance is less than gas reserve', async () => {
+      const store = createMockStore();
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const gasReserve = sdkAmount.fromBaseUnits(20000000000000000n, 18); // 0.02 ETH
+      calculateFeeOffset.mockReturnValue(undefined);
+      getGasReserve.mockReturnValue(gasReserve);
+      getGasToken.mockReturnValue(mockToken);
+      isSameToken.mockReturnValue(true);
+      useGetTokens.mockReturnValue({
+        sourceToken: mockToken,
+        destToken: undefined,
+      } as any);
+
+      const propsWithLowBalance = {
+        ...defaultProps,
+        tokenBalance: sdkAmount.fromBaseUnits(10000000000000000n, 18), // 0.01 ETH
+      };
+
+      render(<PercentButtons {...propsWithLowBalance} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      // Should NOT call amount change handlers when balance is insufficient
+      expect(mockOnAmountChange).not.toHaveBeenCalled();
+      expect(mockOnDebouncedAmountChange).not.toHaveBeenCalled();
+      expect(mockOnPercentSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Combined offsets', () => {
+    it('subtracts both fee offset and gas reserve from Max amount', async () => {
+      const store = createMockStore('MayanRoute');
+      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
+      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
+      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
+      const { getGasToken } = vi.mocked(await import('utils'));
+      const { isSameToken } = vi.mocked(
+        await import('@wormhole-foundation/sdk'),
+      );
+
+      const feeOffset = sdkAmount.fromBaseUnits(5000000000000000n, 18); // 0.005 ETH
+      const gasReserve = sdkAmount.fromBaseUnits(10000000000000000n, 18); // 0.01 ETH
+      calculateFeeOffset.mockReturnValue(feeOffset);
+      getGasReserve.mockReturnValue(gasReserve);
+      getGasToken.mockReturnValue(mockToken);
+      isSameToken.mockReturnValue(true);
+      useGetTokens.mockReturnValue({
+        sourceToken: mockToken,
+        destToken: mockToken,
+      } as any);
+
+      render(<PercentButtons {...defaultProps} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const buttonMax = screen.getByText('Max');
+      fireEvent.click(buttonMax);
+
+      // 1 ETH - 0.005 ETH fee - 0.01 ETH gas = 0.985 ETH
+      expect(mockOnAmountChange).toHaveBeenCalledWith('0.985');
+      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.985');
+    });
+  });
+
+  describe('Button states', () => {
+    it('disables all buttons when transaction is in progress', () => {
+      const store = createMockStore();
+      const propsWithInProgress = {
+        ...defaultProps,
+        isTransactionInProgress: true,
+      };
+
+      render(<PercentButtons {...propsWithInProgress} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const button25 = screen.getByText('25%');
+      const button50 = screen.getByText('50%');
+      const buttonMax = screen.getByText('Max');
+
+      expect(button25.closest('button')).toBeDisabled();
+      expect(button50.closest('button')).toBeDisabled();
+      expect(buttonMax.closest('button')).toBeDisabled();
+    });
+
+    it('applies selected styles to the selected button', () => {
+      const store = createMockStore();
+      const propsWithSelected = {
+        ...defaultProps,
+        selectedPercent: 50,
+      };
+
+      render(<PercentButtons {...propsWithSelected} />, {
+        wrapper: AppWrapper(store),
+      });
+
+      const button50 = screen.getByText('50%').closest('button');
+
+      // Selected button should have the primary background color
+      expect(button50).toHaveStyle({
+        backgroundColor: theme.palette.primary.main,
+      });
+    });
+  });
+});

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.test.tsx
@@ -48,6 +48,11 @@ vi.mock('config', () => ({
     routes: {
       get: vi.fn(),
     },
+    ui: {
+      experimental: {
+        feeOffsetting: false,
+      },
+    },
   },
 }));
 
@@ -159,34 +164,6 @@ describe('PercentButtons', () => {
       expect(mockOnAmountChange).toHaveBeenCalledWith('1');
       expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('1');
       expect(mockOnPercentSelect).toHaveBeenCalledWith(100);
-    });
-  });
-
-  describe('Fee offset subtraction', () => {
-    it('subtracts fee offset from Max amount when route has fees', async () => {
-      const store = createMockStore('MayanRoute');
-      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
-      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
-      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
-
-      const feeOffset = sdkAmount.fromBaseUnits(10000000000000000n, 18); // 0.01 ETH
-      calculateFeeOffset.mockReturnValue(feeOffset);
-      getGasReserve.mockReturnValue(undefined);
-      useGetTokens.mockReturnValue({
-        sourceToken: mockToken,
-        destToken: mockToken,
-      } as any);
-
-      render(<PercentButtons {...defaultProps} />, {
-        wrapper: AppWrapper(store),
-      });
-
-      const buttonMax = screen.getByText('Max');
-      fireEvent.click(buttonMax);
-
-      // 1 ETH - 0.01 ETH fee = 0.99 ETH
-      expect(mockOnAmountChange).toHaveBeenCalledWith('0.99');
-      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.99');
     });
   });
 
@@ -413,41 +390,6 @@ describe('PercentButtons', () => {
           name: /You don't have enough funds in your wallet to cover both this amount and the gas cost of the transfer/i,
         }),
       ).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Combined offsets', () => {
-    it('subtracts both fee offset and gas reserve from Max amount', async () => {
-      const store = createMockStore('MayanRoute');
-      const { calculateFeeOffset } = vi.mocked(await import('utils/fees'));
-      const { getGasReserve } = vi.mocked(await import('utils/gasReserve'));
-      const { useGetTokens } = vi.mocked(await import('hooks/useGetTokens'));
-      const { getGasToken } = vi.mocked(await import('utils'));
-      const { isSameToken } = vi.mocked(
-        await import('@wormhole-foundation/sdk'),
-      );
-
-      const feeOffset = sdkAmount.fromBaseUnits(5000000000000000n, 18); // 0.005 ETH
-      const gasReserve = sdkAmount.fromBaseUnits(10000000000000000n, 18); // 0.01 ETH
-      calculateFeeOffset.mockReturnValue(feeOffset);
-      getGasReserve.mockReturnValue(gasReserve);
-      getGasToken.mockReturnValue(mockToken);
-      isSameToken.mockReturnValue(true);
-      useGetTokens.mockReturnValue({
-        sourceToken: mockToken,
-        destToken: mockToken,
-      } as any);
-
-      render(<PercentButtons {...defaultProps} />, {
-        wrapper: AppWrapper(store),
-      });
-
-      const buttonMax = screen.getByText('Max');
-      fireEvent.click(buttonMax);
-
-      // 1 ETH - 0.005 ETH fee - 0.01 ETH gas = 0.985 ETH
-      expect(mockOnAmountChange).toHaveBeenCalledWith('0.985');
-      expect(mockOnDebouncedAmountChange).toHaveBeenCalledWith('0.985');
     });
   });
 

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
@@ -1,6 +1,13 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { Box, Button, Typography, useTheme } from '@mui/material';
+import {
+  Box,
+  Button,
+  ClickAwayListener,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
 import type { Chain } from '@wormhole-foundation/sdk';
 import { amount as sdkAmount, isSameToken } from '@wormhole-foundation/sdk';
 
@@ -23,12 +30,20 @@ type Props = {
 
 const PERCENT_VALUES = [25, 50, 100];
 
+const INSUFFICIENT_FUNDS_MESSAGE =
+  "You don't have enough funds in your wallet to cover both this amount and the gas cost of the transfer.";
+const GAS_RESERVE_INFO_MESSAGE =
+  'A small amount of the network token balance is reserved to cover the network cost of this transaction.';
+
 function PercentButtons(props: Props) {
   const theme: any = useTheme();
   const { route: selectedRoute } = useSelector(
     (state: RootState) => state.transferInput,
   );
   const { sourceToken, destToken } = useGetTokens();
+  const [showInsufficientTooltip, setShowInsufficientTooltip] = useState<
+    number | undefined
+  >(undefined);
 
   const styles = useMemo(
     () => ({
@@ -49,94 +64,176 @@ function PercentButtons(props: Props) {
     [theme],
   );
 
-  const renderPercentButton = useCallback(
-    (percent: number) => (
-      <Button
-        sx={{
-          ...styles.percentButton,
-          ...(props.selectedPercent === percent
-            ? styles.percentButtonSelected
-            : {}),
-        }}
-        disabled={props.isTransactionInProgress}
-        onClick={() => {
-          if (props.tokenBalance) {
-            // Calculate the desired amount for the selected percentage
-            let amountInBaseUnits =
-              (sdkAmount.units(props.tokenBalance) * BigInt(percent)) /
-              BigInt(100);
+  // Check if the selected token is the gas token for the chain
+  const isGasToken = useMemo(() => {
+    if (!sourceToken || !props.chain) {
+      return false;
+    }
+    try {
+      const gasToken = getGasToken(props.chain);
+      return isSameToken(sourceToken, gasToken);
+    } catch {
+      return false;
+    }
+  }, [sourceToken, props.chain]);
 
-            if (percent === 100) {
-              // User clicks "Max" when fee-offsetting is enabled.
-              // We need to subtract the fee offset amount from the balance
-              // This is to ensure user doesn't get insufficient funds error when fee offset is applied
-              // 1. Fee offset for referral fees
-              if (
-                config.ui?.experimental?.feeOffsetting &&
-                selectedRoute &&
-                sourceToken &&
-                destToken
-              ) {
-                const feeOffset = calculateFeeOffset(
-                  config.routes.get(selectedRoute),
-                  props.tokenBalance,
-                  sourceToken,
-                  destToken,
-                );
-                if (feeOffset) {
-                  amountInBaseUnits -= sdkAmount.units(feeOffset);
-                }
-              }
+  // Check if user has insufficient balance for gas reserve
+  const hasInsufficientGasReserve = useMemo(() => {
+    if (!props.tokenBalance || !props.chain || !isGasToken) {
+      return false;
+    }
 
-              // 2. Gas reserve for gas tokens
-              if (sourceToken && props.chain) {
-                try {
-                  const gasToken = getGasToken(props.chain);
-                  if (isSameToken(sourceToken, gasToken)) {
-                    const gasReserve = getGasReserve(
-                      props.chain,
-                      props.tokenBalance.decimals,
-                    );
-                    if (gasReserve) {
-                      amountInBaseUnits -= sdkAmount.units(gasReserve);
+    const gasReserve = getGasReserve(props.chain, props.tokenBalance.decimals);
+    if (!gasReserve) {
+      return false;
+    }
 
-                      // If balance is insufficient after subtracting gas reserve, don't set amount
-                      if (amountInBaseUnits <= 0n) {
-                        return;
-                      }
-                    }
-                  }
-                } catch {
-                  // Gas token not found for chain, proceed without reserve
-                }
-              }
-            }
+    // Disable Max if balance is less than or equal to gas reserve
+    return sdkAmount.units(props.tokenBalance) <= sdkAmount.units(gasReserve);
+  }, [props.tokenBalance, props.chain, isGasToken]);
 
-            const displayAmount = sdkAmount.display(
-              sdkAmount.fromBaseUnits(
-                amountInBaseUnits,
-                props.tokenBalance.decimals,
-              ),
-            );
-            props.onAmountChange(displayAmount);
-            props.onDebouncedAmountChange(displayAmount);
-            props.onPercentSelect(percent);
+  // Calculate the amount for a given percentage
+  const calculatePercentAmount = useCallback(
+    (percent: number): string | null => {
+      if (!props.tokenBalance) {
+        return null;
+      }
+
+      let amountInBaseUnits =
+        (sdkAmount.units(props.tokenBalance) * BigInt(percent)) / BigInt(100);
+
+      if (percent === 100) {
+        // User clicks "Max" when fee-offsetting is enabled.
+        // We need to subtract the fee offset amount from the balance
+        // This is to ensure user doesn't get insufficient funds error when fee offset is applied
+        // 1. Fee offset for referral fees
+        if (
+          config.ui?.experimental?.feeOffsetting &&
+          selectedRoute &&
+          sourceToken &&
+          destToken
+        ) {
+          const feeOffset = calculateFeeOffset(
+            config.routes.get(selectedRoute),
+            props.tokenBalance,
+            sourceToken,
+            destToken,
+          );
+          if (feeOffset) {
+            amountInBaseUnits -= sdkAmount.units(feeOffset);
           }
-        }}
-      >
-        <Typography fontSize={12} fontWeight={600} textTransform="none">
-          {percent === 100 ? 'Max' : `${percent}%`}
-        </Typography>
-      </Button>
-    ),
+        }
+
+        // 2. Gas reserve for gas tokens
+        if (isGasToken && props.chain) {
+          const gasReserve = getGasReserve(
+            props.chain,
+            props.tokenBalance.decimals,
+          );
+          if (gasReserve) {
+            amountInBaseUnits -= sdkAmount.units(gasReserve);
+          }
+        }
+      }
+
+      return sdkAmount.display(
+        sdkAmount.fromBaseUnits(amountInBaseUnits, props.tokenBalance.decimals),
+      );
+    },
     [
-      styles.percentButton,
-      styles.percentButtonSelected,
-      props,
+      props.tokenBalance,
+      props.chain,
       selectedRoute,
       sourceToken,
       destToken,
+      isGasToken,
     ],
+  );
+
+  // Handle click on percent button
+  const handlePercentClick = useCallback(
+    (event: React.MouseEvent, percent: number) => {
+      event.stopPropagation();
+
+      // Show tooltip for insufficient balance
+      if (hasInsufficientGasReserve && isGasToken) {
+        setShowInsufficientTooltip(percent);
+        return;
+      }
+
+      // Calculate and set amount
+      const amount = calculatePercentAmount(percent);
+      if (amount) {
+        props.onAmountChange(amount);
+        props.onDebouncedAmountChange(amount);
+        props.onPercentSelect(percent);
+      }
+    },
+    [hasInsufficientGasReserve, isGasToken, calculatePercentAmount, props],
+  );
+
+  // Wrap button with appropriate tooltip
+  const renderPercentButtonWithTooltip = useCallback(
+    (button: React.ReactElement, percent: number) => {
+      if (!isGasToken) {
+        return button;
+      }
+
+      if (hasInsufficientGasReserve) {
+        return (
+          <ClickAwayListener
+            onClickAway={() => setShowInsufficientTooltip(undefined)}
+          >
+            <Tooltip
+              open={showInsufficientTooltip === percent}
+              onClose={() => setShowInsufficientTooltip(undefined)}
+              title={INSUFFICIENT_FUNDS_MESSAGE}
+              arrow
+              disableFocusListener
+              disableHoverListener
+              disableTouchListener
+            >
+              {button}
+            </Tooltip>
+          </ClickAwayListener>
+        );
+      }
+
+      if (percent === 100) {
+        return (
+          <Tooltip title={GAS_RESERVE_INFO_MESSAGE} arrow>
+            {button}
+          </Tooltip>
+        );
+      }
+
+      return button;
+    },
+    [isGasToken, hasInsufficientGasReserve, showInsufficientTooltip],
+  );
+
+  const renderPercentButton = useCallback(
+    (percent: number) => {
+      const button = (
+        <Button
+          sx={{
+            ...styles.percentButton,
+            ...(props.selectedPercent === percent
+              ? styles.percentButtonSelected
+              : {}),
+          }}
+          disabled={props.isTransactionInProgress}
+          onClick={(e) => handlePercentClick(e, percent)}
+        >
+          <Typography fontSize={12} fontWeight={600} textTransform="none">
+            {percent === 100 ? 'Max' : `${percent}%`}
+          </Typography>
+        </Button>
+      );
+
+      return renderPercentButtonWithTooltip(button, percent);
+    },
+    [styles, props, handlePercentClick, renderPercentButtonWithTooltip],
   );
 
   return (

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
@@ -83,7 +83,7 @@ function PercentButtons(props: Props) {
       return false;
     }
 
-    const gasReserve = getGasReserve(props.chain, props.tokenBalance.decimals);
+    const gasReserve = getGasReserve(props.chain);
     if (!gasReserve) {
       return false;
     }
@@ -126,10 +126,7 @@ function PercentButtons(props: Props) {
 
         // 2. Gas reserve for gas tokens
         if (isGasToken && props.chain) {
-          const gasReserve = getGasReserve(
-            props.chain,
-            props.tokenBalance.decimals,
-          );
+          const gasReserve = getGasReserve(props.chain);
           if (gasReserve) {
             amountInBaseUnits -= sdkAmount.units(gasReserve);
           }

--- a/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
+++ b/src/views/v3/Bridge/AssetPicker/PercentButtons.tsx
@@ -1,0 +1,153 @@
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { Box, Button, Typography, useTheme } from '@mui/material';
+import type { Chain } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount, isSameToken } from '@wormhole-foundation/sdk';
+
+import config from 'config';
+import type { RootState } from 'store';
+import { calculateFeeOffset } from 'utils/fees';
+import { getGasReserve } from 'utils/gasReserve';
+import { getGasToken } from 'utils';
+import { useGetTokens } from 'hooks/useGetTokens';
+
+type Props = {
+  tokenBalance: sdkAmount.Amount | null;
+  chain?: Chain;
+  isTransactionInProgress: boolean;
+  selectedPercent: number;
+  onAmountChange: (amount: string) => void;
+  onDebouncedAmountChange: (amount: string) => void;
+  onPercentSelect: (percent: number) => void;
+};
+
+const PERCENT_VALUES = [25, 50, 100];
+
+function PercentButtons(props: Props) {
+  const theme: any = useTheme();
+  const { route: selectedRoute } = useSelector(
+    (state: RootState) => state.transferInput,
+  );
+  const { sourceToken, destToken } = useGetTokens();
+
+  const styles = useMemo(
+    () => ({
+      percentButton: {
+        borderRadius: '50px',
+        color: theme.palette.text.primary,
+        height: '22px',
+        minWidth: '36px',
+        padding: '0 8px',
+        opacity: 0.7,
+      },
+      percentButtonSelected: {
+        color: theme.palette.formContainer.background,
+        backgroundColor: theme.palette.primary.main,
+        opacity: 'unset',
+      },
+    }),
+    [theme],
+  );
+
+  const renderPercentButton = useCallback(
+    (percent: number) => (
+      <Button
+        sx={{
+          ...styles.percentButton,
+          ...(props.selectedPercent === percent
+            ? styles.percentButtonSelected
+            : {}),
+        }}
+        disabled={props.isTransactionInProgress}
+        onClick={() => {
+          if (props.tokenBalance) {
+            // Calculate the desired amount for the selected percentage
+            let amountInBaseUnits =
+              (sdkAmount.units(props.tokenBalance) * BigInt(percent)) /
+              BigInt(100);
+
+            if (percent === 100) {
+              // User clicks "Max" when fee-offsetting is enabled.
+              // We need to subtract the fee offset amount from the balance
+              // This is to ensure user doesn't get insufficient funds error when fee offset is applied
+              // 1. Fee offset for referral fees
+              if (
+                config.ui?.experimental?.feeOffsetting &&
+                selectedRoute &&
+                sourceToken &&
+                destToken
+              ) {
+                const feeOffset = calculateFeeOffset(
+                  config.routes.get(selectedRoute),
+                  props.tokenBalance,
+                  sourceToken,
+                  destToken,
+                );
+                if (feeOffset) {
+                  amountInBaseUnits -= sdkAmount.units(feeOffset);
+                }
+              }
+
+              // 2. Gas reserve for gas tokens
+              if (sourceToken && props.chain) {
+                try {
+                  const gasToken = getGasToken(props.chain);
+                  if (isSameToken(sourceToken, gasToken)) {
+                    const gasReserve = getGasReserve(
+                      props.chain,
+                      props.tokenBalance.decimals,
+                    );
+                    if (gasReserve) {
+                      amountInBaseUnits -= sdkAmount.units(gasReserve);
+
+                      // If balance is insufficient after subtracting gas reserve, don't set amount
+                      if (amountInBaseUnits <= 0n) {
+                        return;
+                      }
+                    }
+                  }
+                } catch {
+                  // Gas token not found for chain, proceed without reserve
+                }
+              }
+            }
+
+            const displayAmount = sdkAmount.display(
+              sdkAmount.fromBaseUnits(
+                amountInBaseUnits,
+                props.tokenBalance.decimals,
+              ),
+            );
+            props.onAmountChange(displayAmount);
+            props.onDebouncedAmountChange(displayAmount);
+            props.onPercentSelect(percent);
+          }
+        }}
+      >
+        <Typography fontSize={12} fontWeight={600} textTransform="none">
+          {percent === 100 ? 'Max' : `${percent}%`}
+        </Typography>
+      </Button>
+    ),
+    [
+      styles.percentButton,
+      styles.percentButtonSelected,
+      props,
+      selectedRoute,
+      sourceToken,
+      destToken,
+    ],
+  );
+
+  return (
+    <Box sx={{ display: 'flex', gap: '6px' }}>
+      {PERCENT_VALUES.map((percent) => (
+        <React.Fragment key={percent}>
+          {renderPercentButton(percent)}
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+}
+
+export default React.memo(PercentButtons);

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -296,6 +296,17 @@ function AssetPicker(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amount]);
 
+  // Clear amount when source wallet address changes (user connects/disconnects/switches wallet)
+  useEffect(() => {
+    if (props.isSource && (amountInput || debouncedAmountInput)) {
+      handleAmountChange('');
+      handleDebouncedAmountChange('');
+      setSelectedPercentButton(0);
+    }
+    // Re-run only when wallet address changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [props.wallet.address]);
+
   // Adjust amount when route changes if user had clicked Max button previously
   // This handles both cases:
   // 1. Switching from non-fee-offset route to fee-offset route: deduct fee offset

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -2,11 +2,10 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, TextField, useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import Button from '@mui/material/Button';
 import { usePopupState, bindTrigger } from 'material-ui-popup-state/hooks';
 import Typography from '@mui/material/Typography';
 import type { Chain, routes } from '@wormhole-foundation/sdk';
-import { amount as sdkAmount, isSameToken } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
 import config from 'config';
 import type { ChainConfig } from 'config/types';
@@ -24,21 +23,17 @@ import type { AmountValidationResult } from 'hooks/useAmountValidation';
 import { OPACITY } from 'utils/style';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
-import {
-  calculateUSDPrice,
-  getTokenDisplaySymbolByTokenAddress,
-  getGasToken,
-} from 'utils';
 import { formatNumberIntl, formatMaxDigits } from 'utils/formatNumber';
+import { calculateUSDPrice, getTokenDisplaySymbolByTokenAddress } from 'utils';
 import {
   handleTelemetryOnChainSelect,
   handleTelemetryOnTokenSelect,
 } from 'telemetry/utils';
 import FeeOffset from './FeeOffset';
 import { calculateFeeOffset } from 'utils/fees';
-import { getGasReserve } from 'utils/gasReserve';
 import { useGetTokens } from 'hooks/useGetTokens';
 import TokenPickerButton from './TokenPickerButton';
+import PercentButtons from './PercentButtons';
 
 type Props = {
   chain?: Chain | undefined;
@@ -83,9 +78,6 @@ function AssetPicker(props: Props) {
     amount ? sdkAmount.display(amount) : '',
   );
   const [selectedPercentButton, setSelectedPercentButton] = useState(0);
-  const [gasReserveError, setGasReserveError] = useState<string | undefined>(
-    undefined,
-  );
 
   const sortedTokens = useTokenList({
     tokenList: props.tokenList || [],
@@ -198,19 +190,6 @@ function AssetPicker(props: Props) {
         justifyContent: 'space-between',
         marginBottom: '16px',
       },
-      percentButton: {
-        borderRadius: '50px',
-        color: theme.palette.text.primary,
-        height: '22px',
-        minWidth: '40px',
-        backgroundColor: theme.palette.text.primary + OPACITY[10],
-        opacity: 0.7,
-      },
-      percentButtonSelected: {
-        color: theme.palette.formContainer.background,
-        backgroundColor: theme.palette.primary.main,
-        opacity: 'unset',
-      },
     }),
     [theme],
   );
@@ -252,7 +231,6 @@ function AssetPicker(props: Props) {
     (newValue: string): void => {
       setAmountInput(newValue);
       setSelectedPercentButton(0); // Reset selected percent button when amount changes
-      setGasReserveError(undefined); // Clear gas reserve error when user manually changes amount
 
       if (!newValue) {
         // If the input is cleared, we need to clear the amount in handleAmountChange instead of handleDebouncedAmountChange.
@@ -366,107 +344,6 @@ function AssetPicker(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRoute]);
 
-  const renderPercentButton = useCallback(
-    (percent: number) => (
-      <Button
-        sx={{
-          ...styles.percentButton,
-          ...(selectedPercentButton === percent
-            ? styles.percentButtonSelected
-            : {}),
-        }}
-        disabled={props.isTransactionInProgress}
-        onClick={() => {
-          if (tokenBalance) {
-            // Calculate the desired amount for the selected percentage
-            let amountInBaseUnits =
-              (sdkAmount.units(tokenBalance) * BigInt(percent)) / BigInt(100);
-
-            if (percent === 100) {
-              // User clicks "Max" when fee-offsetting is enabled.
-              // We need to subtract the fee offset amount from the balance
-              // This is to ensure user doesn't get insufficient funds error when fee offset is applied
-              // 1. Fee offset for referral fees
-              if (
-                config.ui?.experimental?.feeOffsetting &&
-                selectedRoute &&
-                sourceToken &&
-                destToken
-              ) {
-                const feeOffset = calculateFeeOffset(
-                  config.routes.get(selectedRoute),
-                  tokenBalance,
-                  sourceToken,
-                  destToken,
-                );
-                if (feeOffset) {
-                  amountInBaseUnits -= sdkAmount.units(feeOffset);
-                }
-              }
-
-              // 2. Gas reserve for gas tokens (only for source asset picker)
-              if (props.isSource && sourceToken && props.chain) {
-                try {
-                  const gasToken = getGasToken(props.chain);
-                  if (isSameToken(sourceToken, gasToken)) {
-                    const gasReserve = getGasReserve(
-                      props.chain,
-                      tokenBalance.decimals,
-                    );
-                    if (gasReserve) {
-                      amountInBaseUnits -= sdkAmount.units(gasReserve);
-
-                      // Check if there's enough balance after subtracting gas reserve
-                      if (amountInBaseUnits <= 0n) {
-                        const tokenSymbol =
-                          getTokenDisplaySymbolByTokenAddress(sourceToken);
-                        const gasReserveDisplay = sdkAmount.display(gasReserve);
-                        setGasReserveError(
-                          `Insufficient balance. A minimum of ${gasReserveDisplay} ${tokenSymbol} must be reserved for transaction fees.`,
-                        );
-                        return;
-                      }
-                    }
-                  }
-                } catch {
-                  // Gas token not found for chain, proceed without reserve
-                }
-              }
-            }
-
-            // Clear any previous gas reserve error
-            setGasReserveError(undefined);
-
-            const displayAmount = sdkAmount.display(
-              sdkAmount.fromBaseUnits(amountInBaseUnits, tokenBalance.decimals),
-            );
-            handleAmountChange(displayAmount);
-            handleDebouncedAmountChange(displayAmount);
-            setSelectedPercentButton(percent);
-          }
-        }}
-      >
-        <Typography fontSize={12} fontWeight={600} textTransform="none">
-          {percent === 100 ? 'Max' : `${percent}%`}
-        </Typography>
-      </Button>
-    ),
-    [
-      styles.percentButton,
-      styles.percentButtonSelected,
-      selectedPercentButton,
-      props.isTransactionInProgress,
-      tokenBalance,
-      selectedRoute,
-      sourceToken,
-      destToken,
-      props.chain,
-      props.isSource,
-      handleAmountChange,
-      handleDebouncedAmountChange,
-    ],
-  );
-
   const destTokenUnitPrice = useMemo(() => {
     if (!props.token) {
       return null;
@@ -502,11 +379,15 @@ function AssetPicker(props: Props) {
 
   const percentButtons =
     !props.wallet.address || !tokenBalance ? null : (
-      <Box sx={{ display: 'flex', gap: '6px' }}>
-        {renderPercentButton(25)}
-        {renderPercentButton(50)}
-        {renderPercentButton(100)}
-      </Box>
+      <PercentButtons
+        tokenBalance={tokenBalance}
+        chain={props.chain}
+        isTransactionInProgress={props.isTransactionInProgress}
+        selectedPercent={selectedPercentButton}
+        onAmountChange={handleAmountChange}
+        onDebouncedAmountChange={handleDebouncedAmountChange}
+        onPercentSelect={setSelectedPercentButton}
+      />
     );
 
   return (
@@ -567,7 +448,7 @@ function AssetPicker(props: Props) {
                 props.token ? props.balances[props.token.key]?.balance : null
               }
               warning={props.amountValidation?.warning}
-              error={gasReserveError || props.amountValidation?.error}
+              error={props.amountValidation?.error}
               onChange={handleAmountChange}
               onDebouncedChange={handleDebouncedAmountChange}
             />

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -6,7 +6,7 @@ import Button from '@mui/material/Button';
 import { usePopupState, bindTrigger } from 'material-ui-popup-state/hooks';
 import Typography from '@mui/material/Typography';
 import type { Chain, routes } from '@wormhole-foundation/sdk';
-import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount, isSameToken } from '@wormhole-foundation/sdk';
 
 import config from 'config';
 import type { ChainConfig } from 'config/types';
@@ -24,7 +24,11 @@ import type { AmountValidationResult } from 'hooks/useAmountValidation';
 import { OPACITY } from 'utils/style';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
-import { calculateUSDPrice, getTokenDisplaySymbolByTokenAddress } from 'utils';
+import {
+  calculateUSDPrice,
+  getTokenDisplaySymbolByTokenAddress,
+  getGasToken,
+} from 'utils';
 import { formatNumberIntl, formatMaxDigits } from 'utils/formatNumber';
 import {
   handleTelemetryOnChainSelect,
@@ -32,6 +36,7 @@ import {
 } from 'telemetry/utils';
 import FeeOffset from './FeeOffset';
 import { calculateFeeOffset } from 'utils/fees';
+import { getGasReserve } from 'utils/gasReserve';
 import { useGetTokens } from 'hooks/useGetTokens';
 import TokenPickerButton from './TokenPickerButton';
 
@@ -78,6 +83,9 @@ function AssetPicker(props: Props) {
     amount ? sdkAmount.display(amount) : '',
   );
   const [selectedPercentButton, setSelectedPercentButton] = useState(0);
+  const [gasReserveError, setGasReserveError] = useState<string | undefined>(
+    undefined,
+  );
 
   const sortedTokens = useTokenList({
     tokenList: props.tokenList || [],
@@ -244,6 +252,7 @@ function AssetPicker(props: Props) {
     (newValue: string): void => {
       setAmountInput(newValue);
       setSelectedPercentButton(0); // Reset selected percent button when amount changes
+      setGasReserveError(undefined); // Clear gas reserve error when user manually changes amount
 
       if (!newValue) {
         // If the input is cleared, we need to clear the amount in handleAmountChange instead of handleDebouncedAmountChange.
@@ -369,32 +378,67 @@ function AssetPicker(props: Props) {
         disabled={props.isTransactionInProgress}
         onClick={() => {
           if (tokenBalance) {
-            let balancePercent =
+            // Calculate the desired amount for the selected percentage
+            let amountInBaseUnits =
               (sdkAmount.units(tokenBalance) * BigInt(percent)) / BigInt(100);
 
-            // User clicks "Max" when fee-offsetting is enabled.
-            // We need to subtract the fee offset amount from the balance
-            // This is to ensure user doesn't get insufficient funds error when fee offset is applied
-            if (
-              config.ui?.experimental?.feeOffsetting &&
-              percent === 100 &&
-              selectedRoute &&
-              sourceToken &&
-              destToken
-            ) {
-              const feeOffset = calculateFeeOffset(
-                config.routes.get(selectedRoute),
-                tokenBalance,
-                sourceToken,
-                destToken,
-              );
-              if (feeOffset) {
-                balancePercent -= sdkAmount.units(feeOffset);
+            if (percent === 100) {
+              // User clicks "Max" when fee-offsetting is enabled.
+              // We need to subtract the fee offset amount from the balance
+              // This is to ensure user doesn't get insufficient funds error when fee offset is applied
+              // 1. Fee offset for referral fees
+              if (
+                config.ui?.experimental?.feeOffsetting &&
+                selectedRoute &&
+                sourceToken &&
+                destToken
+              ) {
+                const feeOffset = calculateFeeOffset(
+                  config.routes.get(selectedRoute),
+                  tokenBalance,
+                  sourceToken,
+                  destToken,
+                );
+                if (feeOffset) {
+                  amountInBaseUnits -= sdkAmount.units(feeOffset);
+                }
+              }
+
+              // 2. Gas reserve for gas tokens (only for source asset picker)
+              if (props.isSource && sourceToken && props.chain) {
+                try {
+                  const gasToken = getGasToken(props.chain);
+                  if (isSameToken(sourceToken, gasToken)) {
+                    const gasReserve = getGasReserve(
+                      props.chain,
+                      tokenBalance.decimals,
+                    );
+                    if (gasReserve) {
+                      amountInBaseUnits -= sdkAmount.units(gasReserve);
+
+                      // Check if there's enough balance after subtracting gas reserve
+                      if (amountInBaseUnits <= 0n) {
+                        const tokenSymbol =
+                          getTokenDisplaySymbolByTokenAddress(sourceToken);
+                        const gasReserveDisplay = sdkAmount.display(gasReserve);
+                        setGasReserveError(
+                          `Insufficient balance. A minimum of ${gasReserveDisplay} ${tokenSymbol} must be reserved for transaction fees.`,
+                        );
+                        return;
+                      }
+                    }
+                  }
+                } catch {
+                  // Gas token not found for chain, proceed without reserve
+                }
               }
             }
 
+            // Clear any previous gas reserve error
+            setGasReserveError(undefined);
+
             const displayAmount = sdkAmount.display(
-              sdkAmount.fromBaseUnits(balancePercent, tokenBalance.decimals),
+              sdkAmount.fromBaseUnits(amountInBaseUnits, tokenBalance.decimals),
             );
             handleAmountChange(displayAmount);
             handleDebouncedAmountChange(displayAmount);
@@ -416,6 +460,8 @@ function AssetPicker(props: Props) {
       selectedRoute,
       sourceToken,
       destToken,
+      props.chain,
+      props.isSource,
       handleAmountChange,
       handleDebouncedAmountChange,
     ],
@@ -521,7 +567,7 @@ function AssetPicker(props: Props) {
                 props.token ? props.balances[props.token.key]?.balance : null
               }
               warning={props.amountValidation?.warning}
-              error={props.amountValidation?.error}
+              error={gasReserveError || props.amountValidation?.error}
               onChange={handleAmountChange}
               onDebouncedChange={handleDebouncedAmountChange}
             />

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -5,7 +5,7 @@ import { useTheme } from '@mui/material/styles';
 import { usePopupState, bindTrigger } from 'material-ui-popup-state/hooks';
 import Typography from '@mui/material/Typography';
 import type { Chain, routes } from '@wormhole-foundation/sdk';
-import { amount as sdkAmount } from '@wormhole-foundation/sdk';
+import { amount as sdkAmount, isSameToken } from '@wormhole-foundation/sdk';
 
 import config from 'config';
 import type { ChainConfig } from 'config/types';
@@ -31,6 +31,8 @@ import {
 } from 'telemetry/utils';
 import FeeOffset from './FeeOffset';
 import { calculateFeeOffset } from 'utils/fees';
+import { getGasReserve } from 'utils/gasReserve';
+import { getGasToken } from 'utils';
 import { useGetTokens } from 'hooks/useGetTokens';
 import TokenPickerButton from './TokenPickerButton';
 import PercentButtons from './PercentButtons';
@@ -302,6 +304,7 @@ function AssetPicker(props: Props) {
     if (
       selectedPercentButton !== 100 || // Only adjust if user had clicked "Max"
       !props.isSource || // Only adjust for source asset picker
+      !props.chain ||
       !tokenBalance ||
       !amount ||
       !selectedRoute ||
@@ -312,7 +315,29 @@ function AssetPicker(props: Props) {
     }
 
     const currentAmountUnits = sdkAmount.units(amount);
-    const maxAmountUnits = sdkAmount.units(tokenBalance);
+    let maxAmountUnits = sdkAmount.units(tokenBalance);
+
+    // Check if source token is the gas token for gas reserve deduction
+    let isGasToken = false;
+    try {
+      const gasToken = getGasToken(props.chain);
+      isGasToken = isSameToken(sourceToken, gasToken);
+    } catch {
+      // Gas token not configured for this chain
+    }
+
+    // Deduct gas reserve if applicable
+    if (isGasToken) {
+      const gasReserve = getGasReserve(props.chain);
+      if (gasReserve) {
+        const gasReserveUnits = sdkAmount.units(gasReserve);
+        // Only deduct if user has sufficient balance
+        if (maxAmountUnits > gasReserveUnits) {
+          maxAmountUnits -= gasReserveUnits;
+        }
+        // Do not deduct if balance <= gas reserve
+      }
+    }
 
     // Calculate fee offset for the new route
     const feeOffset = calculateFeeOffset(
@@ -334,8 +359,10 @@ function AssetPicker(props: Props) {
         dispatch(setAmount(displayAmount));
       }
     } else if (currentAmountUnits < maxAmountUnits) {
-      // Case 2: New route has no fee offset AND the amount is smaller than max -> restore full balance
-      const displayAmount = sdkAmount.display(tokenBalance);
+      // Case 2: New route has no fee offset AND the amount is smaller than max -> restore full balance (minus gas reserve)
+      const displayAmount = sdkAmount.display(
+        sdkAmount.fromBaseUnits(maxAmountUnits, tokenBalance.decimals),
+      );
       setAmountInput(displayAmount);
       setDebouncedAmountInput(displayAmount);
       dispatch(setAmount(displayAmount));


### PR DESCRIPTION
- Gas reserve mechanism to prevent users from transferring their entire gas token balance, ensuring they retain enough to complete transactions.
- Refactored percent buttons into a standalone component and added unit test coverage for gas reserve functionality and percent button behavior.

Please see the loom for the new behavior.
https://www.loom.com/share/2f20e803af594bfa8bc9c192dd5b9022