### PR TITLE
fix: optimize mayan route to remove unnecessary quoting

### DIFF
--- a/src/routes/mayan/MayanRouteBase.ts
+++ b/src/routes/mayan/MayanRouteBase.ts
@@ -184,6 +184,7 @@ export class MayanRouteBase<N extends Network> extends routes.AutomaticRoute<
   ): Promise<ValidationResult> {
     try {
       const hyperCoreValidation = validateHyperCoreTransfer(request, params);
+
       if (hyperCoreValidation) {
         return hyperCoreValidation;
       }

--- a/src/routes/mayan/MayanRouteCrossChain.ts
+++ b/src/routes/mayan/MayanRouteCrossChain.ts
@@ -1,0 +1,25 @@
+import type { Network } from '@wormhole-foundation/sdk-base';
+import type { routes } from '@wormhole-foundation/sdk-connect';
+import { MayanRouteBase } from './MayanRouteBase';
+import type { TransferParams, ValidationResult } from './types';
+
+export abstract class MayanRouteCrossChain<
+  N extends Network,
+> extends MayanRouteBase<N> {
+  override async validate(
+    request: routes.RouteTransferRequest<N>,
+    params: TransferParams,
+  ): Promise<ValidationResult> {
+    if (request.fromChain?.chain === request.toChain?.chain) {
+      return {
+        valid: false,
+        params,
+        error: new Error(
+          'This route does not support same-chain swaps. Use MONO_CHAIN route for same-chain swaps.',
+        ),
+      };
+    }
+
+    return super.validate(request, params);
+  }
+}

--- a/src/routes/mayan/MayanRouteFastMCTP.ts
+++ b/src/routes/mayan/MayanRouteFastMCTP.ts
@@ -1,10 +1,10 @@
 import type { routes } from '@wormhole-foundation/sdk-connect';
 import type { Network } from '@wormhole-foundation/sdk-base';
 import { MayanProtocol } from './types';
-import { MayanRouteBase } from './MayanRouteBase';
+import { MayanRouteCrossChain } from './MayanRouteCrossChain';
 
 export class MayanRouteFastMCTP<N extends Network>
-  extends MayanRouteBase<N>
+  extends MayanRouteCrossChain<N>
   implements routes.StaticRouteMethods<typeof MayanRouteFastMCTP>
 {
   static meta = {

--- a/src/routes/mayan/MayanRouteMCTP.ts
+++ b/src/routes/mayan/MayanRouteMCTP.ts
@@ -1,10 +1,10 @@
 import type { Network } from '@wormhole-foundation/sdk-base';
 import type { routes } from '@wormhole-foundation/sdk-connect';
-import { MayanRouteBase } from './MayanRouteBase';
+import { MayanRouteCrossChain } from './MayanRouteCrossChain';
 import { MayanProtocol } from './types';
 
 export class MayanRouteMCTP<N extends Network>
-  extends MayanRouteBase<N>
+  extends MayanRouteCrossChain<N>
   implements routes.StaticRouteMethods<typeof MayanRouteMCTP>
 {
   static meta = {

--- a/src/routes/mayan/MayanRouteMONOCHAIN.ts
+++ b/src/routes/mayan/MayanRouteMONOCHAIN.ts
@@ -2,7 +2,11 @@ import { chainToPlatform } from '@wormhole-foundation/sdk-base';
 import type { Chain, Network } from '@wormhole-foundation/sdk-connect';
 import type { routes } from '@wormhole-foundation/sdk-connect';
 import { MayanRouteBase } from './MayanRouteBase';
-import { MayanProtocol } from './types';
+import {
+  MayanProtocol,
+  type TransferParams,
+  type ValidationResult,
+} from './types';
 
 export class MayanRouteMONOCHAIN<N extends Network>
   extends MayanRouteBase<N>
@@ -14,6 +18,23 @@ export class MayanRouteMONOCHAIN<N extends Network>
   };
 
   override protocols: MayanProtocol[] = [MayanProtocol.MONO_CHAIN];
+
+  override async validate(
+    request: routes.RouteTransferRequest<N>,
+    params: TransferParams,
+  ): Promise<ValidationResult> {
+    if (request.fromChain?.chain !== request.toChain?.chain) {
+      return {
+        valid: false,
+        params,
+        error: new Error(
+          'MONO_CHAIN route requires source and destination chains to be the same',
+        ),
+      };
+    }
+
+    return super.validate(request, params);
+  }
 
   static supportsSameChainSwaps(network: Network, chain: Chain) {
     const platform = chainToPlatform(chain);

--- a/src/routes/mayan/MayanRouteSWIFT.ts
+++ b/src/routes/mayan/MayanRouteSWIFT.ts
@@ -1,10 +1,10 @@
 import type { Network } from '@wormhole-foundation/sdk-base';
 import type { routes } from '@wormhole-foundation/sdk-connect';
-import { MayanRouteBase } from './MayanRouteBase';
+import { MayanRouteCrossChain } from './MayanRouteCrossChain';
 import { MayanProtocol } from './types';
 
 export class MayanRouteSWIFT<N extends Network>
-  extends MayanRouteBase<N>
+  extends MayanRouteCrossChain<N>
   implements routes.StaticRouteMethods<typeof MayanRouteSWIFT>
 {
   static meta = {

--- a/src/routes/mayan/MayanRouteWH.ts
+++ b/src/routes/mayan/MayanRouteWH.ts
@@ -1,10 +1,10 @@
 import type { Network } from '@wormhole-foundation/sdk-base';
 import type { routes } from '@wormhole-foundation/sdk-connect';
-import { MayanRouteBase } from './MayanRouteBase';
+import { MayanRouteCrossChain } from './MayanRouteCrossChain';
 import { MayanProtocol } from './types';
 
 export class MayanRouteWH<N extends Network>
-  extends MayanRouteBase<N>
+  extends MayanRouteCrossChain<N>
   implements routes.StaticRouteMethods<typeof MayanRouteWH>
 {
   static meta = {

--- a/src/routes/mayan/__tests__/validation.test.ts
+++ b/src/routes/mayan/__tests__/validation.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { routes } from '@wormhole-foundation/sdk-connect';
+import type { Network } from '@wormhole-foundation/sdk-base';
+import { MayanRouteMONOCHAIN } from '../MayanRouteMONOCHAIN';
+import { MayanRouteFastMCTP } from '../MayanRouteFastMCTP';
+import { MayanRouteMCTP } from '../MayanRouteMCTP';
+import { MayanRouteSWIFT } from '../MayanRouteSWIFT';
+import { MayanRouteWH } from '../MayanRouteWH';
+import type { TransferParams } from '../types';
+
+describe('Mayan Routes - Validation', () => {
+  let mockWormhole: any;
+  let mockParams: TransferParams;
+
+  beforeEach(() => {
+    mockWormhole = {
+      network: 'Mainnet' as Network,
+    };
+
+    mockParams = {
+      amount: '100',
+      options: {
+        gasDrop: 0,
+        slippageBps: 'auto',
+        optimizeFor: 'speed',
+      },
+    };
+  });
+
+  describe('MayanRouteMONOCHAIN - Same-chain validation', () => {
+    let route: MayanRouteMONOCHAIN<'Mainnet'>;
+
+    beforeEach(() => {
+      route = new MayanRouteMONOCHAIN(mockWormhole);
+    });
+
+    it('should return valid for same-chain swap (Ethereum to Ethereum)', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return valid for same-chain swap (Solana to Solana)', async () => {
+      const request = {
+        fromChain: { chain: 'Solana', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid for cross-chain swap (Ethereum to Solana)', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toBeDefined();
+        expect(result.error?.message).toContain('same');
+      }
+    });
+
+    it('should return invalid for cross-chain swap (Solana to Ethereum)', async () => {
+      const request = {
+        fromChain: { chain: 'Solana', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toBeDefined();
+      }
+    });
+  });
+
+  describe('MayanRouteFastMCTP - Cross-chain validation', () => {
+    let route: MayanRouteFastMCTP<'Mainnet'>;
+
+    beforeEach(() => {
+      route = new MayanRouteFastMCTP(mockWormhole);
+    });
+
+    it('should return valid for cross-chain swap (Ethereum to Solana)', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return valid for cross-chain swap (Solana to Ethereum)', async () => {
+      const request = {
+        fromChain: { chain: 'Solana', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid for same-chain swap (Ethereum to Ethereum)', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toBeDefined();
+        expect(result.error?.message).toContain('same-chain');
+      }
+    });
+
+    it('should return invalid for same-chain swap (Solana to Solana)', async () => {
+      const request = {
+        fromChain: { chain: 'Solana', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error).toBeDefined();
+      }
+    });
+  });
+
+  describe('MayanRouteMCTP - Cross-chain validation', () => {
+    let route: MayanRouteMCTP<'Mainnet'>;
+
+    beforeEach(() => {
+      route = new MayanRouteMCTP(mockWormhole);
+    });
+
+    it('should return valid for cross-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid for same-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('MayanRouteSWIFT - Cross-chain validation', () => {
+    let route: MayanRouteSWIFT<'Mainnet'>;
+
+    beforeEach(() => {
+      route = new MayanRouteSWIFT(mockWormhole);
+    });
+
+    it('should return valid for cross-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid for same-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('MayanRouteWH - Cross-chain validation', () => {
+    let route: MayanRouteWH<'Mainnet'>;
+
+    beforeEach(() => {
+      route = new MayanRouteWH(mockWormhole);
+    });
+
+    it('should return valid for cross-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Solana', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('should return invalid for same-chain swap', async () => {
+      const request = {
+        fromChain: { chain: 'Ethereum', network: 'Mainnet' },
+        toChain: { chain: 'Ethereum', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('Edge cases - Different chains', () => {
+    it('MONO_CHAIN should reject Avalanche to Polygon', async () => {
+      const route = new MayanRouteMONOCHAIN(mockWormhole);
+      const request = {
+        fromChain: { chain: 'Avalanche', network: 'Mainnet' },
+        toChain: { chain: 'Polygon', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('FastMCTP should accept Avalanche to Polygon', async () => {
+      const route = new MayanRouteFastMCTP(mockWormhole);
+      const request = {
+        fromChain: { chain: 'Avalanche', network: 'Mainnet' },
+        toChain: { chain: 'Polygon', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it('FastMCTP should reject Sui to Sui', async () => {
+      const route = new MayanRouteFastMCTP(mockWormhole);
+      const request = {
+        fromChain: { chain: 'Sui', network: 'Mainnet' },
+        toChain: { chain: 'Sui', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('MONO_CHAIN should accept Sui to Sui', async () => {
+      const route = new MayanRouteMONOCHAIN(mockWormhole);
+      const request = {
+        fromChain: { chain: 'Sui', network: 'Mainnet' },
+        toChain: { chain: 'Sui', network: 'Mainnet' },
+      } as routes.RouteTransferRequest<'Mainnet'>;
+
+      const result = await route.validate(request, mockParams);
+
+      expect(result.valid).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
- Should not request mono chain quotes when not same chain swaps
- Should not request cross chain quotes when same chain swaps