### PR TITLE
feat: add Pawtato (TATO) to mainnet token list

### DIFF
--- a/src/config/mainnet/tokens.ts
+++ b/src/config/mainnet/tokens.ts
@@ -988,4 +988,26 @@ export const MAINNET_TOKENS: TokenConfig[] = [
     decimals: 18,
     icon: TokenIcon.MOCA,
   },
+  // Pawtato (TATO) — Wormhole NTT: Sui hub (locking) + Solana spoke (burning)
+  {
+    symbol: 'TATO',
+    name: 'Pawtato',
+    decimals: 9,
+    icon: 'https://img.pawtato.app/tato/TATO.png',
+    tokenId: {
+      chain: 'Sui',
+      address:
+        '0x04deb377c33bfced1ab81cde96918e2538fe78735777150b0064ccf7df5e1c81::tato::TATO',
+    },
+  },
+  {
+    symbol: 'TATO',
+    name: 'Pawtato',
+    decimals: 9,
+    icon: 'https://img.pawtato.app/tato/TATO.png',
+    tokenId: {
+      chain: 'Solana',
+      address: 'pawTUoFAzJt2e6vuqyZ3MwaGKPLuVFDp2CctWAEtato',
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

Adds **Pawtato (TATO)** to the mainnet token list (`src/config/mainnet/tokens.ts`) so Connect/Portal render the token's **symbol (`TATO`)** and icon, instead of falling back to the on-chain `CoinMetadata.name` ("Pawtato").

TATO is deployed and live on mainnet via **Wormhole NTT**:
- **Sui** = hub, `locking` mode
- **Solana** = spoke, `burning` mode

`ntt status` reports the deployment is in sync with on-chain config (peers linked, rate limits set).

## Token details

| | Sui | Solana |
|---|---|---|
| symbol | `TATO` | `TATO` |
| name | Pawtato | Pawtato |
| decimals | 9 | 9 |
| address | `0x04deb377c33bfced1ab81cde96918e2538fe78735777150b0064ccf7df5e1c81::tato::TATO` | `pawTUoFAzJt2e6vuqyZ3MwaGKPLuVFDp2CctWAEtato` |
| NTT manager | `0x91e84cf68ff518056abb4195685af2f2166ac1561917e50710fc077fd9bc00a2` | `nttpcCqjAnpquiMin6MTf6icWnSRWLPtSUDUXPySAas` |
| NTT transceiver | `0x4404b1d4dbda6f5bb5afeac755cc781ea0478d2ead24eaa845c10c8a8e9795e0` | `FPCV5etr5ywXzsswmgEL6miw8zYwV1jeuRDg58agk2eb` |

- Icon: `https://img.pawtato.app/tato/TATO.png` (served with CORS, `image/png`)
- On-chain metadata: name `Pawtato`, symbol `TATO`, decimals `9`

## Notes

Opened as a **draft** — happy to adjust formatting, icon handling (`TokenIcon` enum vs URL), or placement to match maintainer preferences.
