### PR TITLE
fix: Refunded transfer doesn't get cleared from in progress widget

### DIFF
--- a/src/views/v3/Redeem/index.tsx
+++ b/src/views/v3/Redeem/index.tsx
@@ -291,6 +291,9 @@ function Redeem() {
         type: 'transfer.refunded',
         details,
       });
+      if (txData?.sendTx) {
+        removeTxFromLocalStorage(txData.sendTx);
+      }
     } else if (isFailed(receipt)) {
       const [uiError, transferError] = interpretTransferError(
         receipt.error,


### PR DESCRIPTION
<img width="631" height="185" alt="image" src="https://github.com/user-attachments/assets/c8fe920e-e2f8-4c30-aac6-5f4f12ea48af" />

<img width="607" height="693" alt="image" src="https://github.com/user-attachments/assets/63f46c1d-fb90-4506-a0b9-e5911bb0e81c" />

The in progress transaction would never get cleared and it would stay as "Wrapping up..."