### PR TITLE
fix: Skipping value loss filtering for NTT routes

### DIFF
--- a/src/hooks/useFetchQuotes.ts
+++ b/src/hooks/useFetchQuotes.ts
@@ -12,6 +12,7 @@ import { calculateUSDPriceRaw } from 'utils';
 import config from 'config';
 import type { Token } from 'config/tokens';
 import { useTokens } from 'contexts/TokensContext';
+import { isNttRoute } from 'utils/ntt';
 
 type Params = {
   sourceChain?: Chain;
@@ -241,6 +242,11 @@ export default (routes: string[], params: Params): HookReturn => {
     // OR if both tokens have the same symbol and we fail to fetch a USD for either of them
     // we assume they are the same token and just compare the token amounts.
     for (const name in filtered) {
+      // Skip value loss filtering for NTT routes (native token transfers should preserve value 1:1)
+      if (isNttRoute(name)) {
+        continue;
+      }
+
       const quote = filtered[name];
 
       if (quote !== undefined && quote.success) {

--- a/src/utils/ntt.ts
+++ b/src/utils/ntt.ts
@@ -10,6 +10,10 @@ export const nttRoutes = [
   'NttExecutorRoute',
 ] as const;
 
+export const isNttRoute = (routeName: string): boolean => {
+  return (nttRoutes as readonly string[]).includes(routeName);
+};
+
 interface NttTokenOption {
   chain: Chain;
   token: string;


### PR DESCRIPTION
Because native token transfers should preserve value 1:1