### PR TITLE
feat: Format/limit digits shown for token balance

### DIFF
--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -337,6 +337,8 @@ describe('formatNumber utilities', () => {
     it('should handle invalid inputs', () => {
       expect(formatMaxDigits('invalid', 6, 4)).toBe('0');
       expect(formatMaxDigits('', 6, 4)).toBe('0');
+      expect(formatMaxDigits('Infinity', 6, 4)).toBe('0');
+      expect(formatMaxDigits('-Infinity', 6, 4)).toBe('0');
     });
 
     it('should handle edge cases', () => {

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -4,6 +4,7 @@ import {
   removeFormatting,
   isValidFormattedNumber,
   formatMinAmount,
+  formatWithPrecision,
 } from './formatNumber';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
@@ -266,6 +267,103 @@ describe('formatNumber utilities', () => {
       // 2 decimals
       const amount2Dec = sdkAmount.fromBaseUnits(12345n, 2); // 123.45
       expect(formatMinAmount(amount2Dec)).toBe('123');
+    });
+  });
+
+  describe('formatWithPrecision', () => {
+    it('should format with integer part less than totalDigits', () => {
+      // Integer part: 3 digits, totalDigits: 6, maxDecimals: 4
+      // Should show 3 decimals (6 - 3 = 3, min with 4 = 3)
+      expect(formatWithPrecision('123.456789', 6, 4)).toBe('123.456');
+
+      // Integer part: 2 digits, totalDigits: 6, maxDecimals: 4
+      // Should show 4 decimals (6 - 2 = 4, min with 4 = 4)
+      expect(formatWithPrecision('12.3456789', 6, 4)).toBe('12.3456');
+
+      // Integer part: 1 digit, totalDigits: 4, maxDecimals: 4
+      // Should show 3 decimals (4 - 1 = 3, min with 4 = 3)
+      expect(formatWithPrecision('1.23456', 4, 4)).toBe('1.234');
+    });
+
+    it('should respect maxDecimals when remaining digits exceed it', () => {
+      // Integer part: 3 digits, totalDigits: 8, maxDecimals: 4
+      // Should show 4 decimals (6 - 3 = 5, min with 4 = 4)
+      expect(formatWithPrecision('123.456789', 8, 4)).toBe('123.4567');
+
+      // Integer part: 1 digit, totalDigits: 10, maxDecimals: 2
+      // Should show 2 decimals (10 - 1 = 9, min with 2 = 2)
+      expect(formatWithPrecision('1.23456', 10, 2)).toBe('1.23');
+    });
+
+    it('should show fewer decimals when integer part is large', () => {
+      // Integer part: 5 digits, totalDigits: 6, maxDecimals: 4
+      // Should show 1 decimal (6 - 5 = 1, min with 4 = 1)
+      expect(formatWithPrecision('12345.6789', 6, 4)).toBe('12345.6');
+
+      // Integer part: 4 digits, totalDigits: 6, maxDecimals: 4
+      // Should show 2 decimals (6 - 4 = 2, min with 4 = 2)
+      expect(formatWithPrecision('1234.56789', 6, 4)).toBe('1234.56');
+    });
+
+    it('should show no decimals when integer part equals totalDigits', () => {
+      // Integer part: 6 digits, totalDigits: 6, maxDecimals: 4
+      // Should show 0 decimals (6 - 6 = 0)
+      expect(formatWithPrecision('123456.789', 6, 4)).toBe('123456');
+
+      expect(formatWithPrecision('1234.56', 4, 2)).toBe('1234');
+    });
+
+    it('should show full integer when it exceeds totalDigits', () => {
+      // Integer part: 7 digits, totalDigits: 6, maxDecimals: 4
+      // Should show full integer
+      expect(formatWithPrecision('1234567.89', 6, 4)).toBe('1234567');
+
+      expect(formatWithPrecision('123456.789', 5, 2)).toBe('123456');
+    });
+
+    it('should handle numbers with leading zero', () => {
+      // Integer part: 1 digit (0), totalDigits: 4, maxDecimals: 4
+      // Should show 3 decimals (4 - 1 = 3)
+      expect(formatWithPrecision('0.123456', 4, 4)).toBe('0.123');
+
+      expect(formatWithPrecision('0.987654321', 5, 6)).toBe('0.9876');
+    });
+
+    it('should handle zero', () => {
+      expect(formatWithPrecision('0', 6, 4)).toBe('0');
+      expect(formatWithPrecision(0, 6, 4)).toBe('0');
+    });
+
+    it('should accept numeric values', () => {
+      expect(formatWithPrecision(123.456789, 6, 4)).toBe('123.456');
+      expect(formatWithPrecision(12345.6789, 6, 4)).toBe('12345.6');
+    });
+
+    it('should handle invalid inputs', () => {
+      expect(formatWithPrecision('invalid', 6, 4)).toBe('0');
+      expect(formatWithPrecision(NaN, 6, 4)).toBe('0');
+    });
+
+    it('should handle edge cases', () => {
+      // Very small numbers
+      expect(formatWithPrecision('0.00123456', 4, 6)).toBe('0.001');
+
+      // Large integer with small decimal
+      expect(formatWithPrecision('999999.1', 6, 2)).toBe('999999');
+
+      // Exact fit
+      expect(formatWithPrecision('12.34', 4, 2)).toBe('12.34');
+    });
+
+    it('should truncate decimals without rounding', () => {
+      // Should truncate to 3 decimals
+      expect(formatWithPrecision('123.4567', 6, 4)).toBe('123.456');
+
+      // Should truncate, not round up
+      expect(formatWithPrecision('1.9999', 4, 2)).toBe('1.99');
+
+      // Should truncate to 2 decimals
+      expect(formatWithPrecision('12.345', 5, 2)).toBe('12.34');
     });
   });
 });

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -365,5 +365,41 @@ describe('formatNumber utilities', () => {
       // Should truncate to 2 decimals
       expect(formatWithPrecision('12.345', 5, 2)).toBe('12.34');
     });
+
+    describe('Sample token amounts from ETH, SOL and USDC', () => {
+      it('should format ETH amounts (18 decimals) with totalDigits=9, maxDecimals=4', () => {
+        expect(formatWithPrecision('0.001234567890123456', 9, 4)).toBe(
+          '0.0012',
+        );
+        expect(formatWithPrecision('1.234567890123456789', 9, 4)).toBe(
+          '1.2345',
+        );
+        expect(formatWithPrecision('123.456789012345678', 9, 4)).toBe(
+          '123.4567',
+        );
+        expect(formatWithPrecision('123456.789012345678', 9, 4)).toBe(
+          '123456.789',
+        );
+        expect(formatWithPrecision('123456789.123456789', 9, 4)).toBe(
+          '123456789',
+        );
+      });
+
+      it('should format SOL amounts (9 decimals) with totalDigits=9, maxDecimals=4', () => {
+        expect(formatWithPrecision('0.123456789', 9, 4)).toBe('0.1234');
+        expect(formatWithPrecision('12.345678901', 9, 4)).toBe('12.3456');
+        expect(formatWithPrecision('1234.56789', 9, 4)).toBe('1234.5678');
+        expect(formatWithPrecision('123456.78912345', 9, 4)).toBe('123456.789');
+        expect(formatWithPrecision('123456789.123456', 9, 4)).toBe('123456789');
+      });
+
+      it('should format USDC amounts (6 decimals) with totalDigits=9, maxDecimals=4', () => {
+        expect(formatWithPrecision('0.123456', 9, 4)).toBe('0.1234');
+        expect(formatWithPrecision('123.456789', 9, 4)).toBe('123.4567');
+        expect(formatWithPrecision('123456.7890', 9, 4)).toBe('123456.789');
+        expect(formatWithPrecision('123456.789012', 9, 4)).toBe('123456.789');
+        expect(formatWithPrecision('123456789.123', 9, 4)).toBe('123456789');
+      });
+    });
   });
 });

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -4,7 +4,7 @@ import {
   removeFormatting,
   isValidFormattedNumber,
   formatMinAmount,
-  formatWithPrecision,
+  formatMaxDigits,
 } from './formatNumber';
 import { amount as sdkAmount } from '@wormhole-foundation/sdk';
 
@@ -270,135 +270,125 @@ describe('formatNumber utilities', () => {
     });
   });
 
-  describe('formatWithPrecision', () => {
+  describe('formatMaxDigits', () => {
     it('should format with integer part less than totalDigits', () => {
       // Integer part: 3 digits, totalDigits: 6, maxDecimals: 4
       // Should show 3 decimals (6 - 3 = 3, min with 4 = 3)
-      expect(formatWithPrecision('123.456789', 6, 4)).toBe('123.456');
+      expect(formatMaxDigits('123.456789', 6, 4)).toBe('123.456');
 
       // Integer part: 2 digits, totalDigits: 6, maxDecimals: 4
       // Should show 4 decimals (6 - 2 = 4, min with 4 = 4)
-      expect(formatWithPrecision('12.3456789', 6, 4)).toBe('12.3456');
+      expect(formatMaxDigits('12.3456789', 6, 4)).toBe('12.3456');
 
       // Integer part: 1 digit, totalDigits: 4, maxDecimals: 4
       // Should show 3 decimals (4 - 1 = 3, min with 4 = 3)
-      expect(formatWithPrecision('1.23456', 4, 4)).toBe('1.234');
+      expect(formatMaxDigits('1.23456', 4, 4)).toBe('1.234');
     });
 
     it('should respect maxDecimals when remaining digits exceed it', () => {
       // Integer part: 3 digits, totalDigits: 8, maxDecimals: 4
       // Should show 4 decimals (6 - 3 = 5, min with 4 = 4)
-      expect(formatWithPrecision('123.456789', 8, 4)).toBe('123.4567');
+      expect(formatMaxDigits('123.456789', 8, 4)).toBe('123.4567');
 
       // Integer part: 1 digit, totalDigits: 10, maxDecimals: 2
       // Should show 2 decimals (10 - 1 = 9, min with 2 = 2)
-      expect(formatWithPrecision('1.23456', 10, 2)).toBe('1.23');
+      expect(formatMaxDigits('1.23456', 10, 2)).toBe('1.23');
     });
 
     it('should show fewer decimals when integer part is large', () => {
       // Integer part: 5 digits, totalDigits: 6, maxDecimals: 4
       // Should show 1 decimal (6 - 5 = 1, min with 4 = 1)
-      expect(formatWithPrecision('12345.6789', 6, 4)).toBe('12345.6');
+      expect(formatMaxDigits('12345.6789', 6, 4)).toBe('12345.6');
 
       // Integer part: 4 digits, totalDigits: 6, maxDecimals: 4
       // Should show 2 decimals (6 - 4 = 2, min with 4 = 2)
-      expect(formatWithPrecision('1234.56789', 6, 4)).toBe('1234.56');
+      expect(formatMaxDigits('1234.56789', 6, 4)).toBe('1234.56');
     });
 
     it('should show no decimals when integer part equals totalDigits', () => {
       // Integer part: 6 digits, totalDigits: 6, maxDecimals: 4
       // Should show 0 decimals (6 - 6 = 0)
-      expect(formatWithPrecision('123456.789', 6, 4)).toBe('123456');
+      expect(formatMaxDigits('123456.789', 6, 4)).toBe('123456');
 
-      expect(formatWithPrecision('1234.56', 4, 2)).toBe('1234');
+      expect(formatMaxDigits('1234.56', 4, 2)).toBe('1234');
     });
 
     it('should show full integer when it exceeds totalDigits', () => {
       // Integer part: 7 digits, totalDigits: 6, maxDecimals: 4
       // Should show full integer
-      expect(formatWithPrecision('1234567.89', 6, 4)).toBe('1234567');
+      expect(formatMaxDigits('1234567.89', 6, 4)).toBe('1234567');
 
-      expect(formatWithPrecision('123456.789', 5, 2)).toBe('123456');
+      expect(formatMaxDigits('123456.789', 5, 2)).toBe('123456');
     });
 
     it('should handle numbers with leading zero', () => {
       // Integer part: 1 digit (0), totalDigits: 4, maxDecimals: 4
       // Should show 3 decimals (4 - 1 = 3)
-      expect(formatWithPrecision('0.123456', 4, 4)).toBe('0.123');
+      expect(formatMaxDigits('0.123456', 4, 4)).toBe('0.123');
 
-      expect(formatWithPrecision('0.987654321', 5, 6)).toBe('0.9876');
+      expect(formatMaxDigits('0.987654321', 5, 6)).toBe('0.9876');
     });
 
     it('should handle zero', () => {
-      expect(formatWithPrecision('0', 6, 4)).toBe('0');
-      expect(formatWithPrecision(0, 6, 4)).toBe('0');
+      expect(formatMaxDigits('0', 6, 4)).toBe('0');
+      expect(formatMaxDigits(0, 6, 4)).toBe('0');
     });
 
     it('should accept numeric values', () => {
-      expect(formatWithPrecision(123.456789, 6, 4)).toBe('123.456');
-      expect(formatWithPrecision(12345.6789, 6, 4)).toBe('12345.6');
+      expect(formatMaxDigits(123.456789, 6, 4)).toBe('123.456');
+      expect(formatMaxDigits(12345.6789, 6, 4)).toBe('12345.6');
     });
 
     it('should handle invalid inputs', () => {
-      expect(formatWithPrecision('invalid', 6, 4)).toBe('0');
-      expect(formatWithPrecision(NaN, 6, 4)).toBe('0');
+      expect(formatMaxDigits('invalid', 6, 4)).toBe('0');
+      expect(formatMaxDigits(NaN, 6, 4)).toBe('0');
     });
 
     it('should handle edge cases', () => {
       // Very small numbers
-      expect(formatWithPrecision('0.00123456', 4, 6)).toBe('0.001');
+      expect(formatMaxDigits('0.00123456', 4, 6)).toBe('0.001');
 
       // Large integer with small decimal
-      expect(formatWithPrecision('999999.1', 6, 2)).toBe('999999');
+      expect(formatMaxDigits('999999.1', 6, 2)).toBe('999999');
 
       // Exact fit
-      expect(formatWithPrecision('12.34', 4, 2)).toBe('12.34');
+      expect(formatMaxDigits('12.34', 4, 2)).toBe('12.34');
     });
 
     it('should truncate decimals without rounding', () => {
       // Should truncate to 3 decimals
-      expect(formatWithPrecision('123.4567', 6, 4)).toBe('123.456');
+      expect(formatMaxDigits('123.4567', 6, 4)).toBe('123.456');
 
       // Should truncate, not round up
-      expect(formatWithPrecision('1.9999', 4, 2)).toBe('1.99');
+      expect(formatMaxDigits('1.9999', 4, 2)).toBe('1.99');
 
       // Should truncate to 2 decimals
-      expect(formatWithPrecision('12.345', 5, 2)).toBe('12.34');
+      expect(formatMaxDigits('12.345', 5, 2)).toBe('12.34');
     });
 
     describe('Sample token amounts from ETH, SOL and USDC', () => {
       it('should format ETH amounts (18 decimals) with totalDigits=9, maxDecimals=4', () => {
-        expect(formatWithPrecision('0.001234567890123456', 9, 4)).toBe(
-          '0.0012',
-        );
-        expect(formatWithPrecision('1.234567890123456789', 9, 4)).toBe(
-          '1.2345',
-        );
-        expect(formatWithPrecision('123.456789012345678', 9, 4)).toBe(
-          '123.4567',
-        );
-        expect(formatWithPrecision('123456.789012345678', 9, 4)).toBe(
-          '123456.789',
-        );
-        expect(formatWithPrecision('123456789.123456789', 9, 4)).toBe(
-          '123456789',
-        );
+        expect(formatMaxDigits('0.001234567890123456', 9, 4)).toBe('0.0012');
+        expect(formatMaxDigits('1.234567890123456789', 9, 4)).toBe('1.2345');
+        expect(formatMaxDigits('123.456789012345678', 9, 4)).toBe('123.4567');
+        expect(formatMaxDigits('123456.789012345678', 9, 4)).toBe('123456.789');
+        expect(formatMaxDigits('123456789.123456789', 9, 4)).toBe('123456789');
       });
 
       it('should format SOL amounts (9 decimals) with totalDigits=9, maxDecimals=4', () => {
-        expect(formatWithPrecision('0.123456789', 9, 4)).toBe('0.1234');
-        expect(formatWithPrecision('12.345678901', 9, 4)).toBe('12.3456');
-        expect(formatWithPrecision('1234.56789', 9, 4)).toBe('1234.5678');
-        expect(formatWithPrecision('123456.78912345', 9, 4)).toBe('123456.789');
-        expect(formatWithPrecision('123456789.123456', 9, 4)).toBe('123456789');
+        expect(formatMaxDigits('0.123456789', 9, 4)).toBe('0.1234');
+        expect(formatMaxDigits('12.345678901', 9, 4)).toBe('12.3456');
+        expect(formatMaxDigits('1234.56789', 9, 4)).toBe('1234.5678');
+        expect(formatMaxDigits('123456.78912345', 9, 4)).toBe('123456.789');
+        expect(formatMaxDigits('123456789.123456', 9, 4)).toBe('123456789');
       });
 
       it('should format USDC amounts (6 decimals) with totalDigits=9, maxDecimals=4', () => {
-        expect(formatWithPrecision('0.123456', 9, 4)).toBe('0.1234');
-        expect(formatWithPrecision('123.456789', 9, 4)).toBe('123.4567');
-        expect(formatWithPrecision('123456.7890', 9, 4)).toBe('123456.789');
-        expect(formatWithPrecision('123456.789012', 9, 4)).toBe('123456.789');
-        expect(formatWithPrecision('123456789.123', 9, 4)).toBe('123456789');
+        expect(formatMaxDigits('0.123456', 9, 4)).toBe('0.1234');
+        expect(formatMaxDigits('123.456789', 9, 4)).toBe('123.4567');
+        expect(formatMaxDigits('123456.7890', 9, 4)).toBe('123456.789');
+        expect(formatMaxDigits('123456.789012', 9, 4)).toBe('123456.789');
+        expect(formatMaxDigits('123456789.123', 9, 4)).toBe('123456789');
       });
     });
   });

--- a/src/utils/formatNumber.test.ts
+++ b/src/utils/formatNumber.test.ts
@@ -331,17 +331,12 @@ describe('formatNumber utilities', () => {
 
     it('should handle zero', () => {
       expect(formatMaxDigits('0', 6, 4)).toBe('0');
-      expect(formatMaxDigits(0, 6, 4)).toBe('0');
-    });
-
-    it('should accept numeric values', () => {
-      expect(formatMaxDigits(123.456789, 6, 4)).toBe('123.456');
-      expect(formatMaxDigits(12345.6789, 6, 4)).toBe('12345.6');
+      expect(formatMaxDigits('0.0', 6, 4)).toBe('0');
     });
 
     it('should handle invalid inputs', () => {
       expect(formatMaxDigits('invalid', 6, 4)).toBe('0');
-      expect(formatMaxDigits(NaN, 6, 4)).toBe('0');
+      expect(formatMaxDigits('', 6, 4)).toBe('0');
     });
 
     it('should handle edge cases', () => {

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -155,12 +155,12 @@ export const formatMinAmount = (minAmount: sdkAmount.Amount): string => {
  * formatMaxDigits('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
  */
 export const formatMaxDigits = (
-  value: string | number,
+  value: string,
   totalDigits: number,
   maxDecimals: number,
 ): string => {
-  const numValue = typeof value === 'string' ? parseFloat(value) : value;
-
+  // Parse only for validation (zero/NaN check)
+  const numValue = parseFloat(value);
   // Handle zero and NaN cases
   if (numValue === 0 || Number.isNaN(numValue)) {
     return '0';
@@ -171,23 +171,25 @@ export const formatMaxDigits = (
   // 2. It doesn't respect maxDecimals constraint properly
   // 3. It can return scientific notation for large/small numbers
 
+  // Work with original string to preserve precision (avoid parseFloat precision loss)
+  const [intPart, decimalPart] = value.split('.');
+
   // Get the integer part length (count digits, not including decimal)
-  const integerPart = Math.floor(numValue);
-  const integerDigits = integerPart === 0 ? 1 : integerPart.toString().length;
+  const integerDigits = intPart === '0' ? 1 : intPart.length;
 
   // If integer part already exceeds or equals totalDigits, return just the integer
   if (integerDigits >= totalDigits) {
-    return integerPart.toString();
+    return intPart;
   }
 
   // Calculate how many decimal places we can show
   const remainingDigits = totalDigits - integerDigits;
   const decimalsToShow = Math.min(remainingDigits, maxDecimals);
 
-  // Truncate decimals to match the max allowed
-  const [intPart, decimalPart] = numValue.toString().split('.');
+  // No decimal part or no space for decimals
   if (!decimalPart || decimalsToShow === 0) {
     return intPart;
   }
+
   return `${intPart}.${decimalPart.substring(0, decimalsToShow)}`;
 };

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -151,10 +151,8 @@ export const formatMinAmount = (minAmount: sdkAmount.Amount): string => {
  * @example
  * formatWithPrecision('123.456789', 6, 4)     // '123.456' (3 int + 3 dec = 6 total)
  * formatWithPrecision('123.456789', 8, 4)     // '123.4567' (3 int + 4 dec, limited by maxDecimals)
- * formatWithPrecision('12345.6789', 6, 4)     // '12345.6' (5 int + 1 dec = 6 total)
  * formatWithPrecision('123456.789', 6, 4)     // '123456' (6 int, no space for decimals)
  * formatWithPrecision('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
- * formatWithPrecision('0.123456', 4, 4)       // '0.123' (1 int + 3 dec = 4 total)
  */
 export const formatWithPrecision = (
   value: string | number,
@@ -187,13 +185,9 @@ export const formatWithPrecision = (
   const decimalsToShow = Math.min(remainingDigits, maxDecimals);
 
   // Truncate decimals to match the max allowed
-  const valueStr = numValue.toString();
-  const [intPart, decPart] = valueStr.split('.');
-
-  if (!decPart || decimalsToShow === 0) {
+  const [intPart, decimalPart] = numValue.toString().split('.');
+  if (!decimalPart || decimalsToShow === 0) {
     return intPart;
   }
-
-  const truncatedDecimals = decPart.substring(0, decimalsToShow);
-  return `${intPart}.${truncatedDecimals}`;
+  return `${intPart}.${decimalPart.substring(0, decimalsToShow)}`;
 };

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -149,12 +149,12 @@ export const formatMinAmount = (minAmount: sdkAmount.Amount): string => {
  * @returns Formatted number string (decimals truncated)
  *
  * @example
- * formatWithPrecision('123.456789', 6, 4)     // '123.456' (3 int + 3 dec = 6 total)
- * formatWithPrecision('123.456789', 8, 4)     // '123.4567' (3 int + 4 dec, limited by maxDecimals)
- * formatWithPrecision('123456.789', 6, 4)     // '123456' (6 int, no space for decimals)
- * formatWithPrecision('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
+ * formatMaxDigits('123.456789', 6, 4)     // '123.456' (3 int + 3 dec = 6 total)
+ * formatMaxDigits('123.456789', 8, 4)     // '123.4567' (3 int + 4 dec, limited by maxDecimals)
+ * formatMaxDigits('123456.789', 6, 4)     // '123456' (6 int, no space for decimals)
+ * formatMaxDigits('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
  */
-export const formatWithPrecision = (
+export const formatMaxDigits = (
   value: string | number,
   totalDigits: number,
   maxDecimals: number,

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -137,3 +137,63 @@ export const formatMinAmount = (minAmount: sdkAmount.Amount): string => {
     return asNumber.toPrecision(3);
   }
 };
+
+/**
+ * Format a number with smart precision based on total digits and max decimal digits.
+ * If the integer part is less than totalDigits, show decimals up to maxDecimals
+ * (limited by remaining space from totalDigits).
+ *
+ * @param value - The numeric value to format (string or number)
+ * @param totalDigits - Maximum total significant digits to display
+ * @param maxDecimals - Maximum number of decimal places to show
+ * @returns Formatted number string (decimals truncated)
+ *
+ * @example
+ * formatWithPrecision('123.456789', 6, 4)     // '123.456' (3 int + 3 dec = 6 total)
+ * formatWithPrecision('123.456789', 8, 4)     // '123.4567' (3 int + 4 dec, limited by maxDecimals)
+ * formatWithPrecision('12345.6789', 6, 4)     // '12345.6' (5 int + 1 dec = 6 total)
+ * formatWithPrecision('123456.789', 6, 4)     // '123456' (6 int, no space for decimals)
+ * formatWithPrecision('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
+ * formatWithPrecision('0.123456', 4, 4)       // '0.123' (1 int + 3 dec = 4 total)
+ */
+export const formatWithPrecision = (
+  value: string | number,
+  totalDigits: number,
+  maxDecimals: number,
+): string => {
+  const numValue = typeof value === 'string' ? parseFloat(value) : value;
+
+  // Handle zero and NaN cases
+  if (numValue === 0 || Number.isNaN(numValue)) {
+    return '0';
+  }
+
+  // Note: We don't use toPrecision() because:
+  // 1. It rounds instead of truncates
+  // 2. It doesn't respect maxDecimals constraint properly
+  // 3. It can return scientific notation for large/small numbers
+
+  // Get the integer part length (count digits, not including decimal)
+  const integerPart = Math.floor(numValue);
+  const integerDigits = integerPart === 0 ? 1 : integerPart.toString().length;
+
+  // If integer part already exceeds or equals totalDigits, return just the integer
+  if (integerDigits >= totalDigits) {
+    return integerPart.toString();
+  }
+
+  // Calculate how many decimal places we can show
+  const remainingDigits = totalDigits - integerDigits;
+  const decimalsToShow = Math.min(remainingDigits, maxDecimals);
+
+  // Truncate decimals to match the max allowed
+  const valueStr = numValue.toString();
+  const [intPart, decPart] = valueStr.split('.');
+
+  if (!decPart || decimalsToShow === 0) {
+    return intPart;
+  }
+
+  const truncatedDecimals = decPart.substring(0, decimalsToShow);
+  return `${intPart}.${truncatedDecimals}`;
+};

--- a/src/utils/formatNumber.ts
+++ b/src/utils/formatNumber.ts
@@ -159,10 +159,10 @@ export const formatMaxDigits = (
   totalDigits: number,
   maxDecimals: number,
 ): string => {
-  // Parse only for validation (zero/NaN check)
+  // Parse only for validation (zero/NaN/Infinity check)
   const numValue = parseFloat(value);
-  // Handle zero and NaN cases
-  if (numValue === 0 || Number.isNaN(numValue)) {
+  // Handle zero, NaN, and Infinity cases
+  if (!Number.isFinite(numValue) || numValue === 0) {
     return '0';
   }
 

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -25,7 +25,7 @@ import { OPACITY } from 'utils/style';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
 import { calculateUSDPrice, getTokenDisplaySymbolByTokenAddress } from 'utils';
-import { formatNumberIntl, formatWithPrecision } from 'utils/formatNumber';
+import { formatNumberIntl, formatMaxDigits } from 'utils/formatNumber';
 import {
   handleTelemetryOnChainSelect,
   handleTelemetryOnTokenSelect,
@@ -106,7 +106,7 @@ function AssetPicker(props: Props) {
     if (!tokenBalance) {
       return null;
     }
-    const formattedBalance = formatWithPrecision(
+    const formattedBalance = formatMaxDigits(
       sdkAmount.display(tokenBalance),
       9, // Max total digits
       4, // Max decimal places

--- a/src/views/v3/Bridge/AssetPicker/index.tsx
+++ b/src/views/v3/Bridge/AssetPicker/index.tsx
@@ -25,7 +25,7 @@ import { OPACITY } from 'utils/style';
 import AssetPickerDrawer from 'views/v3/Bridge/AssetPicker/PickerBottomSheet';
 import AssetPickerPopover from 'views/v3/Bridge/AssetPicker/PickerModal';
 import { calculateUSDPrice, getTokenDisplaySymbolByTokenAddress } from 'utils';
-import { formatNumberIntl } from 'utils/formatNumber';
+import { formatNumberIntl, formatWithPrecision } from 'utils/formatNumber';
 import {
   handleTelemetryOnChainSelect,
   handleTelemetryOnTokenSelect,
@@ -106,7 +106,12 @@ function AssetPicker(props: Props) {
     if (!tokenBalance) {
       return null;
     }
-    const displayValue = `${sdkAmount.display(tokenBalance)} ${
+    const formattedBalance = formatWithPrecision(
+      sdkAmount.display(tokenBalance),
+      9, // Max total digits
+      4, // Max decimal places
+    );
+    const displayValue = `${formattedBalance} ${
       props.token ? getTokenDisplaySymbolByTokenAddress(props.token) : ''
     }`;
     return (


### PR DESCRIPTION
Formatting examples:
```
formatWithPrecision('123.456789', 6, 4)     // '123.456' (3 int + 3 dec = 6 total)
formatWithPrecision('123.456789', 8, 4)     // '123.4567' (3 int + 4 dec, limited by maxDecimals)
formatWithPrecision('12345.6789', 6, 4)     // '12345.6' (5 int + 1 dec = 6 total)
formatWithPrecision('123456.789', 6, 4)     // '123456' (6 int, no space for decimals)
formatWithPrecision('1234567.89', 6, 4)     // '1234567' (int exceeds totalDigits, show full int)
formatWithPrecision('0.123456', 4, 4)       // '0.123' (1 int + 3 dec = 4 total)
```