### PR TITLE
fix: main.js -> main.mjs in the hosted version

### DIFF
--- a/src/hosted.ts
+++ b/src/hosted.ts
@@ -28,7 +28,7 @@ export function wormholeConnectHosted(
     `https://cdn.jsdelivr.net/npm/@wormhole-foundation/wormhole-connect@${version}`;
 
   const script = document.createElement('script');
-  script.setAttribute('src', `${baseUrl}/dist/main.js`);
+  script.setAttribute('src', `${baseUrl}/dist/main.mjs`);
   script.setAttribute('type', 'module');
 
   parentNode.appendChild(connectRoot);


### PR DESCRIPTION
This was broken in version 5.0.0 when the built `main.js` is replaced with `main.mjs`