### PR TITLE
feat: Emitting swap.input event when user swaps assets

### DIFF
--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -118,6 +118,14 @@ export enum UserActions {
   SelectSrcChain = 'select.src.chain',
   SelectDestToken = 'select.dest.token',
   SelectDestChain = 'select.dest.chain',
+  SwapInputs = 'swap.inputs',
+}
+
+export interface SwapInputs {
+  fromChain: Chain;
+  fromToken?: Token;
+  toChain: Chain;
+  toToken?: Token;
 }
 
 type UserActionValueMap = {
@@ -125,6 +133,7 @@ type UserActionValueMap = {
   [UserActions.SelectDestToken]: Token;
   [UserActions.SelectSrcChain]: Chain;
   [UserActions.SelectDestChain]: Chain;
+  [UserActions.SwapInputs]: SwapInputs;
 };
 
 export type UserActionEvent<A extends UserActions = UserActions> = {

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -118,14 +118,6 @@ export enum UserActions {
   SelectSrcChain = 'select.src.chain',
   SelectDestToken = 'select.dest.token',
   SelectDestChain = 'select.dest.chain',
-  SwapInputs = 'swap.inputs',
-}
-
-export interface SwapInputs {
-  fromChain: Chain;
-  fromToken?: Token;
-  toChain: Chain;
-  toToken?: Token;
 }
 
 type UserActionValueMap = {
@@ -133,7 +125,6 @@ type UserActionValueMap = {
   [UserActions.SelectDestToken]: Token;
   [UserActions.SelectSrcChain]: Chain;
   [UserActions.SelectDestChain]: Chain;
-  [UserActions.SwapInputs]: SwapInputs;
 };
 
 export type UserActionEvent<A extends UserActions = UserActions> = {

--- a/src/views/v3/Bridge/SwapInputs/index.tsx
+++ b/src/views/v3/Bridge/SwapInputs/index.tsx
@@ -9,6 +9,8 @@ import type { RootState } from 'store';
 import useWalletProvider from 'hooks/useWalletProvider';
 import { setAmount, swapInputs } from 'store/transferInput';
 import { setToNativeToken } from 'store/relay';
+import config from 'config';
+import { UserActions } from 'telemetry/types';
 
 function SwapInputs() {
   const dispatch = useDispatch();
@@ -16,9 +18,8 @@ function SwapInputs() {
   const theme: any = useTheme();
   const [rotateAnimation, setRotateAnimation] = useState('');
 
-  const { isTransactionInProgress, fromChain, toChain } = useSelector(
-    (state: RootState) => state.transferInput,
-  );
+  const { isTransactionInProgress, fromChain, toChain, token, destToken } =
+    useSelector((state: RootState) => state.transferInput);
 
   const styles = useMemo(
     () => ({
@@ -84,7 +85,37 @@ function SwapInputs() {
 
     dispatch(swapInputs());
     dispatch(setAmount(''));
-  }, [canSwap, isTransactionInProgress, dispatch, swapWallets]);
+
+    // Emit swap event after swapping state with the new swapped values
+    // We do not expect fromChain, toChain to be falsy here but adding a check for safety nonetheless
+    if (fromChain && toChain) {
+      // Tokens can be undefined if user swaps before selecting a token
+      const fromToken = token && config.tokens.get(token);
+      const toToken = destToken && config.tokens.get(destToken);
+
+      config.triggerEvent({
+        type: 'user.action',
+        details: {
+          action: UserActions.SwapInputs,
+          value: {
+            fromChain: toChain,
+            fromToken: toToken,
+            toChain: fromChain,
+            toToken: fromToken,
+          },
+        },
+      });
+    }
+  }, [
+    canSwap,
+    isTransactionInProgress,
+    dispatch,
+    swapWallets,
+    fromChain,
+    toChain,
+    token,
+    destToken,
+  ]);
 
   return (
     <IconButton

--- a/src/views/v3/Bridge/SwapInputs/index.tsx
+++ b/src/views/v3/Bridge/SwapInputs/index.tsx
@@ -4,12 +4,12 @@ import { useTheme } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import Color from 'color';
 
+import config from 'config';
 import SwapVerticalIcon from 'icons/SwapVertical';
-import type { RootState } from 'store';
 import useWalletProvider from 'hooks/useWalletProvider';
+import type { RootState } from 'store';
 import { setAmount, swapInputs } from 'store/transferInput';
 import { setToNativeToken } from 'store/relay';
-import config from 'config';
 import { UserActions } from 'telemetry/types';
 
 function SwapInputs() {
@@ -73,6 +73,14 @@ function SwapInputs() {
 
   const canSwap = !isTransactionInProgress && fromChain && toChain;
 
+  // Helper function to emit user action events
+  const emitUserAction = useCallback((action: UserActions, value: any) => {
+    config.triggerEvent({
+      type: 'user.action',
+      details: { action, value },
+    });
+  }, []);
+
   const swap = useCallback(() => {
     if (!canSwap || isTransactionInProgress) return;
 
@@ -86,33 +94,30 @@ function SwapInputs() {
     dispatch(swapInputs());
     dispatch(setAmount(''));
 
-    // Emit swap event after swapping state with the new swapped values
-    // We do not expect fromChain, toChain to be falsy here but adding a check for safety nonetheless
-    if (fromChain && toChain) {
-      // Tokens can be undefined if user swaps before selecting a token
-      const fromToken = token && config.tokens.get(token);
-      const toToken = destToken && config.tokens.get(destToken);
+    // Emit select.* events to notify about the swap action
+    emitUserAction(UserActions.SelectSrcChain, toChain);
+    emitUserAction(UserActions.SelectDestChain, fromChain);
 
-      config.triggerEvent({
-        type: 'user.action',
-        details: {
-          action: UserActions.SwapInputs,
-          value: {
-            fromChain: toChain,
-            fromToken: toToken,
-            toChain: fromChain,
-            toToken: fromToken,
-          },
-        },
-      });
+    if (token) {
+      const fromToken = config.tokens.get(token);
+      if (fromToken) {
+        emitUserAction(UserActions.SelectDestToken, fromToken);
+      }
+    }
+    if (destToken) {
+      const toToken = config.tokens.get(destToken);
+      if (toToken) {
+        emitUserAction(UserActions.SelectSrcToken, toToken);
+      }
     }
   }, [
     canSwap,
     isTransactionInProgress,
     dispatch,
     swapWallets,
-    fromChain,
+    emitUserAction,
     toChain,
+    fromChain,
     token,
     destToken,
   ]);

--- a/src/views/v3/Bridge/SwapInputs/index.tsx
+++ b/src/views/v3/Bridge/SwapInputs/index.tsx
@@ -10,7 +10,10 @@ import useWalletProvider from 'hooks/useWalletProvider';
 import type { RootState } from 'store';
 import { setAmount, swapInputs } from 'store/transferInput';
 import { setToNativeToken } from 'store/relay';
-import { UserActions } from 'telemetry/types';
+import {
+  handleTelemetryOnChainSelect,
+  handleTelemetryOnTokenSelect,
+} from 'telemetry/utils';
 
 function SwapInputs() {
   const dispatch = useDispatch();
@@ -73,14 +76,6 @@ function SwapInputs() {
 
   const canSwap = !isTransactionInProgress && fromChain && toChain;
 
-  // Helper function to emit user action events
-  const emitUserAction = useCallback((action: UserActions, value: any) => {
-    config.triggerEvent({
-      type: 'user.action',
-      details: { action, value },
-    });
-  }, []);
-
   const swap = useCallback(() => {
     if (!canSwap || isTransactionInProgress) return;
 
@@ -95,19 +90,20 @@ function SwapInputs() {
     dispatch(setAmount(''));
 
     // Emit select.* events to notify about the swap action
-    emitUserAction(UserActions.SelectSrcChain, toChain);
-    emitUserAction(UserActions.SelectDestChain, fromChain);
+    handleTelemetryOnChainSelect(fromChain, false);
+    handleTelemetryOnChainSelect(toChain, true);
 
+    // There is a possibility that swap action happens before user selects tokens
     if (token) {
       const fromToken = config.tokens.get(token);
       if (fromToken) {
-        emitUserAction(UserActions.SelectDestToken, fromToken);
+        handleTelemetryOnTokenSelect(fromToken, false);
       }
     }
     if (destToken) {
       const toToken = config.tokens.get(destToken);
       if (toToken) {
-        emitUserAction(UserActions.SelectSrcToken, toToken);
+        handleTelemetryOnTokenSelect(toToken, true);
       }
     }
   }, [
@@ -115,7 +111,6 @@ function SwapInputs() {
     isTransactionInProgress,
     dispatch,
     swapWallets,
-    emitUserAction,
     toChain,
     fromChain,
     token,


### PR DESCRIPTION
This will be used by the integrator/host app to adjust any local state when source/destination assets are switched.