### PR TITLE
[WIP] feat: Filter spam tokens using CoinGecko token list

### DIFF
--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -9,6 +9,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Ethereum',
     symbol: 'ETH',
     gasReserve: '0.01',
+    coingeckoPlatformId: 1,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Bsc: {
     displayName: 'BNB',
@@ -18,6 +20,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Bsc',
     symbol: 'BSC',
     gasReserve: '0.01',
+    coingeckoPlatformId: 56,
+    coingeckoNativeTokenId: 'binancecoin',
   },
   Polygon: {
     displayName: 'Polygon',
@@ -27,6 +31,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Polygon',
     symbol: 'POL',
     gasReserve: '0.01',
+    coingeckoPlatformId: 137,
+    coingeckoNativeTokenId: 'polygon-ecosystem-token',
   },
   Avalanche: {
     displayName: 'Avalanche',
@@ -36,6 +42,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Avalanche',
     symbol: 'AVAX',
     gasReserve: '0.01',
+    coingeckoPlatformId: 43114,
+    coingeckoNativeTokenId: 'avalanche-2',
   },
   Fantom: {
     displayName: 'Fantom',
@@ -44,6 +52,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Fantom Explorer',
     icon: 'Fantom',
     symbol: 'FTM',
+    coingeckoPlatformId: 250,
+    coingeckoNativeTokenId: 'fantom',
   },
   Celo: {
     displayName: 'Celo',
@@ -53,6 +63,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Celo',
     symbol: 'CELO',
     gasReserve: '0.01',
+    coingeckoPlatformId: 42220,
+    coingeckoNativeTokenId: 'celo',
   },
   Moonbeam: {
     displayName: 'Moonbeam',
@@ -62,6 +74,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Moonbeam',
     symbol: 'GLMR',
     gasReserve: '0.03',
+    coingeckoPlatformId: 1284,
+    coingeckoNativeTokenId: 'moonbeam',
   },
   Solana: {
     displayName: 'Solana',
@@ -71,6 +85,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Solana',
     symbol: 'SOL',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'solana',
+    coingeckoNativeTokenId: 'solana',
   },
   Sui: {
     displayName: 'Sui',
@@ -80,6 +96,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Sui',
     symbol: 'SUI',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'sui',
+    coingeckoNativeTokenId: 'sui',
   },
   Aptos: {
     displayName: 'Aptos',
@@ -89,6 +107,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Aptos',
     symbol: 'APT',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'aptos',
+    coingeckoNativeTokenId: 'aptos',
   },
   Base: {
     displayName: 'Base',
@@ -98,6 +118,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Base',
     symbol: 'BASE',
     gasReserve: '0.001',
+    coingeckoPlatformId: 8453,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Arbitrum: {
     displayName: 'Arbitrum',
@@ -107,6 +129,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Arbitrum',
     symbol: 'ARB',
     gasReserve: '0.001',
+    coingeckoPlatformId: 42161,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Optimism: {
     displayName: 'Optimism',
@@ -116,6 +140,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Optimism',
     symbol: 'OP',
     gasReserve: '0.001',
+    coingeckoPlatformId: 10,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Klaytn: {
     displayName: 'Kaia',
@@ -125,6 +151,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Klaytn',
     symbol: 'KAIA',
     gasReserve: '0.01',
+    coingeckoPlatformId: 8217,
+    coingeckoNativeTokenId: 'kaia',
   },
   Scroll: {
     displayName: 'Scroll',
@@ -134,6 +162,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Scroll',
     symbol: 'SCR',
     gasReserve: '0.001',
+    coingeckoPlatformId: 534352,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Xlayer: {
     displayName: 'X Layer',
@@ -143,6 +173,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Xlayer',
     symbol: 'OKX',
     gasReserve: '0.001',
+    coingeckoPlatformId: 196,
+    coingeckoNativeTokenId: 'okb',
   },
   Mantle: {
     displayName: 'Mantle',
@@ -152,6 +184,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Mantle',
     symbol: 'MNT',
     gasReserve: '0.001',
+    coingeckoPlatformId: 5000,
+    coingeckoNativeTokenId: 'mantle',
   },
   Worldchain: {
     displayName: 'World Chain',
@@ -160,6 +194,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'World Scan',
     icon: 'Worldchain',
     symbol: 'WORLD',
+    coingeckoPlatformId: 480,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Unichain: {
     displayName: 'Unichain',
@@ -168,6 +204,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Uniscan',
     icon: 'Unichain',
     symbol: 'UNI',
+    coingeckoPlatformId: 1301,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Berachain: {
     displayName: 'Berachain',
@@ -176,6 +214,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Berascan',
     icon: 'Berachain',
     symbol: 'BERA',
+    coingeckoPlatformId: 80084,
+    coingeckoNativeTokenId: 'berachain-bera',
   },
   Ink: {
     displayName: 'Ink',
@@ -184,6 +224,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Ink Explorer',
     icon: 'Ink',
     symbol: 'INK',
+    coingeckoPlatformId: 'ink',
+    coingeckoNativeTokenId: 'ethereum',
   },
   Linea: {
     displayName: 'Linea',
@@ -192,6 +234,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Lineascan',
     icon: 'Linea',
     symbol: 'LINEA',
+    coingeckoPlatformId: 59144,
+    coingeckoNativeTokenId: 'ethereum',
   },
   Sonic: {
     displayName: 'Sonic',
@@ -200,6 +244,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Sonicscan',
     icon: 'Sonic',
     symbol: 'S',
+    coingeckoPlatformId: 146,
+    coingeckoNativeTokenId: 'sonic',
   },
   Mezo: {
     displayName: 'Mezo',
@@ -208,6 +254,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Mezo Explorer',
     icon: 'Mezo',
     symbol: 'BTC',
+    coingeckoPlatformId: 'mezo',
+    coingeckoNativeTokenId: 'tbtc',
   },
   Seievm: {
     displayName: 'SeiEVM',
@@ -216,6 +264,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Seitrace',
     icon: 'Seievm',
     symbol: 'SEI',
+    coingeckoPlatformId: 1329,
+    coingeckoNativeTokenId: 'sei',
   },
   Plume: {
     displayName: 'Plume',
@@ -224,6 +274,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Plume Explorer',
     icon: 'Plume',
     symbol: 'PLUME',
+    coingeckoPlatformId: 'plume-network',
+    coingeckoNativeTokenId: 'plume',
   },
   HyperEVM: {
     displayName: 'HyperEVM',
@@ -232,6 +284,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'HyperEVMScan',
     icon: 'HyperEVM',
     symbol: 'HYPE',
+    coingeckoPlatformId: 'hyperevm',
+    coingeckoNativeTokenId: 'hyperliquid',
   },
   HyperCore: {
     displayName: 'HyperCore',
@@ -240,6 +294,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Hyperliquid Explorer',
     icon: 'HyperCore',
     symbol: 'HyperCore',
+    coingeckoPlatformId: 'hypercore',
+    coingeckoNativeTokenId: 'usd-coin',
   },
   XRPLEVM: {
     displayName: 'XRPL EVM',
@@ -249,6 +305,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'XRPLEVM',
     symbol: 'XRP',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'xrpl-evm-sidechain',
+    coingeckoNativeTokenId: 'xrp',
   },
   CreditCoin: {
     displayName: 'Creditcoin',
@@ -257,6 +315,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Blockscout',
     icon: 'CreditCoin',
     symbol: 'CTC',
+    coingeckoPlatformId: 'creditcoin',
+    coingeckoNativeTokenId: 'creditcoin',
   },
   Fogo: {
     displayName: 'Fogo',
@@ -266,6 +326,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Fogo',
     symbol: 'FOGO',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'fogo',
+    coingeckoNativeTokenId: 'fogo',
   },
   Monad: {
     displayName: 'Monad',
@@ -275,6 +337,8 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Monad',
     symbol: 'MON',
     gasReserve: '0.01',
+    coingeckoPlatformId: 'monad',
+    coingeckoNativeTokenId: 'monad',
   },
   MegaETH: {
     displayName: 'MegaETH',
@@ -284,5 +348,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'MegaETH',
     symbol: 'MEGA',
     gasReserve: '0.001',
+    coingeckoPlatformId: 'megaeth',
+    coingeckoNativeTokenId: 'ethereum',
   },
 };

--- a/src/config/mainnet/chains.ts
+++ b/src/config/mainnet/chains.ts
@@ -9,7 +9,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Ethereum',
     symbol: 'ETH',
     gasReserve: '0.01',
-    coingeckoPlatformId: 1,
+    coingeckoPlatformId: 'ethereum',
     coingeckoNativeTokenId: 'ethereum',
   },
   Bsc: {
@@ -20,7 +20,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Bsc',
     symbol: 'BSC',
     gasReserve: '0.01',
-    coingeckoPlatformId: 56,
+    coingeckoPlatformId: 'binance-smart-chain',
     coingeckoNativeTokenId: 'binancecoin',
   },
   Polygon: {
@@ -31,7 +31,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Polygon',
     symbol: 'POL',
     gasReserve: '0.01',
-    coingeckoPlatformId: 137,
+    coingeckoPlatformId: 'polygon-pos',
     coingeckoNativeTokenId: 'polygon-ecosystem-token',
   },
   Avalanche: {
@@ -42,7 +42,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Avalanche',
     symbol: 'AVAX',
     gasReserve: '0.01',
-    coingeckoPlatformId: 43114,
+    coingeckoPlatformId: 'avalanche',
     coingeckoNativeTokenId: 'avalanche-2',
   },
   Fantom: {
@@ -52,7 +52,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Fantom Explorer',
     icon: 'Fantom',
     symbol: 'FTM',
-    coingeckoPlatformId: 250,
+    coingeckoPlatformId: 'fantom',
     coingeckoNativeTokenId: 'fantom',
   },
   Celo: {
@@ -63,7 +63,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Celo',
     symbol: 'CELO',
     gasReserve: '0.01',
-    coingeckoPlatformId: 42220,
+    coingeckoPlatformId: 'celo',
     coingeckoNativeTokenId: 'celo',
   },
   Moonbeam: {
@@ -74,7 +74,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Moonbeam',
     symbol: 'GLMR',
     gasReserve: '0.03',
-    coingeckoPlatformId: 1284,
+    coingeckoPlatformId: 'moonbeam',
     coingeckoNativeTokenId: 'moonbeam',
   },
   Solana: {
@@ -118,7 +118,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Base',
     symbol: 'BASE',
     gasReserve: '0.001',
-    coingeckoPlatformId: 8453,
+    coingeckoPlatformId: 'base',
     coingeckoNativeTokenId: 'ethereum',
   },
   Arbitrum: {
@@ -129,7 +129,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Arbitrum',
     symbol: 'ARB',
     gasReserve: '0.001',
-    coingeckoPlatformId: 42161,
+    coingeckoPlatformId: 'arbitrum-one',
     coingeckoNativeTokenId: 'ethereum',
   },
   Optimism: {
@@ -140,7 +140,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Optimism',
     symbol: 'OP',
     gasReserve: '0.001',
-    coingeckoPlatformId: 10,
+    coingeckoPlatformId: 'optimistic-ethereum',
     coingeckoNativeTokenId: 'ethereum',
   },
   Klaytn: {
@@ -151,7 +151,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Klaytn',
     symbol: 'KAIA',
     gasReserve: '0.01',
-    coingeckoPlatformId: 8217,
+    coingeckoPlatformId: 'klay-token',
     coingeckoNativeTokenId: 'kaia',
   },
   Scroll: {
@@ -162,7 +162,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Scroll',
     symbol: 'SCR',
     gasReserve: '0.001',
-    coingeckoPlatformId: 534352,
+    coingeckoPlatformId: 'scroll',
     coingeckoNativeTokenId: 'ethereum',
   },
   Xlayer: {
@@ -173,7 +173,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Xlayer',
     symbol: 'OKX',
     gasReserve: '0.001',
-    coingeckoPlatformId: 196,
+    coingeckoPlatformId: 'x-layer',
     coingeckoNativeTokenId: 'okb',
   },
   Mantle: {
@@ -184,7 +184,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     icon: 'Mantle',
     symbol: 'MNT',
     gasReserve: '0.001',
-    coingeckoPlatformId: 5000,
+    coingeckoPlatformId: 'mantle',
     coingeckoNativeTokenId: 'mantle',
   },
   Worldchain: {
@@ -194,7 +194,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'World Scan',
     icon: 'Worldchain',
     symbol: 'WORLD',
-    coingeckoPlatformId: 480,
+    coingeckoPlatformId: 'world-chain',
     coingeckoNativeTokenId: 'ethereum',
   },
   Unichain: {
@@ -204,7 +204,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Uniscan',
     icon: 'Unichain',
     symbol: 'UNI',
-    coingeckoPlatformId: 1301,
+    coingeckoPlatformId: 'unichain',
     coingeckoNativeTokenId: 'ethereum',
   },
   Berachain: {
@@ -214,7 +214,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Berascan',
     icon: 'Berachain',
     symbol: 'BERA',
-    coingeckoPlatformId: 80084,
+    coingeckoPlatformId: 'berachain',
     coingeckoNativeTokenId: 'berachain-bera',
   },
   Ink: {
@@ -234,7 +234,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Lineascan',
     icon: 'Linea',
     symbol: 'LINEA',
-    coingeckoPlatformId: 59144,
+    coingeckoPlatformId: 'linea',
     coingeckoNativeTokenId: 'ethereum',
   },
   Sonic: {
@@ -244,7 +244,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Sonicscan',
     icon: 'Sonic',
     symbol: 'S',
-    coingeckoPlatformId: 146,
+    coingeckoPlatformId: 'sonic',
     coingeckoNativeTokenId: 'sonic',
   },
   Mezo: {
@@ -264,7 +264,7 @@ export const MAINNET_CHAINS: ChainsConfig = {
     explorerName: 'Seitrace',
     icon: 'Seievm',
     symbol: 'SEI',
-    coingeckoPlatformId: 1329,
+    coingeckoPlatformId: 'sei-v2',
     coingeckoNativeTokenId: 'sei',
   },
   Plume: {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -246,6 +246,17 @@ export interface ChainConfig {
    * - Solana: '0.01' ($1.3 notional)
    */
   gasReserve?: string;
+  /**
+   * CoinGecko platform identifier for token lists and prices.
+   * Can be chain ID number (EVM) or platform name string.
+   * Examples: 1 (Ethereum), 56 (BSC), 'solana', 'binance-smart-chain'
+   */
+  coingeckoPlatformId?: number | string;
+  /**
+   * CoinGecko coin ID for the chain's native token price.
+   * Examples: 'ethereum', 'solana', 'binancecoin'
+   */
+  coingeckoNativeTokenId?: string;
 }
 
 export type ChainsConfig = {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -248,10 +248,9 @@ export interface ChainConfig {
   gasReserve?: string;
   /**
    * CoinGecko platform identifier for token lists and prices.
-   * Can be chain ID number (EVM) or platform name string.
-   * Examples: 1 (Ethereum), 56 (BSC), 'solana', 'binance-smart-chain'
+   * Examples: 'ethereum', 'binance-smart-chain', 'solana', 'arbitrum-one'
    */
-  coingeckoPlatformId?: number | string;
+  coingeckoPlatformId?: string;
   /**
    * CoinGecko coin ID for the chain's native token price.
    * Examples: 'ethereum', 'solana', 'binancecoin'

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -95,7 +95,7 @@ export type TestOptions = {
   enableHeadlessSigner?: boolean;
 };
 
-export type Experiments = 'feeOffsetting';
+export type Experiments = 'feeOffsetting' | 'enableCoingeckoSpamFilter';
 export type Experimental = {
   [Experiment in Experiments]?: boolean;
 };

--- a/src/hooks/useCoingeckoTokenList.ts
+++ b/src/hooks/useCoingeckoTokenList.ts
@@ -1,20 +1,29 @@
 import { useEffect, useState } from 'react';
 import type { Chain } from '@wormhole-foundation/sdk';
 import { fetchCoingeckoTokenListForChain } from 'utils/coingecko';
+import config from 'config';
 
 /**
  * Hook to fetch and cache CoinGecko token list for a specific chain.
  * Returns null while loading or if the chain is not supported.
  * Returns a Set of token addresses (lowercase) once loaded.
+ *
+ * The hook respects the experimental flag `enableCoingeckoSpamFilter`.
+ * If the flag is disabled, the hook will not fetch data and returns undefined.
  */
 export const useCoingeckoTokenList = (
   chain: Chain | undefined,
-): Set<string> | null => {
-  const [tokenList, setTokenList] = useState<Set<string> | null>(null);
+): Set<string> | undefined => {
+  const [tokenList, setTokenList] = useState<Set<string> | undefined>(
+    undefined,
+  );
 
   useEffect(() => {
-    if (!chain) {
-      setTokenList(null);
+    // Check experimental flag to enable/disable CoinGecko fetching
+    const enableCoingecko = config.ui?.experimental?.enableCoingeckoSpamFilter;
+
+    if (!chain || !enableCoingecko) {
+      setTokenList(undefined);
       return;
     }
 

--- a/src/hooks/useCoingeckoTokenList.ts
+++ b/src/hooks/useCoingeckoTokenList.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import type { Chain } from '@wormhole-foundation/sdk';
+import { fetchCoingeckoTokenListForChain } from 'utils/coingecko';
+
+/**
+ * Hook to fetch and cache CoinGecko token list for a specific chain.
+ * Returns null while loading or if the chain is not supported.
+ * Returns a Set of token addresses (lowercase) once loaded.
+ */
+export const useCoingeckoTokenList = (
+  chain: Chain | undefined,
+): Set<string> | null => {
+  const [tokenList, setTokenList] = useState<Set<string> | null>(null);
+
+  useEffect(() => {
+    if (!chain) {
+      setTokenList(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchTokens = async () => {
+      try {
+        const tokens = await fetchCoingeckoTokenListForChain(chain);
+
+        if (!cancelled) {
+          setTokenList(tokens);
+        }
+      } catch (error) {
+        console.error('Error in useCoingeckoTokenList:', error);
+        if (!cancelled) {
+          // Return empty set on error to allow fallback filter
+          setTokenList(new Set());
+        }
+      }
+    };
+
+    fetchTokens();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [chain]);
+
+  return tokenList;
+};

--- a/src/hooks/useCoingeckoTokenList.ts
+++ b/src/hooks/useCoingeckoTokenList.ts
@@ -39,8 +39,8 @@ export const useCoingeckoTokenList = (
       } catch (error) {
         console.error('Error in useCoingeckoTokenList:', error);
         if (!cancelled) {
-          // Return empty set on error to allow fallback filter
-          setTokenList(new Set());
+          // Return undefined on error to fall back to basic filtering
+          setTokenList(undefined);
         }
       }
     };

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -10,8 +10,10 @@ import {
   applyTokenWhitelist,
   applyCustomTokenSupport,
   applyShittokenFilter,
+  applyCoingeckoFilter,
 } from 'utils/tokenListUtils';
 import config from 'config';
+import { useCoingeckoTokenList } from './useCoingeckoTokenList';
 
 interface UseTokenListParams {
   tokenList: Token[];
@@ -37,6 +39,9 @@ export const useTokenList = ({
   isSourceList = false,
 }: UseTokenListParams): Token[] => {
   const { getTokenPrice, lastTokenPriceUpdate } = useTokens();
+
+  // Fetch CoinGecko token list for spam filtering
+  const coingeckoTokens = useCoingeckoTokenList(selectedChainConfig?.sdkName);
 
   return useMemo(() => {
     if (!tokenList) return [];
@@ -65,8 +70,13 @@ export const useTokenList = ({
 
     // For source list, we filter further because we're loading arbitrary tokens in their wallet
     if (isSourceList && !searchQuery && config.network === 'Mainnet') {
-      // Filter out possible scamcoins
-      tokens = applyShittokenFilter(tokens);
+      // Use CoinGecko filter if available, otherwise fallback to old filter
+      if (coingeckoTokens && coingeckoTokens.size > 0) {
+        tokens = applyCoingeckoFilter(tokens, coingeckoTokens);
+      } else {
+        // Fallback to old filter while CoinGecko list is loading or unavailable
+        tokens = applyShittokenFilter(tokens);
+      }
     }
 
     return tokens;
@@ -83,5 +93,6 @@ export const useTokenList = ({
     isSourceList,
     sourceToken,
     destToken,
+    coingeckoTokens,
   ]);
 };

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -9,8 +9,7 @@ import {
   sortTokensByPreference,
   applyTokenWhitelist,
   applyCustomTokenSupport,
-  applyShittokenFilter,
-  applyCoingeckoFilter,
+  applySpamFilter,
 } from 'utils/tokenListUtils';
 import config from 'config';
 import { useCoingeckoTokenList } from './useCoingeckoTokenList';
@@ -70,13 +69,8 @@ export const useTokenList = ({
 
     // For source list, we filter further because we're loading arbitrary tokens in their wallet
     if (isSourceList && !searchQuery && config.network === 'Mainnet') {
-      // Use CoinGecko filter if available, otherwise fallback to old filter
-      if (coingeckoTokens && coingeckoTokens.size > 0) {
-        tokens = applyCoingeckoFilter(tokens, coingeckoTokens);
-      } else {
-        // Fallback to old filter while CoinGecko list is loading or unavailable
-        tokens = applyShittokenFilter(tokens);
-      }
+      // Apply spam filter (uses CoinGecko data if available, falls back to basic filtering)
+      tokens = applySpamFilter(tokens, coingeckoTokens || undefined);
     }
 
     return tokens;

--- a/src/hooks/useTokenList.ts
+++ b/src/hooks/useTokenList.ts
@@ -40,6 +40,7 @@ export const useTokenList = ({
   const { getTokenPrice, lastTokenPriceUpdate } = useTokens();
 
   // Fetch CoinGecko token list for spam filtering
+  // The hook internally checks the experimental flag
   const coingeckoTokens = useCoingeckoTokenList(selectedChainConfig?.sdkName);
 
   return useMemo(() => {
@@ -69,8 +70,8 @@ export const useTokenList = ({
 
     // For source list, we filter further because we're loading arbitrary tokens in their wallet
     if (isSourceList && !searchQuery && config.network === 'Mainnet') {
-      // Apply spam filter (uses CoinGecko data if available, falls back to basic filtering)
-      tokens = applySpamFilter(tokens, coingeckoTokens || undefined);
+      // Apply spam filter with CoinGecko data
+      tokens = applySpamFilter(tokens, coingeckoTokens);
     }
 
     return tokens;

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -1,4 +1,4 @@
-import type { Chain, NativeAddress } from '@wormhole-foundation/sdk';
+import type { Chain, NativeAddress, Platform } from '@wormhole-foundation/sdk';
 import { chainToPlatform, encoding, toNative } from '@wormhole-foundation/sdk';
 import { isValidSuiAddress } from '@mysten/sui/utils';
 import { Connection, PublicKey } from '@solana/web3.js';
@@ -90,4 +90,20 @@ export async function validateWalletAddress(
   }
 
   return null;
+}
+
+/**
+ * Normalizes an address for comparison purposes.
+ * EVM addresses are case-insensitive, so we lowercase them.
+ * Other platforms (Solana, Sui, Aptos) have case-sensitive addresses.
+ */
+export function normalizeAddress(address: string, chain: Chain): string {
+  const platform: Platform = chainToPlatform(chain);
+
+  if (platform === 'Evm') {
+    return address.toLowerCase();
+  }
+
+  // Solana, Sui, Aptos addresses are case-sensitive
+  return address;
 }

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -11,97 +11,6 @@ const COINGECKO_TOKEN_LIST_URL = 'https://tokens.coingecko.com';
 const TOKEN_LIST_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
 const ASSET_PLATFORMS_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
 
-// Map our Chain types to their numeric chain IDs or platform identifiers on CoinGecko
-// These will be used to match against CoinGecko's asset_platforms API
-const CHAIN_TO_COINGECKO_ID: Partial<Record<Chain, number | string>> = {
-  Ethereum: 1,
-  Bsc: 56,
-  Polygon: 137,
-  Avalanche: 43114,
-  Fantom: 250,
-  Celo: 42220,
-  Moonbeam: 1284,
-  Base: 8453,
-  Arbitrum: 42161,
-  Optimism: 10,
-  Klaytn: 8217,
-  Scroll: 534352,
-  Xlayer: 196,
-  Mantle: 5000,
-  Worldchain: 480,
-  Unichain: 1301,
-  Berachain: 80084,
-  Ink: 'ink',
-  Linea: 59144,
-  Sonic: 146,
-  Mezo: 'mezo',
-  Seievm: 1329,
-  Plume: 'plume-network',
-  HyperEVM: 'hyperevm',
-  HyperCore: 'hypercore',
-  XRPLEVM: 'xrpl-evm-sidechain',
-  CreditCoin: 'creditcoin',
-  Fogo: 'fogo',
-  Solana: 'solana',
-  Sui: 'sui',
-  Aptos: 'aptos',
-};
-
-const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
-  Solana: 'solana',
-  Ethereum: 'ethereum',
-  Arbitrum: 'ethereum',
-  Optimism: 'ethereum',
-  Base: 'ethereum',
-  Scroll: 'ethereum',
-  Bsc: 'binancecoin',
-  Polygon: 'matic-network',
-  Avalanche: 'avalanche-2',
-  Fantom: 'fantom',
-  Moonbeam: 'moonbeam',
-  Klaytn: 'kaia',
-  Xlayer: 'okb',
-  Mantle: 'mantle',
-  Aptos: 'aptos',
-  Sui: 'sui',
-  Berachain: 'berachain-bera',
-  Unichain: 'ethereum',
-  Sonic: 'sonic-3',
-  Linea: 'ethereum',
-  Worldchain: 'ethereum',
-  Seievm: 'sei',
-  Mezo: 'wrapped-bitcoin',
-  Plume: 'plume',
-  Ink: 'ethereum',
-  HyperEVM: 'hyperliquid',
-  HyperCore: 'usd-coin',
-  CreditCoin: 'wrapped-ctc',
-  Monad: 'monad',
-  Fogo: 'fogo',
-  Moca: 'moca',
-  MegaETH: 'ethereum',
-};
-
-// This refers to Coingecko API's platform names: https://api.coingecko.com/api/v3/asset_platforms
-const CHAIN_IDS: Partial<Record<Chain, string>> = {
-  Bsc: 'binance-smart-chain',
-  Arbitrum: 'arbitrum-one',
-  Optimism: 'optimistic-ethereum',
-  Polygon: 'polygon-pos',
-  Klaytn: 'klay-token',
-  Xlayer: 'x-layer',
-  Worldchain: 'world-chain',
-  Seievm: 'sei-v2',
-  Mezo: 'mezo',
-  HyperEVM: 'hyperevm',
-  Plume: 'plume-network',
-  Ink: 'ink',
-  HyperCore: 'hypercore',
-  Monad: 'monad',
-  Fogo: 'fogo',
-  Moca: 'moca',
-};
-
 export interface CoingeckoParams {
   abort: AbortController;
 }
@@ -191,7 +100,9 @@ export const fetchTokenPrices = async (
 
     return new Promise((resolve, reject) => {
       const addrs = addresses.join(',');
-      const cgChain = CHAIN_IDS[chain] || chain.toLowerCase();
+      const chainConfig = config.chains[chain as Chain];
+      const platformId = chainConfig?.coingeckoPlatformId;
+      const cgChain = platformId?.toString() || chain.toLowerCase();
 
       coingeckoRequest(
         `/api/v3/simple/token_price/${cgChain}?contract_addresses=${addrs}&vs_currencies=usd`,
@@ -234,7 +145,8 @@ export const fetchTokenPrices = async (
       new Promise((resolve, reject) => {
         const ids: string[] = [];
         for (const token of nativeTokens) {
-          const cgid = NATIVE_TOKEN_IDS[token.chain];
+          const chainConfig = config.chains[token.chain];
+          const cgid = chainConfig?.coingeckoNativeTokenId;
           if (cgid) {
             ids.push(cgid);
           } else {
@@ -252,7 +164,8 @@ export const fetchTokenPrices = async (
             resolve(
               nativeTokens
                 .map((tokenId) => {
-                  const cgid = NATIVE_TOKEN_IDS[tokenId.chain];
+                  const chainConfig = config.chains[tokenId.chain];
+                  const cgid = chainConfig?.coingeckoNativeTokenId;
                   if (cgid) {
                     const { usd } = data[cgid];
                     return {
@@ -373,7 +286,8 @@ const fetchAssetPlatforms = async (): Promise<Record<string, string>> => {
  * Uses the asset platforms API to dynamically match chains.
  */
 const getPlatformIdForChain = async (chain: Chain): Promise<string | null> => {
-  const identifier = CHAIN_TO_COINGECKO_ID[chain];
+  const chainConfig = config.chains[chain];
+  const identifier = chainConfig?.coingeckoPlatformId;
   if (!identifier) {
     return null;
   }
@@ -445,7 +359,10 @@ export const fetchCoingeckoTokenListForChain = async (
       throw new Error('Invalid token list response format');
     }
 
-    // Extract addresses and normalize to lowercase
+    // TODO: Address normalization should be chain-aware instead of blanket toLowerCase()
+    // Current implementation works for EVM chains but breaks Solana/Sui case-sensitive addresses.
+    // Should use SDK's canonicalAddress() or a chain-aware normalizeAddress() utility.
+    // Extract addresses and normalize to lowercase (EVM-only, breaks Solana/Sui)
     const addresses = data.tokens.map((token: any) =>
       token.address.toLowerCase(),
     );

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -2,6 +2,7 @@ import type { Chain, TokenId } from '@wormhole-foundation/sdk';
 import { isNative, Wormhole } from '@wormhole-foundation/sdk';
 import config from 'config';
 import { TokenMapping } from 'config/tokens';
+import { normalizeAddress } from './address';
 
 const COINGECKO_URL = 'https://api.coingecko.com';
 const COINGECKO_URL_PRO = 'https://pro-api.coingecko.com';
@@ -359,12 +360,10 @@ export const fetchCoingeckoTokenListForChain = async (
       throw new Error('Invalid token list response format');
     }
 
-    // TODO: Address normalization should be chain-aware instead of blanket toLowerCase()
-    // Current implementation works for EVM chains but breaks Solana/Sui case-sensitive addresses.
-    // Should use SDK's canonicalAddress() or a chain-aware normalizeAddress() utility.
-    // Extract addresses and normalize to lowercase (EVM-only, breaks Solana/Sui)
+    // Normalize addresses based on chain type
+    // EVM: lowercase (case-insensitive), Solana/Sui/Aptos: preserve case
     const addresses = data.tokens.map((token: any) =>
-      token.address.toLowerCase(),
+      normalizeAddress(token.address, chain),
     );
 
     // Cache in localStorage

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -6,7 +6,6 @@ import { normalizeAddress } from './address';
 
 const COINGECKO_URL = 'https://api.coingecko.com';
 const COINGECKO_URL_PRO = 'https://pro-api.coingecko.com';
-const COINGECKO_TOKEN_LIST_URL = 'https://tokens.coingecko.com';
 
 // Cache durations
 const TOKEN_LIST_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
@@ -240,25 +239,9 @@ export const fetchCoingeckoTokenListForChain = async (
   try {
     console.info(`Fetching CoinGecko token list for ${chain}...`);
 
-    let data;
-    // Use Pro API endpoint if API key is configured, otherwise use public token list URL
-    if (config.coingecko?.apiKey) {
-      data = await coingeckoRequest(
-        `/api/v3/token_lists/${platformId}/all.json`,
-      );
-    } else {
-      const response = await fetch(
-        `${COINGECKO_TOKEN_LIST_URL}/${platformId}/all.json`,
-      );
-
-      if (!response.ok) {
-        throw new Error(
-          `Failed to fetch token list: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      data = await response.json();
-    }
+    const data = await coingeckoRequest(
+      `/api/v3/token_lists/${platformId}/all.json`,
+    );
 
     if (!data || !data.tokens || !Array.isArray(data.tokens)) {
       throw new Error('Invalid token list response format');

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -5,6 +5,47 @@ import { TokenMapping } from 'config/tokens';
 
 const COINGECKO_URL = 'https://api.coingecko.com';
 const COINGECKO_URL_PRO = 'https://pro-api.coingecko.com';
+const COINGECKO_TOKEN_LIST_URL = 'https://tokens.coingecko.com';
+
+// Cache durations
+const TOKEN_LIST_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+const ASSET_PLATFORMS_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
+
+// Map our Chain types to their numeric chain IDs or platform identifiers on CoinGecko
+// These will be used to match against CoinGecko's asset_platforms API
+const CHAIN_TO_COINGECKO_ID: Partial<Record<Chain, number | string>> = {
+  Ethereum: 1,
+  Bsc: 56,
+  Polygon: 137,
+  Avalanche: 43114,
+  Fantom: 250,
+  Celo: 42220,
+  Moonbeam: 1284,
+  Base: 8453,
+  Arbitrum: 42161,
+  Optimism: 10,
+  Klaytn: 8217,
+  Scroll: 534352,
+  Xlayer: 196,
+  Mantle: 5000,
+  Worldchain: 480,
+  Unichain: 1301,
+  Berachain: 80084,
+  Ink: 'ink',
+  Linea: 59144,
+  Sonic: 146,
+  Mezo: 'mezo',
+  Seievm: 1329,
+  Plume: 'plume-network',
+  HyperEVM: 'hyperevm',
+  HyperCore: 'hypercore',
+  XRPLEVM: 'xrpl-evm-sidechain',
+  CreditCoin: 'creditcoin',
+  Fogo: 'fogo',
+  Solana: 'solana',
+  Sui: 'sui',
+  Aptos: 'aptos',
+};
 
 const NATIVE_TOKEN_IDS: Partial<Record<Chain, string>> = {
   Solana: 'solana',
@@ -63,6 +104,24 @@ const CHAIN_IDS: Partial<Record<Chain, string>> = {
 
 export interface CoingeckoParams {
   abort: AbortController;
+}
+
+interface TokenListCache {
+  addresses: string[];
+  timestamp: number;
+}
+
+interface AssetPlatform {
+  id: string;
+  chain_identifier: number | null;
+  name: string;
+  shortname: string;
+}
+
+interface AssetPlatformsCache {
+  platforms: AssetPlatform[];
+  platformMap: Record<string, string>; // Chain identifier/name -> platform id
+  timestamp: number;
 }
 
 const coingeckoRequest = async (
@@ -231,4 +290,173 @@ export const fetchTokenPrices = async (
   }
 
   return tm;
+};
+
+/**
+ * Fetches and caches the asset platforms from CoinGecko API.
+ * Returns a mapping from our chain identifiers to CoinGecko platform IDs.
+ * Uses localStorage for caching with 24-hour TTL.
+ */
+const fetchAssetPlatforms = async (): Promise<Record<string, string>> => {
+  const cacheKey = config.cacheKey('coingecko-platforms');
+
+  // Try to load from localStorage cache
+  try {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      const { platformMap, timestamp }: AssetPlatformsCache =
+        JSON.parse(cached);
+      const now = Date.now();
+
+      if (now - timestamp < ASSET_PLATFORMS_CACHE_DURATION) {
+        console.debug('Using cached CoinGecko asset platforms');
+        return platformMap;
+      }
+    }
+  } catch (e) {
+    console.error('Error reading CoinGecko asset platforms cache:', e);
+  }
+
+  // Fetch fresh data from CoinGecko
+  try {
+    console.info('Fetching CoinGecko asset platforms...');
+    const platforms = await coingeckoRequest('/api/v3/asset_platforms');
+
+    if (!platforms || !Array.isArray(platforms)) {
+      throw new Error('Invalid asset platforms response');
+    }
+
+    // Build mapping from chain_identifier -> platform id
+    const platformMap: Record<string, string> = {};
+
+    for (const platform of platforms as AssetPlatform[]) {
+      // Map by chain_identifier (for EVM chains)
+      if (platform.chain_identifier !== null) {
+        platformMap[platform.chain_identifier.toString()] = platform.id;
+      }
+      // Also map by platform id (for non-EVM chains)
+      platformMap[platform.id] = platform.id;
+    }
+
+    // Cache in localStorage
+    try {
+      const cacheData: AssetPlatformsCache = {
+        platforms: platforms as AssetPlatform[],
+        platformMap,
+        timestamp: Date.now(),
+      };
+      localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+      console.info(`Cached ${platforms.length} asset platforms from CoinGecko`);
+    } catch (e) {
+      console.error('Error caching CoinGecko asset platforms:', e);
+    }
+
+    return platformMap;
+  } catch (error) {
+    console.error('Error fetching CoinGecko asset platforms:', error);
+    return {};
+  }
+};
+
+/**
+ * Gets the CoinGecko platform ID for a given chain.
+ * Uses the asset platforms API to dynamically match chains.
+ */
+const getPlatformIdForChain = async (chain: Chain): Promise<string | null> => {
+  const identifier = CHAIN_TO_COINGECKO_ID[chain];
+  if (!identifier) {
+    return null;
+  }
+
+  const platformMap = await fetchAssetPlatforms();
+  return platformMap[identifier.toString()] || null;
+};
+
+/**
+ * Fetches the CoinGecko token list for a specific chain.
+ * Returns a Set of token addresses (lowercase) that are in CoinGecko's top 1000 for that chain.
+ * Uses localStorage for caching with 24-hour TTL.
+ */
+export const fetchCoingeckoTokenListForChain = async (
+  chain: Chain,
+): Promise<Set<string>> => {
+  const platformId = await getPlatformIdForChain(chain);
+
+  if (!platformId) {
+    console.debug(
+      `No CoinGecko token list platform ID for chain ${chain}, skipping filter`,
+    );
+    return new Set();
+  }
+
+  const cacheKey = config.cacheKey(`coingecko-tokens-${chain}`);
+
+  // Try to load from localStorage cache
+  try {
+    const cached = localStorage.getItem(cacheKey);
+    if (cached) {
+      const { addresses, timestamp }: TokenListCache = JSON.parse(cached);
+      const now = Date.now();
+
+      if (now - timestamp < TOKEN_LIST_CACHE_DURATION) {
+        console.debug(`Using cached CoinGecko token list for ${chain}`);
+        return new Set(addresses);
+      }
+    }
+  } catch (e) {
+    console.error('Error reading CoinGecko token list cache:', e);
+  }
+
+  // Fetch fresh data
+  try {
+    console.info(`Fetching CoinGecko token list for ${chain}...`);
+
+    let data;
+    // Use Pro API endpoint if API key is configured, otherwise use public token list URL
+    if (config.coingecko?.apiKey) {
+      data = await coingeckoRequest(
+        `/api/v3/token_lists/${platformId}/all.json`,
+      );
+    } else {
+      const response = await fetch(
+        `${COINGECKO_TOKEN_LIST_URL}/${platformId}/all.json`,
+      );
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch token list: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      data = await response.json();
+    }
+
+    if (!data || !data.tokens || !Array.isArray(data.tokens)) {
+      throw new Error('Invalid token list response format');
+    }
+
+    // Extract addresses and normalize to lowercase
+    const addresses = data.tokens.map((token: any) =>
+      token.address.toLowerCase(),
+    );
+
+    // Cache in localStorage
+    try {
+      const cacheData: TokenListCache = {
+        addresses,
+        timestamp: Date.now(),
+      };
+      localStorage.setItem(cacheKey, JSON.stringify(cacheData));
+    } catch (e) {
+      console.error('Error caching CoinGecko token list:', e);
+    }
+
+    console.info(
+      `Fetched ${addresses.length} tokens from CoinGecko for ${chain}`,
+    );
+    return new Set(addresses);
+  } catch (error) {
+    console.error(`Error fetching CoinGecko token list for ${chain}:`, error);
+    return new Set();
+  }
 };

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -10,7 +10,6 @@ const COINGECKO_TOKEN_LIST_URL = 'https://tokens.coingecko.com';
 
 // Cache durations
 const TOKEN_LIST_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
-const ASSET_PLATFORMS_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours
 
 export interface CoingeckoParams {
   abort: AbortController;
@@ -18,19 +17,6 @@ export interface CoingeckoParams {
 
 interface TokenListCache {
   addresses: string[];
-  timestamp: number;
-}
-
-interface AssetPlatform {
-  id: string;
-  chain_identifier: number | null;
-  name: string;
-  shortname: string;
-}
-
-interface AssetPlatformsCache {
-  platforms: AssetPlatform[];
-  platformMap: Record<string, string>; // Chain identifier/name -> platform id
   timestamp: number;
 }
 
@@ -207,94 +193,12 @@ export const fetchTokenPrices = async (
 };
 
 /**
- * Fetches and caches the asset platforms from CoinGecko API.
- * Returns a mapping from our chain identifiers to CoinGecko platform IDs.
- * Uses localStorage for caching with 24-hour TTL.
- */
-const fetchAssetPlatforms = async (): Promise<Record<string, string>> => {
-  const cacheKey = config.cacheKey('coingecko-platforms');
-
-  // Try to load from localStorage cache
-  try {
-    const cached = localStorage.getItem(cacheKey);
-    if (cached) {
-      const { platformMap, timestamp }: AssetPlatformsCache =
-        JSON.parse(cached);
-      const now = Date.now();
-
-      if (now - timestamp < ASSET_PLATFORMS_CACHE_DURATION) {
-        console.debug('Using cached CoinGecko asset platforms');
-        return platformMap;
-      }
-    }
-  } catch (e) {
-    console.error('Error reading CoinGecko asset platforms cache:', e);
-  }
-
-  // Fetch fresh data from CoinGecko
-  // Always use standard CoinGecko API for asset platforms (not custom URL)
-  // This is a static reference list that should come from official API
-  try {
-    console.info('Fetching CoinGecko asset platforms...');
-    const response = await fetch(`${COINGECKO_URL}/api/v3/asset_platforms`);
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch asset platforms: ${response.status} ${response.statusText}`,
-      );
-    }
-
-    const platforms = await response.json();
-
-    if (!platforms || !Array.isArray(platforms)) {
-      throw new Error('Invalid asset platforms response');
-    }
-
-    // Build mapping from chain_identifier -> platform id
-    const platformMap: Record<string, string> = {};
-
-    for (const platform of platforms as AssetPlatform[]) {
-      // Map by chain_identifier (for EVM chains)
-      if (platform.chain_identifier !== null) {
-        platformMap[platform.chain_identifier.toString()] = platform.id;
-      }
-      // Also map by platform id (for non-EVM chains)
-      platformMap[platform.id] = platform.id;
-    }
-
-    // Cache in localStorage
-    try {
-      const cacheData: AssetPlatformsCache = {
-        platforms: platforms as AssetPlatform[],
-        platformMap,
-        timestamp: Date.now(),
-      };
-      localStorage.setItem(cacheKey, JSON.stringify(cacheData));
-      console.info(`Cached ${platforms.length} asset platforms from CoinGecko`);
-    } catch (e) {
-      console.error('Error caching CoinGecko asset platforms:', e);
-    }
-
-    return platformMap;
-  } catch (error) {
-    console.error('Error fetching CoinGecko asset platforms:', error);
-    return {};
-  }
-};
-
-/**
  * Gets the CoinGecko platform ID for a given chain.
- * Uses the asset platforms API to dynamically match chains.
+ * Returns the coingeckoPlatformId directly from chain config.
  */
-const getPlatformIdForChain = async (chain: Chain): Promise<string | null> => {
+const getPlatformIdForChain = (chain: Chain): string | null => {
   const chainConfig = config.chains[chain];
-  const identifier = chainConfig?.coingeckoPlatformId;
-  if (!identifier) {
-    return null;
-  }
-
-  const platformMap = await fetchAssetPlatforms();
-  return platformMap[identifier.toString()] || null;
+  return chainConfig?.coingeckoPlatformId ?? null;
 };
 
 /**
@@ -305,7 +209,7 @@ const getPlatformIdForChain = async (chain: Chain): Promise<string | null> => {
 export const fetchCoingeckoTokenListForChain = async (
   chain: Chain,
 ): Promise<Set<string>> => {
-  const platformId = await getPlatformIdForChain(chain);
+  const platformId = getPlatformIdForChain(chain);
 
   if (!platformId) {
     console.debug(

--- a/src/utils/coingecko.ts
+++ b/src/utils/coingecko.ts
@@ -318,9 +318,19 @@ const fetchAssetPlatforms = async (): Promise<Record<string, string>> => {
   }
 
   // Fetch fresh data from CoinGecko
+  // Always use standard CoinGecko API for asset platforms (not custom URL)
+  // This is a static reference list that should come from official API
   try {
     console.info('Fetching CoinGecko asset platforms...');
-    const platforms = await coingeckoRequest('/api/v3/asset_platforms');
+    const response = await fetch(`${COINGECKO_URL}/api/v3/asset_platforms`);
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch asset platforms: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const platforms = await response.json();
 
     if (!platforms || !Array.isArray(platforms)) {
       throw new Error('Invalid asset platforms response');

--- a/src/utils/tokenListUtils.test.ts
+++ b/src/utils/tokenListUtils.test.ts
@@ -5,7 +5,7 @@ import {
   calculateTokenUSDBalance,
   sortTokensByPreference,
   applyCustomTokenSupport,
-  applyShittokenFilter,
+  applySpamFilter,
   filterTokensByBalance,
 } from './tokenListUtils';
 import type { Token } from 'config/tokens';
@@ -395,19 +395,19 @@ describe('tokenListUtils', () => {
     });
   });
 
-  describe('applyShittokenFilter', () => {
-    it('should filter out unknown tokens', () => {
+  describe('applySpamFilter', () => {
+    it('should filter out unknown tokens (basic mode)', () => {
       const unknownToken = createMockToken({
         isNativeGasToken: false,
         isBuiltin: false,
         isTokenBridgeWrappedToken: false,
       });
       const tokens = [unknownToken];
-      const filtered = applyShittokenFilter(tokens);
+      const filtered = applySpamFilter(tokens);
       expect(filtered).toHaveLength(0);
     });
 
-    it('should filter mixed token list correctly', () => {
+    it('should filter mixed token list correctly (basic mode)', () => {
       const nativeToken = createMockToken({
         isNativeGasToken: true,
         symbol: 'ETH',
@@ -419,12 +419,56 @@ describe('tokenListUtils', () => {
       });
 
       const tokens = [unknownToken, nativeToken, verifiedToken];
-      const filtered = applyShittokenFilter(tokens);
+      const filtered = applySpamFilter(tokens);
 
       expect(filtered).toHaveLength(2);
       expect(filtered.find((t) => t.symbol === 'SCAM')).toBeUndefined();
       expect(filtered.find((t) => t.symbol === 'ETH')).toBeDefined();
       expect(filtered.find((t) => t.symbol === 'USDC')).toBeDefined();
+    });
+
+    it('should use strict filtering when CoinGecko data provided', () => {
+      const nativeToken = createMockToken({
+        isNativeGasToken: true,
+        symbol: 'ETH',
+        addressString: 'native',
+      });
+      const verifiedToken = createMockToken({
+        symbol: 'USDC',
+        addressString: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      });
+      const spamToken = createMockToken({
+        symbol: 'SCAM',
+        addressString: '0xdeadbeef',
+      });
+
+      const coingeckoAddresses = new Set([
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48', // USDC
+      ]);
+
+      const tokens = [spamToken, nativeToken, verifiedToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(2);
+      expect(filtered.find((t) => t.symbol === 'SCAM')).toBeUndefined();
+      expect(filtered.find((t) => t.symbol === 'ETH')).toBeDefined();
+      expect(filtered.find((t) => t.symbol === 'USDC')).toBeDefined();
+    });
+
+    it('should always include built-in tokens even with CoinGecko filtering', () => {
+      const builtinToken = createMockToken({
+        symbol: 'CUSTOM',
+        addressString: '0xcustom',
+        isBuiltin: true,
+      });
+
+      const coingeckoAddresses = new Set([]); // Empty - token not in CoinGecko
+
+      const tokens = [builtinToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(builtinToken);
     });
   });
 

--- a/src/utils/tokenListUtils.test.ts
+++ b/src/utils/tokenListUtils.test.ts
@@ -489,6 +489,38 @@ describe('tokenListUtils', () => {
       expect(filtered[0]).toBe(builtinToken);
     });
 
+    it('should always include Token Bridge wrapped tokens', () => {
+      const wrappedToken = createMockToken({
+        symbol: 'WETH',
+        addressString: '0xwrapped',
+        isTokenBridgeWrappedToken: true,
+      });
+
+      const coingeckoAddresses = new Set(['0xother']); // Token not in list
+
+      const tokens = [wrappedToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(wrappedToken);
+    });
+
+    it('should always include tokens with coingeckoWebId', () => {
+      const knownToken = createMockToken({
+        symbol: 'KNOWN',
+        addressString: '0xknown',
+        coingeckoWebId: 'known-token',
+      });
+
+      const coingeckoAddresses = new Set(['0xother']); // Token not in list
+
+      const tokens = [knownToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(knownToken);
+    });
+
     it('should use case-insensitive matching for EVM chains', () => {
       const evmToken = createMockToken({
         chain: 'Ethereum',

--- a/src/utils/tokenListUtils.test.ts
+++ b/src/utils/tokenListUtils.test.ts
@@ -56,6 +56,24 @@ vi.mock('./ntt', () => ({
   isNttToken: vi.fn(() => false),
 }));
 
+vi.mock('./address', () => ({
+  normalizeAddress: vi.fn((address: string, chain: string) => {
+    // Mock EVM chains as case-insensitive, others as case-sensitive
+    const evmChains = [
+      'Ethereum',
+      'Bsc',
+      'Polygon',
+      'Arbitrum',
+      'Optimism',
+      'Base',
+    ];
+    if (evmChains.includes(chain)) {
+      return address.toLowerCase();
+    }
+    return address; // Preserve case for Solana, Sui, etc.
+  }),
+}));
+
 vi.mock('config/tokens', () => ({
   isSameToken: vi.fn((a: any, b: any) => {
     return a.chain === b.chain && a.addressString === b.addressString;
@@ -469,6 +487,62 @@ describe('tokenListUtils', () => {
 
       expect(filtered).toHaveLength(1);
       expect(filtered[0]).toBe(builtinToken);
+    });
+
+    it('should use case-insensitive matching for EVM chains', () => {
+      const evmToken = createMockToken({
+        chain: 'Ethereum',
+        symbol: 'USDC',
+        addressString: '0xA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48', // Uppercase
+      });
+
+      // CoinGecko list has lowercase addresses
+      const coingeckoAddresses = new Set([
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      ]);
+
+      const tokens = [evmToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(evmToken);
+    });
+
+    it('should use case-sensitive matching for Solana', () => {
+      const solanaToken = createMockToken({
+        chain: 'Solana',
+        symbol: 'BONK',
+        addressString: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+      });
+
+      // CoinGecko list with exact case
+      const coingeckoAddresses = new Set([
+        'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+      ]);
+
+      const tokens = [solanaToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0]).toBe(solanaToken);
+    });
+
+    it('should filter out Solana token if case does not match', () => {
+      const solanaToken = createMockToken({
+        chain: 'Solana',
+        symbol: 'BONK',
+        addressString: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263',
+      });
+
+      // CoinGecko list with different case (simulating a mismatch)
+      const coingeckoAddresses = new Set([
+        'dezxaz8z7pnrnrjjz3wxborgixca6xjnb7yab1ppb263', // lowercase - wrong!
+      ]);
+
+      const tokens = [solanaToken];
+      const filtered = applySpamFilter(tokens, coingeckoAddresses);
+
+      expect(filtered).toHaveLength(0);
     });
   });
 

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -14,6 +14,7 @@ import {
 import { calculateUSDPriceRaw, isFrankensteinToken } from 'utils';
 import config from 'config';
 import { isNttToken } from './ntt';
+import { normalizeAddress } from './address';
 import type { Balances } from './wallet/types';
 
 export const getTokenPreferenceScore = (
@@ -218,9 +219,10 @@ export const applySpamFilter = (
           token.tokenBridgeOriginalTokenId,
         );
         if (originalToken) {
-          // TODO: Use chain-aware address normalization instead of toLowerCase()
-          // This breaks Solana/Sui tokens which have case-sensitive addresses
-          const originalAddress = originalToken.addressString.toLowerCase();
+          const originalAddress = normalizeAddress(
+            originalToken.addressString,
+            originalToken.chain,
+          );
           const isInList = coingeckoAddresses.has(originalAddress);
           if (!isInList) {
             console.debug(
@@ -233,9 +235,7 @@ export const applySpamFilter = (
       }
 
       // For regular tokens, check if address is in CoinGecko list
-      // TODO: Use chain-aware address normalization instead of toLowerCase()
-      // This breaks Solana/Sui tokens which have case-sensitive addresses
-      const address = token.addressString.toLowerCase();
+      const address = normalizeAddress(token.addressString, token.chain);
       const isInList = coingeckoAddresses.has(address);
       if (!isInList) {
         console.debug(`Filtering out token (not in CoinGecko list)`, token);

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -190,23 +190,9 @@ export const applyCustomTokenSupport = (
   return tokens.filter((t) => filter(t, sourceToken, tokenListType));
 };
 
-export const applyShittokenFilter = (tokens: Token[]): Token[] => {
-  return tokens.filter((token) => {
-    const isOk =
-      token.isNativeGasToken ||
-      token.isBuiltin ||
-      token.coingeckoWebId ||
-      token.isTokenBridgeWrappedToken ||
-      isNttToken(token);
-    if (!isOk)
-      console.debug(`Filtering out token for likely being spam`, token);
-    return isOk;
-  });
-};
-
-export const applyCoingeckoFilter = (
+export const applySpamFilter = (
   tokens: Token[],
-  coingeckoAddresses: Set<string>,
+  coingeckoAddresses?: Set<string>,
 ): Token[] => {
   return tokens.filter((token) => {
     // Always include NTT tokens
@@ -219,29 +205,50 @@ export const applyCoingeckoFilter = (
       return true;
     }
 
-    // For Token Bridge wrapped tokens, check the original token
-    if (token.isTokenBridgeWrappedToken && token.tokenBridgeOriginalTokenId) {
-      const originalToken = config.tokens.get(token.tokenBridgeOriginalTokenId);
-      if (originalToken) {
-        const originalAddress = originalToken.addressString.toLowerCase();
-        const isInList = coingeckoAddresses.has(originalAddress);
-        if (!isInList) {
-          console.debug(
-            `Filtering out wrapped token (original not in CoinGecko)`,
-            token,
-          );
-        }
-        return isInList;
-      }
+    // Always include built-in tokens configured in Connect
+    if (token.isBuiltin) {
+      return true;
     }
 
-    // For regular tokens, check if address is in CoinGecko list
-    const address = token.addressString.toLowerCase();
-    const isInList = coingeckoAddresses.has(address);
-    if (!isInList) {
-      console.debug(`Filtering out token (not in CoinGecko list)`, token);
+    // If CoinGecko data available, use strict filtering
+    if (coingeckoAddresses && coingeckoAddresses.size > 0) {
+      // For Token Bridge wrapped tokens, check the original token
+      if (token.isTokenBridgeWrappedToken && token.tokenBridgeOriginalTokenId) {
+        const originalToken = config.tokens.get(
+          token.tokenBridgeOriginalTokenId,
+        );
+        if (originalToken) {
+          // TODO: Use chain-aware address normalization instead of toLowerCase()
+          // This breaks Solana/Sui tokens which have case-sensitive addresses
+          const originalAddress = originalToken.addressString.toLowerCase();
+          const isInList = coingeckoAddresses.has(originalAddress);
+          if (!isInList) {
+            console.debug(
+              `Filtering out wrapped token (original not in CoinGecko)`,
+              token,
+            );
+          }
+          return isInList;
+        }
+      }
+
+      // For regular tokens, check if address is in CoinGecko list
+      // TODO: Use chain-aware address normalization instead of toLowerCase()
+      // This breaks Solana/Sui tokens which have case-sensitive addresses
+      const address = token.addressString.toLowerCase();
+      const isInList = coingeckoAddresses.has(address);
+      if (!isInList) {
+        console.debug(`Filtering out token (not in CoinGecko list)`, token);
+      }
+      return isInList;
     }
-    return isInList;
+
+    // Fallback to basic filtering when CoinGecko data unavailable
+    const isOk = token.coingeckoWebId || token.isTokenBridgeWrappedToken;
+    if (!isOk) {
+      console.debug(`Filtering out token for likely being spam`, token);
+    }
+    return isOk;
   });
 };
 

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -204,6 +204,47 @@ export const applyShittokenFilter = (tokens: Token[]): Token[] => {
   });
 };
 
+export const applyCoingeckoFilter = (
+  tokens: Token[],
+  coingeckoAddresses: Set<string>,
+): Token[] => {
+  return tokens.filter((token) => {
+    // Always include NTT tokens
+    if (isNttToken(token)) {
+      return true;
+    }
+
+    // Always include native gas tokens
+    if (token.isNativeGasToken) {
+      return true;
+    }
+
+    // For Token Bridge wrapped tokens, check the original token
+    if (token.isTokenBridgeWrappedToken && token.tokenBridgeOriginalTokenId) {
+      const originalToken = config.tokens.get(token.tokenBridgeOriginalTokenId);
+      if (originalToken) {
+        const originalAddress = originalToken.addressString.toLowerCase();
+        const isInList = coingeckoAddresses.has(originalAddress);
+        if (!isInList) {
+          console.debug(
+            `Filtering out wrapped token (original not in CoinGecko)`,
+            token,
+          );
+        }
+        return isInList;
+      }
+    }
+
+    // For regular tokens, check if address is in CoinGecko list
+    const address = token.addressString.toLowerCase();
+    const isInList = coingeckoAddresses.has(address);
+    if (!isInList) {
+      console.debug(`Filtering out token (not in CoinGecko list)`, token);
+    }
+    return isInList;
+  });
+};
+
 export const filterTokensByBalance = (
   tokens: Token[],
   balances: Record<string, { balance: any }>,

--- a/src/utils/tokenListUtils.ts
+++ b/src/utils/tokenListUtils.ts
@@ -211,30 +211,18 @@ export const applySpamFilter = (
       return true;
     }
 
-    // If CoinGecko data available, use strict filtering
-    if (coingeckoAddresses && coingeckoAddresses.size > 0) {
-      // For Token Bridge wrapped tokens, check the original token
-      if (token.isTokenBridgeWrappedToken && token.tokenBridgeOriginalTokenId) {
-        const originalToken = config.tokens.get(
-          token.tokenBridgeOriginalTokenId,
-        );
-        if (originalToken) {
-          const originalAddress = normalizeAddress(
-            originalToken.addressString,
-            originalToken.chain,
-          );
-          const isInList = coingeckoAddresses.has(originalAddress);
-          if (!isInList) {
-            console.debug(
-              `Filtering out wrapped token (original not in CoinGecko)`,
-              token,
-            );
-          }
-          return isInList;
-        }
-      }
+    // Always include tokens with CoinGecko metadata
+    if (token.coingeckoWebId) {
+      return true;
+    }
 
-      // For regular tokens, check if address is in CoinGecko list
+    // Always include Token Bridge wrapped tokens
+    if (token.isTokenBridgeWrappedToken) {
+      return true;
+    }
+
+    // If CoinGecko token list available, check against it
+    if (coingeckoAddresses && coingeckoAddresses.size > 0) {
       const address = normalizeAddress(token.addressString, token.chain);
       const isInList = coingeckoAddresses.has(address);
       if (!isInList) {
@@ -243,12 +231,9 @@ export const applySpamFilter = (
       return isInList;
     }
 
-    // Fallback to basic filtering when CoinGecko data unavailable
-    const isOk = token.coingeckoWebId || token.isTokenBridgeWrappedToken;
-    if (!isOk) {
-      console.debug(`Filtering out token for likely being spam`, token);
-    }
-    return isOk;
+    // No CoinGecko data and token doesn't pass basic checks - filter it out
+    console.debug(`Filtering out token for likely being spam`, token);
+    return false;
   });
 };
 


### PR DESCRIPTION
Filters spam/scam tokens from the source token list using CoinGecko's curated token lists.

Key changes:
- Fetches CoinGecko token list per chain to validate tokens
- Tokens not in the list are filtered out (unless native, NTT or configured by integrator)
- 24-hour localStorage cache (see open question-1 below)
- Moved NATIVE_TOKEN_IDS and CHAIN_IDS from coingecko.ts to chain config (coingeckoPlatformId, coingeckoNativeTokenId). These were already needed for price fetching and now also used for token list fetching. Consolidating in chain config will make it easier to discover when new chains are added and avoids extra maintenance.

Tokens allowed always:
- Native gas tokens
- NTT tokens
- Tokens configured by integrator
- Tokens with CoinGecko metadata (coingeckoWebId)
- Token Bridge wrapped tokens

CoinGecko Filtering
When experimental flag is enabled and CoinGecko data is available, tokens not in the above list must also be in the CoinGecko token list to be shown.

Config:
```
experimental: {
  enableCoingeckoSpamFilter: true
}
```

Proxy Changes Required:
We need to add these endpoints in coingecko-proxy-worker before merging this PR:
~~GET /api/v3/asset_platforms (cache 24h)~~
GET /api/v3/token_lists/:platform/all.json (cache TBD)

Open Questions
1. Cache duration: 24h may be too long for a newly launched token if it's not in "always allowed" group. Maybe 4 hours or less?
2. Horizontal API: The upcoming Horizontal API may provide token validation data. Current implementation is decoupled - applySpamFilter accepts any Set<string> of valid addresses, making the data source easily swappable.