### PR TITLE
feat: replace old automatic routes with executor routes

### DIFF
--- a/src/components/SampleApp/index.tsx
+++ b/src/components/SampleApp/index.tsx
@@ -68,6 +68,8 @@ const parseConfig = (config: string): WormholeConnectConfig => {
       /* @ts-ignore */
       window.CCTPRoute = routes.CCTPRoute;
       /* @ts-ignore */
+      window.TBTCRoute = routes.TBTCRoute;
+      /* @ts-ignore */
       window.MayanRoute = MayanRoute;
       /* @ts-ignore */
       window.MayanRouteWH = MayanRouteWH;
@@ -258,6 +260,10 @@ function SampleApp() {
                   </li>
                   <li>
                     <pre>CCTPRoute</pre>
+                    <i>{'RouteConstructor'}</i>
+                  </li>
+                  <li>
+                    <pre>TBTCRoute</pre>
                     <i>{'RouteConstructor'}</i>
                   </li>
                   <li>

--- a/src/components/SampleApp/index.tsx
+++ b/src/components/SampleApp/index.tsx
@@ -17,11 +17,10 @@ import type { WormholeConnectConfig } from 'config/types';
  * The exports are:
  * - DEFAULT_ROUTES
  * - nttRoutes
- * - AutomaticTokenBridgeRoute
- * - TokenBridgeExecutorRoute
- * - TokenBridgeRoute
- * - AutomaticCCTPRoute
- * - ManualCCTPRoute
+ * - CCTPRoute
+ * - cctpV2FastExecutorRoute
+ * - cctpV2StandardExecutorRoute
+ * - executorTokenBridgeRoute
  *
  * We also make the following test utilities available:
  * - nttTestRoutesMainnet
@@ -67,15 +66,7 @@ const parseConfig = (config: string): WormholeConnectConfig => {
       /* @ts-ignore */
       window.nttRoutes = nttRoutes;
       /* @ts-ignore */
-      window.AutomaticTokenBridgeRoute = routes.AutomaticTokenBridgeRoute;
-      /* @ts-ignore */
-      window.AutomaticCCTPRoute = routes.AutomaticCCTPRoute;
-      /* @ts-ignore */
-      window.TokenBridgeRoute = routes.TokenBridgeRoute;
-      /* @ts-ignore */
       window.CCTPRoute = routes.CCTPRoute;
-      /* @ts-ignore */
-      window.TBTCRoute = routes.TBTCRoute;
       /* @ts-ignore */
       window.MayanRoute = MayanRoute;
       /* @ts-ignore */
@@ -266,23 +257,7 @@ function SampleApp() {
                     <i>{'RouteConstructor[]'}</i>
                   </li>
                   <li>
-                    <pre>AutomaticTokenBridgeRoute</pre>
-                    <i>{'RouteConstructor'}</i>
-                  </li>
-                  <li>
-                    <pre>TokenBridgeRoute</pre>
-                    <i>{'RouteConstructor'}</i>
-                  </li>
-                  <li>
-                    <pre>AutomaticCCTPRoute</pre>
-                    <i>{'RouteConstructor'}</i>
-                  </li>
-                  <li>
                     <pre>CCTPRoute</pre>
-                    <i>{'RouteConstructor'}</i>
-                  </li>
-                  <li>
-                    <pre>TBTCRoute</pre>
                     <i>{'RouteConstructor'}</i>
                   </li>
                   <li>

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -27,7 +27,7 @@ import type {
   WormholeConnectWalletProvider,
 } from 'utils/wallet/types';
 
-const { CCTPRoute, executorTokenBridgeRoute } = routes;
+const { CCTPRoute, TBTCRoute, executorTokenBridgeRoute } = routes;
 
 export default WormholeConnect;
 
@@ -54,6 +54,7 @@ export {
   // Routes
   DEFAULT_ROUTES,
   CCTPRoute,
+  TBTCRoute,
   executorTokenBridgeRoute,
 };
 

--- a/src/exports/index.ts
+++ b/src/exports/index.ts
@@ -10,6 +10,10 @@ export * as config from 'config/types';
 // Routes
 import { DEFAULT_ROUTES } from 'routes/operator';
 import { routes } from '@wormhole-foundation/sdk';
+export {
+  cctpV2FastExecutorRoute,
+  cctpV2StandardExecutorRoute,
+} from '@wormhole-labs/cctp-executor-route';
 
 import type { Chain, Network } from '@wormhole-foundation/sdk';
 
@@ -23,13 +27,7 @@ import type {
   WormholeConnectWalletProvider,
 } from 'utils/wallet/types';
 
-const {
-  AutomaticTokenBridgeRoute,
-  TokenBridgeRoute,
-  AutomaticCCTPRoute,
-  CCTPRoute,
-  TBTCRoute,
-} = routes;
+const { CCTPRoute, executorTokenBridgeRoute } = routes;
 
 export default WormholeConnect;
 
@@ -55,11 +53,8 @@ export {
 
   // Routes
   DEFAULT_ROUTES,
-  AutomaticTokenBridgeRoute,
-  TokenBridgeRoute,
-  AutomaticCCTPRoute,
   CCTPRoute,
-  TBTCRoute,
+  executorTokenBridgeRoute,
 };
 
 export * from 'telemetry';

--- a/src/exports/ntt.ts
+++ b/src/exports/ntt.ts
@@ -7,7 +7,6 @@ import '@wormhole-foundation/sdk-sui-ntt';
 
 import type { NttRoute } from '@wormhole-foundation/sdk-route-ntt';
 import {
-  nttAutomaticRoute,
   type NttExecutorRoute,
   nttExecutorRoute,
   nttManualRoute,
@@ -35,7 +34,6 @@ const nttRoutes = (
 };
 
 export {
-  nttAutomaticRoute,
   nttExecutorRoute,
   nttManualRoute,
   nttRoutes,

--- a/src/hooks/useFetchSupportedRoutes.ts
+++ b/src/hooks/useFetchSupportedRoutes.ts
@@ -90,11 +90,7 @@ const useFetchSupportedRoutes = ({
       if (_routes.includes('ManualTBTC')) {
         _routes = _routes.filter(
           (route) =>
-            ![
-              'ManualTokenBridge',
-              'AutomaticTokenBridge',
-              'TokenBridgeExecutorRoute',
-            ].includes(route),
+            !['ManualTokenBridge', 'TokenBridgeExecutorRoute'].includes(route),
         );
       }
 

--- a/src/routes/operator.ts
+++ b/src/routes/operator.ts
@@ -40,6 +40,7 @@ export const DEFAULT_ROUTES = [
   cctpV2StandardExecutorRoute(),
   routes.CCTPRoute,
   routes.executorTokenBridgeRoute(),
+  routes.TBTCRoute,
 ];
 
 export interface QuoteParams {

--- a/src/routes/operator.ts
+++ b/src/routes/operator.ts
@@ -17,6 +17,10 @@ import {
   routes,
   amount as sdkAmount,
 } from '@wormhole-foundation/sdk';
+import {
+  cctpV2FastExecutorRoute,
+  cctpV2StandardExecutorRoute,
+} from '@wormhole-labs/cctp-executor-route';
 
 import SDKv2Route from './sdkv2/route';
 import type { QuoteMetadata } from './types';
@@ -32,11 +36,10 @@ export type QuoteResult = routes.QuoteResult<routes.Options>;
 type forEachCallback<T> = (name: string, route: SDKv2Route) => T;
 
 export const DEFAULT_ROUTES = [
-  routes.AutomaticCCTPRoute,
+  cctpV2FastExecutorRoute(),
+  cctpV2StandardExecutorRoute(),
   routes.CCTPRoute,
-  routes.AutomaticTokenBridgeRoute,
-  routes.TokenBridgeRoute,
-  routes.TBTCRoute,
+  routes.executorTokenBridgeRoute(),
 ];
 
 export interface QuoteParams {

--- a/src/routes/sdkv2/route.ts
+++ b/src/routes/sdkv2/route.ts
@@ -38,7 +38,6 @@ export default class SDKv2Route {
   constructor(readonly rc: routes.RouteConstructor) {
     this.IS_TOKEN_BRIDGE_ROUTE = [
       'ManualTokenBridge',
-      'AutomaticTokenBridge',
       'TokenBridgeExecutorRoute',
     ].includes(rc.meta.name);
 

--- a/src/utils/ntt.ts
+++ b/src/utils/ntt.ts
@@ -5,7 +5,6 @@ import { addressString } from 'config/tokens';
 
 export const nttRoutes = [
   'ManualNtt',
-  'AutomaticNtt',
   'M0AutomaticRoute',
   'NttExecutorRoute',
 ] as const;

--- a/src/utils/sdkv2.ts
+++ b/src/utils/sdkv2.ts
@@ -186,12 +186,6 @@ export async function parseReceipt(
           params: NttRoute.ValidatedParams;
         },
       );
-    case 'AutomaticNtt':
-      return parseNttReceipt(
-        receipt as ReceiptWithAttestation<NttRoute.AutomaticAttestationReceipt> & {
-          params: NttRoute.ValidatedParams;
-        },
-      );
     case 'ManualTBTC':
       return parseTBTCReceipt(
         receipt as ReceiptWithAttestation<TBTCBridge.VAA>,

--- a/src/utils/transferValidation.ts
+++ b/src/utils/transferValidation.ts
@@ -147,10 +147,6 @@ export const validateAll = async (
   };
 
   if (isAutomatic) {
-    if (route === 'AutomaticNtt') {
-      // Ntt does not support native gas drop-off
-      return baseValidations;
-    }
     return {
       ...baseValidations,
       toNativeToken: validateToNativeAmt(toNativeToken, maxSwapAmt),

--- a/src/views/v3/Bridge/Routes/utils.ts
+++ b/src/views/v3/Bridge/Routes/utils.ts
@@ -12,12 +12,6 @@ function getRouteProvider(
     return quoteProvider;
   }
 
-  const isLidoNttSpecialCase =
-    route === 'AutomaticNtt' &&
-    sourceTokenSymbol === 'wstETH' &&
-    ((sourceChain === 'Ethereum' && destChain === 'Bsc') ||
-      (sourceChain === 'Bsc' && destChain === 'Ethereum'));
-
   const isSameChain = route === 'MayanSwapMONOCHAIN';
 
   const isSameChainSolana =
@@ -25,9 +19,7 @@ function getRouteProvider(
 
   let providerString = '';
 
-  if (isLidoNttSpecialCase) {
-    providerString = 'NTT: Wormhole + Axelar';
-  } else if (isSameChainSolana) {
+  if (isSameChainSolana) {
     providerString = 'Jupiter';
   } else if (isSameChain) {
     providerString = 'Mayan'; // Needs to eventually call out the evm route


### PR DESCRIPTION
## Summary

Replace non-functioning old automatic routes (`AutomaticCCTPRoute`, `AutomaticTokenBridgeRoute`, `TokenBridgeRoute`, `TBTCRoute`, `AutomaticNtt`) with executor-based alternatives as defaults. The new `DEFAULT_ROUTES` are `cctpV2FastExecutorRoute`, `cctpV2StandardExecutorRoute`, `executorTokenBridgeRoute`, and `CCTPRoute` (manual fallback). All references to removed routes are cleaned up across exports, SampleApp, route filtering, receipt parsing, and validation logic.

## Test plan

- [x] `bun run build:lib` succeeds
- [x] `bun run lint:ci` passes (0 errors)
- [x] `npx tsc --noEmit` passes
- [x] 461 tests pass across 35 test files
- [ ] Manual smoke test: verify executor routes load and produce quotes in SampleApp
- [ ] Verify integrators using custom route configs are unaffected