### PR TITLE
fix: Add tx context (send/redeem) to error interpretation to determine where the error is coming from

### DIFF
--- a/src/hooks/useConfirmTransaction.ts
+++ b/src/hooks/useConfirmTransaction.ts
@@ -271,6 +271,7 @@ const useConfirmTransaction = (props: Props): ReturnProps => {
       const [uiError, transferError] = interpretTransferError(
         e,
         transferDetails,
+        'send',
       );
 
       if (transferError.type === ERR_USER_REJECTED) {

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -188,6 +188,7 @@ describe('interpretTransferError', () => {
       const [message, errorObj] = interpretTransferError(
         error,
         mockTransferDetails,
+        'send',
       );
 
       expect(message).toBe(expectedMessage);
@@ -202,6 +203,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe('Transfer timed out, please try again');
@@ -214,6 +216,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe('Transfer timed out, please try again');
@@ -225,6 +228,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe(
@@ -238,6 +242,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toContain('Insufficient');
@@ -247,7 +252,11 @@ describe('interpretTransferError', () => {
 
   it('should prioritize gas error over generic funds error', () => {
     const error = new Error('insufficient funds for gas');
-    const [message] = interpretTransferError(error, mockTransferDetails);
+    const [message] = interpretTransferError(
+      error,
+      mockTransferDetails,
+      'send',
+    );
 
     // Should match gas error, not generic funds error
     expect(message).toBe(
@@ -267,6 +276,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe(
@@ -287,6 +297,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe('Wallet request declined. Transfer not started.');
@@ -307,6 +318,7 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe('Error with transfer, please try again');
@@ -325,11 +337,69 @@ describe('interpretTransferError', () => {
     const [message, errorObj] = interpretTransferError(
       error,
       mockTransferDetails,
+      'send',
     );
 
     expect(message).toBe(
       'Insufficient funds for this transfer. Please add more funds and try again',
     );
     expect(errorObj.type).toBe(ERR_INSUFFICIENT_FUNDS);
+  });
+
+  it('should return insufficient gas error for send context', () => {
+    const error = new Error('insufficient lamports 1000 required 5000');
+    const [message, errorObj] = interpretTransferError(
+      error,
+      mockTransferDetails,
+      'send',
+    );
+
+    // Should detect as insufficient gas error
+    // Message attempts to use fromChain gas token if config available
+    expect(errorObj.type).toBe(ERR_INSUFFICIENT_GAS);
+    expect(message).toContain('Insufficient');
+  });
+
+  it('should return insufficient gas error for redeem context', () => {
+    const error = new Error('insufficient lamports 1000 required 5000');
+    const [message, errorObj] = interpretTransferError(
+      error,
+      mockTransferDetails,
+      'redeem',
+    );
+
+    // Should detect as insufficient gas error
+    // Message attempts to use toChain gas token if config available
+    expect(errorObj.type).toBe(ERR_INSUFFICIENT_GAS);
+    expect(message).toContain('Insufficient');
+  });
+
+  it('should properly identify destination chain for redeem context', () => {
+    const fogoTransferDetails: TransferDetails = {
+      fromChain: 'Solana',
+      toChain: 'Fogo',
+      fromToken: {
+        symbol: 'SOL',
+        tokenId: { address: 'native', chain: 'Solana' },
+      },
+      toToken: {
+        symbol: 'FOGO',
+        tokenId: { address: 'native', chain: 'Fogo' },
+      },
+      route: 'Bridge',
+      amount: sdkAmount.fromBaseUnits(1000000n, 9),
+    };
+
+    const error = new Error('simulation failed: AccountNotFound');
+    const [message, errorObj] = interpretTransferError(
+      error,
+      fogoTransferDetails,
+      'redeem',
+    );
+
+    // Should return insufficient gas error for destination chain (Fogo, not Solana)
+    // The actual gas token display depends on config availability
+    expect(errorObj.type).toBe(ERR_INSUFFICIENT_GAS);
+    expect(message).toContain('Insufficient');
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -64,6 +64,7 @@ function errorMessageMatches(e: any, regex: RegExp): boolean {
 export function interpretTransferError(
   e: any,
   transferDetails: TransferDetails,
+  context: 'send' | 'redeem',
 ): [string, TransferError] {
   // Fall-back values
   let uiErrorMessage = 'Error with transfer, please try again';
@@ -123,7 +124,14 @@ export function interpretTransferError(
       errorMessageMatches(e, SIMULATION_ACCOUNT_NOT_FOUND_REGEX) ||
       errorMessageMatches(e, INSUFFICIENT_LAMPORTS_REGEX)
     ) {
-      const gasChain = transferDetails.fromChain;
+      // Determine which chain needs gas based on context
+      // - 'send': gas needed on source chain (where send transaction happens)
+      // - 'redeem': gas needed on destination chain (where redeem transaction happens)
+      const gasChain =
+        context === 'send'
+          ? transferDetails.fromChain
+          : transferDetails.toChain;
+
       try {
         const gasToken = getGasToken(gasChain);
         const gasSymbol = getTokenDisplaySymbolByTokenAddress(gasToken);

--- a/src/views/v3/Redeem/index.tsx
+++ b/src/views/v3/Redeem/index.tsx
@@ -298,6 +298,7 @@ function Redeem() {
       const [uiError, transferError] = interpretTransferError(
         receipt.error,
         details,
+        'redeem',
       );
       setClaimError(uiError);
 
@@ -323,6 +324,7 @@ function Redeem() {
       const [uiError, transferError] = interpretTransferError(
         unhandledManualClaimError,
         details,
+        'redeem',
       );
 
       setClaimError(uiError);


### PR DESCRIPTION
This is necessary to know which transaction caused the error, source or destination chain.