### PR TITLE
feat: LiFi route request quote latency improvements

### DIFF
--- a/src/routes/lifi/LiFiRoute.ts
+++ b/src/routes/lifi/LiFiRoute.ts
@@ -207,7 +207,10 @@ export class LiFiRoute<N extends Network>
     };
 
     // Add timing strategies if configured
-    if (this.config?.routeTimingStrategies) {
+    if (
+      this.config?.routeTimingStrategies &&
+      this.config.routeTimingStrategies.length > 0
+    ) {
       routesRequest.options!.timing = {
         routeTimingStrategies:
           this.config.routeTimingStrategies.map(parseTimingStrategy),

--- a/src/routes/lifi/LiFiRoute.ts
+++ b/src/routes/lifi/LiFiRoute.ts
@@ -1,6 +1,6 @@
-import type { QuoteRequest, LiFiStep } from '@lifi/sdk';
+import type { LiFiStep, RoutesRequest } from '@lifi/sdk';
 import {
-  getQuote,
+  getRoutes,
   convertQuoteToRoute,
   config as lifiSdkConfig,
 } from '@lifi/sdk';
@@ -36,6 +36,7 @@ import {
   toLifiTokenAddress,
   generateThrowawayAddress,
   getNativeChainId,
+  parseTimingStrategy,
 } from './utils';
 import {
   DEFAULT_SLIPPAGE_PERCENT,
@@ -163,7 +164,7 @@ export class LiFiRoute<N extends Network>
     } as ValidationResult;
   }
 
-  fetchQuote(
+  async fetchQuote(
     request: routes.RouteTransferRequest<N>,
     params: ValidatedParams,
   ): Promise<LiFiStep> {
@@ -183,39 +184,71 @@ export class LiFiRoute<N extends Network>
 
     const { integrator, feePercent } = this.getFeeConfig(request);
 
-    const quoteRequest: QuoteRequest = {
-      fromChain: fromChainId,
-      toChain: toChainId,
-      fromToken: toLifiTokenAddress(request.source.id),
-      toToken: toLifiTokenAddress(request.destination.id),
+    // Use routes endpoint instead of quote for better latency control
+    const routesRequest: RoutesRequest = {
+      fromChainId,
+      toChainId,
+      fromTokenAddress: toLifiTokenAddress(request.source.id),
+      toTokenAddress: toLifiTokenAddress(request.destination.id),
       fromAmount: sdkAmount
         .units(request.parseAmount(params.amount))
         .toString(),
       fromAddress,
       toAddress,
-      slippage: params.normalizedParams.slippage,
-      maxPriceImpact: params.normalizedParams.maxPriceImpact,
-      integrator,
-      referrer: params.options.referrer,
-      fee: feePercent,
-      routeTimingStrategies: this.config?.routeTimingStrategies,
+      options: {
+        slippage: normalizedParams.slippage,
+        maxPriceImpact: normalizedParams.maxPriceImpact,
+        integrator,
+        referrer: params.options.referrer,
+        fee: feePercent,
+      },
     };
 
-    // Lifi SDK has a AllowDenyPrefer type but then it's converted into a different format for quote requests...
-    if (normalizedParams.bridges?.allow)
-      quoteRequest.allowBridges = normalizedParams.bridges.allow;
-    if (normalizedParams.bridges?.deny)
-      quoteRequest.denyBridges = normalizedParams.bridges.deny;
-    if (normalizedParams.bridges?.prefer)
-      quoteRequest.preferBridges = normalizedParams.bridges.prefer;
-    if (normalizedParams.exchanges?.allow)
-      quoteRequest.allowExchanges = normalizedParams.exchanges.allow;
-    if (normalizedParams.exchanges?.deny)
-      quoteRequest.denyExchanges = normalizedParams.exchanges.deny;
-    if (normalizedParams.exchanges?.prefer)
-      quoteRequest.preferExchanges = normalizedParams.exchanges.prefer;
+    // Add timing strategies if configured
+    if (this.config?.routeTimingStrategies) {
+      routesRequest.options!.timing = {
+        routeTimingStrategies:
+          this.config.routeTimingStrategies.map(parseTimingStrategy),
+      };
+    }
 
-    return getQuote(quoteRequest);
+    // Add bridges and exchanges preferences
+    const bridges = normalizedParams.bridges;
+    if (bridges?.allow || bridges?.deny || bridges?.prefer) {
+      routesRequest.options!.bridges = {
+        ...(bridges.allow && { allow: bridges.allow }),
+        ...(bridges.deny && { deny: bridges.deny }),
+        ...(bridges.prefer && { prefer: bridges.prefer }),
+      };
+    }
+
+    const exchanges = normalizedParams.exchanges;
+    if (exchanges?.allow || exchanges?.deny || exchanges?.prefer) {
+      routesRequest.options!.exchanges = {
+        ...(exchanges.allow && { allow: exchanges.allow }),
+        ...(exchanges.deny && { deny: exchanges.deny }),
+        ...(exchanges.prefer && { prefer: exchanges.prefer }),
+      };
+    }
+
+    const routesResponse = await getRoutes(routesRequest);
+
+    if (!routesResponse.routes || routesResponse.routes.length === 0) {
+      throw new Error('No routes available');
+    }
+
+    const singleStepRoutes = routesResponse.routes.filter(
+      (route) => route.steps.length === 1,
+    );
+
+    if (singleStepRoutes.length === 0) {
+      throw new Error('No single step routes available');
+    }
+
+    const selectedRoute = singleStepRoutes[0];
+
+    // Return the single step directly
+    return selectedRoute.steps[0];
   }
 
   getFeeConfig(request: routes.RouteTransferRequest<N>): LiFiFeeConfig {

--- a/src/routes/lifi/LiFiRoute.ts
+++ b/src/routes/lifi/LiFiRoute.ts
@@ -201,6 +201,8 @@ export class LiFiRoute<N extends Network>
         integrator,
         referrer: params.options.referrer,
         fee: feePercent,
+        allowSwitchChain: false,
+        allowDestinationCall: true,
       },
     };
 
@@ -237,6 +239,7 @@ export class LiFiRoute<N extends Network>
       throw new Error('No routes available');
     }
 
+    // Only care about single step (single signature) routes
     const singleStepRoutes = routesResponse.routes.filter(
       (route) => route.steps.length === 1,
     );
@@ -245,9 +248,8 @@ export class LiFiRoute<N extends Network>
       throw new Error('No single step routes available');
     }
 
+    // Just return the first one
     const selectedRoute = singleStepRoutes[0];
-
-    // Return the single step directly
     return selectedRoute.steps[0];
   }
 

--- a/src/routes/lifi/utils.ts
+++ b/src/routes/lifi/utils.ts
@@ -1,4 +1,4 @@
-import type { ChainId } from '@lifi/sdk';
+import type { ChainId, TimingStrategy, TimingStrategyString } from '@lifi/sdk';
 import {
   getStatus,
   type GetStatusRequest,
@@ -146,4 +146,19 @@ export async function getTransactionStatus(
     return null;
   }
   return response;
+}
+
+export function parseTimingStrategy(
+  strategy: TimingStrategyString,
+): TimingStrategy {
+  const parts = strategy.split('-');
+  if (parts[0] === 'minWaitTime' && parts.length === 4) {
+    return {
+      strategy: 'minWaitTime',
+      minWaitTimeMs: parseInt(parts[1]),
+      startingExpectedResults: parseInt(parts[2]),
+      reduceEveryMs: parseInt(parts[3]),
+    };
+  }
+  throw new Error(`Invalid timing strategy format: ${strategy}`);
 }


### PR DESCRIPTION
Use /advanced/routes instead of the /quote endpoint, which should reduce request latency.

From LiFi:

The routeTimingStrategies setting is not a hard timeout. It only controls how long we wait for enough routes from providers before picking the best one. The /quote endpoint also builds the stepTransaction, which isn’t governed by that timing strategy, so total response time can still end up in the 2–4s range you’re seeing for these routes.

If you need tighter control over latency, we’d recommend calling /routes with your desired timing strategy, selecting a route as soon as you’re happy with one, and then calling /stepTransaction separately when you’re ready to execute. That lets you enforce your own 900ms cutoff on the client side if no acceptable route has arrived yet.

Addresses BRI-190