### PR TITLE
fix: sanitize balance read diagnostics

### DIFF
--- a/src/hooks/useGetTokenBalances.ts
+++ b/src/hooks/useGetTokenBalances.ts
@@ -13,6 +13,10 @@ import type { WalletData } from 'store/wallet';
 import { useTokens } from 'contexts/TokensContext';
 import { processBatches } from 'utils/batch';
 import { getCached, isFailed, markFailed, setCached } from 'utils/balanceCache';
+import {
+  formatBalanceReadDiagnostic,
+  formatIndexedBalanceReadDiagnostic,
+} from 'utils/balanceReadDiagnostic';
 
 export interface ChainBalanceRequest {
   chain: Chain;
@@ -219,7 +223,7 @@ const useGetTokenBalances = ({
             );
             return updatedBalances;
           } catch (e) {
-            console.error(`Error calling getBalances on ${chain}:`, e);
+            console.error(formatIndexedBalanceReadDiagnostic(chain, e));
             // Fall through to individual fetching
           }
         }
@@ -247,7 +251,7 @@ const useGetTokenBalances = ({
             };
             setCached(wallet, token, balance);
           } catch (e) {
-            console.error(`Failed to fetch balance for token ${token.key}`, e);
+            console.error(formatBalanceReadDiagnostic(chain, token.key, e));
           }
         },
         {

--- a/src/utils/balanceReadDiagnostic.test.ts
+++ b/src/utils/balanceReadDiagnostic.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatBalanceReadDiagnostic,
+  formatIndexedBalanceReadDiagnostic,
+} from './balanceReadDiagnostic';
+
+describe('balance read diagnostics', () => {
+  it('identifies Error balance read failures with chain and token key', () => {
+    const diagnostic = formatBalanceReadDiagnostic(
+      'Ethereum',
+      'Ethereum:USDC',
+      new Error('RPC request failed'),
+    );
+
+    expect(diagnostic).toBe(
+      'Balance retrieval/read failure (chain=Ethereum, token=Ethereum:USDC): Error: RPC request failed',
+    );
+    expect(diagnostic).not.toContain('insufficient balance');
+  });
+
+  it('safely formats non-Error thrown values', () => {
+    expect(
+      formatBalanceReadDiagnostic('Solana', 'Solana:USDC', 'request timed out'),
+    ).toBe(
+      'Balance retrieval/read failure (chain=Solana, token=Solana:USDC): Non-Error thrown: request timed out',
+    );
+  });
+
+  it('redacts RPC URLs, credentials, auth values, and wallet addresses', () => {
+    const evmWallet = '0x1234567890abcdef1234567890abcdef12345678';
+    const solanaWallet = '7YttLkHDoNj9wyDur5CVeLjJYF9aL7U9HkY7Q9xHXGgZ';
+    const nearWallet = 'private-wallet.near';
+    const diagnostic = formatBalanceReadDiagnostic(
+      'Ethereum',
+      'Ethereum:USDC',
+      new Error(
+        `request to https://rpc.example/v1/${evmWallet}?apiKey=rpc-secret&auth=session-secret failed for wallet=${solanaWallet}; address=${nearWallet}; token=loose-secret; Authorization: Bearer bearer-secret`,
+      ),
+    );
+
+    expect(diagnostic).toContain('[REDACTED_URL]');
+    expect(diagnostic).toContain('wallet=[REDACTED_ADDRESS]');
+    expect(diagnostic).toContain('Authorization: [REDACTED]');
+    expect(diagnostic).not.toContain('rpc.example');
+    expect(diagnostic).not.toContain('rpc-secret');
+    expect(diagnostic).not.toContain('session-secret');
+    expect(diagnostic).not.toContain('bearer-secret');
+    expect(diagnostic).not.toContain('loose-secret');
+    expect(diagnostic).not.toContain(evmWallet);
+    expect(diagnostic).not.toContain(solanaWallet);
+    expect(diagnostic).not.toContain(nearWallet);
+  });
+
+  it('makes the indexed fallback visible without exposing its raw error', () => {
+    const diagnostic = formatIndexedBalanceReadDiagnostic(
+      'Ethereum',
+      'failed at wss://rpc.example/socket?access_token=socket-secret',
+    );
+
+    expect(diagnostic).toBe(
+      'Indexed balance retrieval failure (chain=Ethereum); falling back to per-token reads: Non-Error thrown: failed at [REDACTED_URL]',
+    );
+  });
+});

--- a/src/utils/balanceReadDiagnostic.ts
+++ b/src/utils/balanceReadDiagnostic.ts
@@ -1,0 +1,64 @@
+import type { Chain } from '@wormhole-foundation/sdk';
+
+const MAX_ERROR_LENGTH = 500;
+
+const getThrownValue = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name || 'Error'}: ${error.message}`;
+  }
+
+  if (typeof error === 'object' && error !== null) {
+    try {
+      const message = Reflect.get(error, 'message');
+      if (typeof message === 'string') {
+        return `Non-Error thrown: ${message}`;
+      }
+    } catch {
+      // Avoid invoking untrusted getters again while formatting diagnostics.
+    }
+
+    return 'Non-Error thrown: [object]';
+  }
+
+  return `Non-Error thrown: ${String(error)}`;
+};
+
+const sanitizeError = (error: unknown): string =>
+  getThrownValue(error)
+    .replace(/\b(?:https?|wss?):\/\/[^\s<>"'`]+/gi, '[REDACTED_URL]')
+    .replace(
+      /\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:(?:bearer|basic)\s+)?[^\s,;]+/gi,
+      'Authorization: [REDACTED]',
+    )
+    .replace(/\b(?:bearer|basic)\s+[^\s,;]+/gi, '[REDACTED]')
+    .replace(
+      /\b(api[-_]?key|access[-_]?token|auth(?:orization)?|client[-_]?secret|credential|key|password|project[-_]?id|secret|signature|token)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s&,;]+)/gi,
+      '$1$2[REDACTED]',
+    )
+    .replace(
+      /\b(wallet(?:address)?|address|account|owner)\b(\s*[:=]\s*)(?:"[^"]*"|'[^']*'|[^\s,;]+)/gi,
+      '$1$2[REDACTED_ADDRESS]',
+    )
+    .replace(/\b0x[a-f\d]{40,64}\b/gi, '[REDACTED_ADDRESS]')
+    .replace(/\b[a-z\d]{2,15}1[ac-hj-np-z02-9]{20,}\b/gi, '[REDACTED_ADDRESS]')
+    .replace(/\b[a-z\d_-]{2,64}\.(?:near|testnet)\b/gi, '[REDACTED_ADDRESS]')
+    .replace(/\b[1-9A-HJ-NP-Za-km-z]{25,64}\b/g, '[REDACTED_ADDRESS]')
+    .replace(/\b[A-Za-z\d+/_=-]{24,}\b/g, '[REDACTED_IDENTIFIER]')
+    .slice(0, MAX_ERROR_LENGTH);
+
+export const formatBalanceReadDiagnostic = (
+  chain: Chain,
+  tokenKey: string,
+  error: unknown,
+): string =>
+  `Balance retrieval/read failure (chain=${chain}, token=${tokenKey}): ${sanitizeError(
+    error,
+  )}`;
+
+export const formatIndexedBalanceReadDiagnostic = (
+  chain: Chain,
+  error: unknown,
+): string =>
+  `Indexed balance retrieval failure (chain=${chain}); falling back to per-token reads: ${sanitizeError(
+    error,
+  )}`;


### PR DESCRIPTION
## Summary

- make indexed balance retrieval failures visible while explicitly noting the existing per-token fallback
- identify per-token balance retrieval/read failures by chain and token key, distinct from insufficient-balance errors
- safely format `Error` and non-`Error` values while redacting RPC URLs, credentials/auth values, and wallet/address-shaped data

## Tests

- `bun run test:unit src/utils/balanceReadDiagnostic.test.ts --run` (1 file, 4 tests passed)
- `bun run type:check`
- `bunx eslint src/utils/balanceReadDiagnostic.ts src/utils/balanceReadDiagnostic.test.ts src/hooks/useGetTokenBalances.ts`
- `bunx prettier --check src/utils/balanceReadDiagnostic.ts src/utils/balanceReadDiagnostic.test.ts src/hooks/useGetTokenBalances.ts`
