### PR TITLE
fix: clarify per-token balance-fetch errors after RPC fallback

### DIFF
--- a/src/hooks/useGetTokenBalances.test.tsx
+++ b/src/hooks/useGetTokenBalances.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { createMockToken } from 'utils/testHelpers';
+import useGetTokenBalances from './useGetTokenBalances';
+
+const WALLET_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const RPC_URL = 'https://ethereum-rpc.publicnode.com';
+const API_KEY = 'sk-super-secret-key';
+
+const mockToken = createMockToken({
+  chain: 'Ethereum',
+  addressString: '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+  symbol: 'USDC',
+  name: 'USD Coin',
+  decimals: 6,
+  key: 'Ethereum:USDC',
+});
+
+const mockWallet = {
+  type: 'Evm' as const,
+  address: WALLET_ADDRESS,
+  currentAddress: WALLET_ADDRESS,
+  error: '',
+  name: 'Test Wallet',
+};
+
+const getBalanceMock = vi.fn();
+
+vi.mock('config', () => ({
+  default: {
+    network: 'Testnet',
+    chains: { Ethereum: { sdkName: 'Ethereum' } },
+    tokens: {
+      get: vi.fn(() => mockToken),
+    },
+    evmIndexers: undefined,
+  },
+  getWormholeContextV2: vi.fn(async () => ({
+    getPlatform: vi.fn(() => ({
+      getRpc: vi.fn(),
+      utils: vi.fn(() => ({
+        getBalance: (...args: unknown[]) => getBalanceMock(...args),
+      })),
+    })),
+  })),
+}));
+
+vi.mock('@wormhole-foundation/sdk', () => ({
+  amount: {
+    fromBaseUnits: vi.fn((value: bigint, decimals: number) => ({
+      amount: value.toString(),
+      decimals,
+    })),
+  },
+  supportsIndexerUtils: vi.fn(() => false),
+  Wormhole: {
+    tokenId: vi.fn((chain: string, address: string) => ({ chain, address })),
+  },
+  routes: {},
+}));
+
+vi.mock('@wormhole-foundation/sdk-base', () => ({
+  chainToPlatform: vi.fn(() => 'Evm'),
+}));
+
+vi.mock('contexts/TokensContext', () => ({
+  useTokens: vi.fn(() => ({
+    getOrFetchToken: vi.fn(async () => mockToken),
+  })),
+}));
+
+vi.mock('utils/balanceCache', () => ({
+  getCached: vi.fn(() => undefined),
+  setCached: vi.fn(),
+  markFailed: vi.fn(),
+  isFailed: vi.fn(() => false),
+}));
+
+vi.mock('utils', () => ({
+  sleep: vi.fn(),
+  chainDisplayName: vi.fn(),
+  getGasToken: vi.fn(),
+  getTokenDisplaySymbolByTokenAddress: vi.fn(),
+}));
+
+const getRequest = () => ({
+  chain: 'Ethereum' as const,
+  wallet: mockWallet,
+  tokens: [mockToken],
+});
+
+describe('useGetTokenBalances per-token fallback errors', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('logs a clarified retrieval error with structured context and no sensitive data', async () => {
+    getBalanceMock.mockRejectedValue(
+      new Error(
+        `request to ${RPC_URL} failed for ${WALLET_ADDRESS} (api_key=${API_KEY})`,
+      ),
+    );
+
+    const { result } = renderHook(() =>
+      useGetTokenBalances({ source: getRequest() }),
+    );
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+    const [message, context] = consoleErrorSpy.mock.calls[0] as [
+      string,
+      { reason: string },
+    ];
+    expect(message).toContain('Balance fetch failed');
+    expect(message).toContain('unavailable');
+    expect(message).not.toContain(RPC_URL);
+    expect(message).not.toContain(WALLET_ADDRESS);
+
+    expect(context).toMatchObject({
+      network: 'Testnet',
+      chain: 'Ethereum',
+      token: 'Ethereum:USDC',
+    });
+    expect(typeof context.reason).toBe('string');
+    expect(context.reason).not.toContain(RPC_URL);
+    expect(context.reason).not.toContain(WALLET_ADDRESS);
+    expect(context.reason).not.toContain(API_KEY);
+    expect(JSON.stringify(context)).not.toContain(WALLET_ADDRESS);
+
+    // A failed fetch must not be reported as a zero balance
+    expect(result.current.source.balances['Ethereum:USDC']).toBeUndefined();
+  });
+
+  it('normalizes non-Error rejections into a bounded single-line reason', async () => {
+    getBalanceMock.mockRejectedValue(
+      `connection to ${RPC_URL} timed out\nafter retrying`,
+    );
+
+    const { result } = renderHook(() =>
+      useGetTokenBalances({ source: getRequest() }),
+    );
+
+    await waitFor(() => expect(consoleErrorSpy).toHaveBeenCalled());
+
+    const reason = (
+      consoleErrorSpy.mock.calls[0] as [string, { reason: string }]
+    )[1].reason;
+    expect(reason).not.toContain('\n');
+    expect(reason).not.toContain(RPC_URL);
+    expect(reason.length).toBeLessThanOrEqual(204);
+
+    expect(result.current.source.balances['Ethereum:USDC']).toBeUndefined();
+  });
+
+  it('keeps a successfully fetched zero balance distinct from an unavailable balance', async () => {
+    getBalanceMock.mockResolvedValue(0n);
+
+    const { result } = renderHook(() =>
+      useGetTokenBalances({ source: getRequest() }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.source.balances['Ethereum:USDC']).toBeDefined(),
+    );
+
+    expect(result.current.source.balances['Ethereum:USDC'].balance).toEqual({
+      amount: '0',
+      decimals: 6,
+    });
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useGetTokenBalances.ts
+++ b/src/hooks/useGetTokenBalances.ts
@@ -12,6 +12,7 @@ import {
 import type { WalletData } from 'store/wallet';
 import { useTokens } from 'contexts/TokensContext';
 import { processBatches } from 'utils/batch';
+import { normalizeBalanceFetchError } from 'utils/errors';
 import { getCached, isFailed, markFailed, setCached } from 'utils/balanceCache';
 
 export interface ChainBalanceRequest {
@@ -247,7 +248,18 @@ const useGetTokenBalances = ({
             };
             setCached(wallet, token, balance);
           } catch (e) {
-            console.error(`Failed to fetch balance for token ${token.key}`, e);
+            // A failed fetch means the balance is unavailable, not confirmed
+            // insufficient. Log structured context with a sanitized reason;
+            // no RPC URLs, wallet addresses, or credentials.
+            console.error(
+              'Balance fetch failed, balance unavailable (not confirmed insufficient)',
+              {
+                network: config.network,
+                chain,
+                token: token.key,
+                reason: normalizeBalanceFetchError(e),
+              },
+            );
           }
         },
         {

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   interpretTransferError,
+  normalizeBalanceFetchError,
   INSUFFICIENT_ALLOWANCE_REGEX,
   INSUFFICIENT_LAMPORTS_REGEX,
   SIMULATION_ACCOUNT_NOT_FOUND_REGEX,
@@ -401,5 +402,79 @@ describe('interpretTransferError', () => {
     // The actual gas token display depends on config availability
     expect(errorObj.type).toBe(ERR_INSUFFICIENT_GAS);
     expect(message).toContain('Insufficient');
+  });
+});
+
+describe('normalizeBalanceFetchError', () => {
+  const RPC_URL = 'https://ethereum-rpc.publicnode.com';
+  const EVM_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+  const SOLANA_ADDRESS = '4Nd1mBQtrMJVYVfKf2PJy9NZUZdTAsp7D4xWLs4gDB4T';
+
+  it('extracts the message from an Error instance', () => {
+    expect(normalizeBalanceFetchError(new Error('connection reset'))).toBe(
+      'connection reset',
+    );
+  });
+
+  it('accepts plain strings and objects with a message', () => {
+    expect(normalizeBalanceFetchError('connection reset')).toBe(
+      'connection reset',
+    );
+    expect(
+      normalizeBalanceFetchError({ message: 'connection reset', code: -32000 }),
+    ).toBe('connection reset');
+  });
+
+  it('falls back to a safe value for null, undefined, and exotic values', () => {
+    expect(normalizeBalanceFetchError(null)).toBe('unknown error');
+    expect(normalizeBalanceFetchError(undefined)).toBe('unknown error');
+    expect(normalizeBalanceFetchError({})).toBe('[object Object]');
+    expect(normalizeBalanceFetchError(42)).toBe('42');
+  });
+
+  it('collapses whitespace to a single line', () => {
+    expect(normalizeBalanceFetchError(new Error('line one\n  line\ttwo'))).toBe(
+      'line one line two',
+    );
+  });
+
+  it('redacts RPC URLs', () => {
+    const normalized = normalizeBalanceFetchError(
+      new Error(`request to ${RPC_URL} failed`),
+    );
+    expect(normalized).not.toContain(RPC_URL);
+    expect(normalized).toContain('[redacted]');
+    expect(normalized).toBe('request to [redacted] failed');
+  });
+
+  it('redacts EVM wallet addresses', () => {
+    const normalized = normalizeBalanceFetchError(
+      new Error(`missing balance for ${EVM_ADDRESS}`),
+    );
+    expect(normalized).not.toContain(EVM_ADDRESS);
+    expect(normalized).toBe('missing balance for [redacted]');
+  });
+
+  it('redacts Solana base58 wallet addresses', () => {
+    const normalized = normalizeBalanceFetchError(
+      new Error(`account ${SOLANA_ADDRESS} not found`),
+    );
+    expect(normalized).not.toContain(SOLANA_ADDRESS);
+    expect(normalized).toBe('account [redacted] not found');
+  });
+
+  it('redacts credential-like values', () => {
+    const normalized = normalizeBalanceFetchError(
+      new Error('request failed with api_key=sk-abc123 and SECRET: hunter2'),
+    );
+    expect(normalized).not.toContain('sk-abc123');
+    expect(normalized).not.toContain('hunter2');
+  });
+
+  it('truncates long messages to a bounded length', () => {
+    const longMessage = 'x'.repeat(500);
+    const normalized = normalizeBalanceFetchError(new Error(longMessage));
+    expect(normalized.length).toBeLessThanOrEqual(204);
+    expect(normalized.endsWith('...')).toBe(true);
   });
 });

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -154,3 +154,44 @@ export function maybeLogSdkError(e: any, prefix?: string) {
 
   console.error(prefix ? `${prefix}: ${e}` : e);
 }
+
+// Normalizes an unknown error into a short, single-line message that is safe
+// to log: RPC URLs, wallet addresses, and credential-like values are redacted
+// and request headers are never read in the first place.
+const SAFE_ERROR_REDACTED = '[redacted]';
+const SAFE_ERROR_MAX_LENGTH = 200;
+
+export function normalizeBalanceFetchError(e: unknown): string {
+  let message: string;
+  if (e instanceof Error) {
+    message = e.message;
+  } else if (typeof e === 'string') {
+    message = e;
+  } else if (e && typeof (e as { message?: unknown }).message === 'string') {
+    message = (e as { message: string }).message;
+  } else if (e == null) {
+    return 'unknown error';
+  } else {
+    try {
+      message = String(e);
+    } catch {
+      return 'unknown error';
+    }
+  }
+
+  message = message
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/https?:\/\/\S+/gi, SAFE_ERROR_REDACTED)
+    .replace(/\b0x[0-9a-fA-F]{40}\b/g, SAFE_ERROR_REDACTED)
+    .replace(/\b[1-9A-HJ-NP-Za-km-z]{43,44}\b/g, SAFE_ERROR_REDACTED)
+    .replace(
+      /(api[-_]?key|secret|password|authorization|bearer)(\s*[=:]\s*)\S+/gi,
+      `$1$2${SAFE_ERROR_REDACTED}`,
+    );
+
+  if (message.length > SAFE_ERROR_MAX_LENGTH) {
+    message = `${message.slice(0, SAFE_ERROR_MAX_LENGTH)}...`;
+  }
+  return message || 'unknown error';
+}


### PR DESCRIPTION
Fixes #4040.

The per-token fallback in `useGetTokenBalances` previously logged `Failed to fetch balance for token X`, which could read as an insufficient balance rather than a retrieval failure. The catch block now logs a clarified message, `Balance fetch failed, balance unavailable (not confirmed insufficient)`, with structured network, chain, and token context.

The underlying error is normalized through a new `normalizeBalanceFetchError` helper in `utils/errors.ts`. It bounds the message to a single line of at most 200 characters and redacts RPC URLs, EVM and Solana wallet addresses, and credential-like values. Request headers are never read, and no wallet address is included in the log.

The fallback behavior itself is unchanged: a failed fetch still leaves no balance entry, so it remains distinct from a successfully fetched low balance.

Tests:
- `utils/errors.test.ts` covers safe normalization: message extraction, whitespace collapsing, URL and address redaction, credential redaction, and truncation.
- `hooks/useGetTokenBalances.test.tsx` covers the clarified log with structured context and sensitive-data exclusions, plus the distinction between an unavailable balance and a successfully fetched zero balance.