### PR TITLE
fix: handle null minAmountIn in Mayan route

### DIFF
--- a/src/routes/mayan/MayanRouteBase.ts
+++ b/src/routes/mayan/MayanRouteBase.ts
@@ -512,7 +512,11 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
     return quotes[0];
   }
 
-  getMinAmount(minAmountIn: string | number, decimals: number) {
+  getMinAmount(minAmountIn: string | number | null, decimals: number) {
+    if (minAmountIn === null) {
+      return null;
+    }
+
     try {
       const minAmount = amount.parse(
         amount.denoise(minAmountIn, decimals),


### PR DESCRIPTION
Fixes this: <img width="541" height="195" alt="image" src="https://github.com/user-attachments/assets/13a2e19c-7d77-4e16-9c3c-1e5619cee832" />
<img width="1217" height="165" alt="image" src="https://github.com/user-attachments/assets/7e7efe21-a31d-4423-9d95-f522926c5bd1" />
