### PR TITLE
Use bun install from lockfile

### DIFF
--- a/E2E_TESTS.md
+++ b/E2E_TESTS.md
@@ -56,7 +56,7 @@ export REACT_APP_TEST_EVM_PK=your_test_wallet_private_key
 
 ```bash
 # Install dependencies
-bun install
+bun install --frozen-lockfile
 
 # Install Playwright browsers (first time only)
 bunx playwright install


### PR DESCRIPTION
Encourages devs to use a targeted bun install from the repo's lockfile instead of a generic installation to update all depedencies.